### PR TITLE
[feat,refactor] Resume from zoo, config, class refactor, more robust

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -1,3 +1,6 @@
+# Configuration version is useful in migrating older configs to new ones
+config_version: 1.0
+
 # Configuration for training
 training:
     # Name of the trainer class used to define the training/evalution loop
@@ -83,12 +86,19 @@ training:
 
     # Should a lr scheduler be used
     lr_scheduler: false
+
+    # DEPRECATED: Look at scheduler_attributes or
+    # Use PythiaScheduler directly instead
     # Steps for LR scheduler, will be an array of iteration count
     # when lr should be decreased
     lr_steps: []
+    # DEPRECATED: Look at scheduler_attributes or
+    # Use PythiaScheduler directly instead
     # Ratio for each lr step
     lr_ratio: 0.1
 
+    # NOTE: Have a look at newer scheduler available in MMF (such as AdamW) before
+    # using these options
     # Should use warmup for lr
     use_warmup: false
     # Warmup factor learning rate warmup
@@ -100,25 +110,6 @@ training:
     device: cuda
     # Local rank of the GPU device
     local_rank: null
-
-    # Use to load specific modules from checkpoint to your model,
-    # this is helpful in finetuning. for e.g. you can specify
-    # text_embeddings: text_embedding_pythia
-    # for loading `text_embedding` module of your model
-    # from `text_embedding_pythia`
-    pretrained_mapping: {}
-    # If using a pretrained model. Must be used with --resume_file parameter
-    # to specify pretrained model checkpoint. Will load only specific layers if
-    # pretrained mapping is specified in config
-    load_pretrained: false
-    # If resume is true, MMF will try to load automatically load
-    # last of same parameters from save_dir
-    resume: false
-    # `resume_file` can be used to load a specific checkpoint from a file
-    resume_file: null
-    # `resume_best` will load the best checkpoint according to monitored metric instead of
-    # the last saved ckpt
-    resume_best: false
 
     # If verbose dump is active, MMF will dump dataset, model specific
     # information which can be useful in debugging
@@ -220,3 +211,54 @@ distributed:
     # Set if you do not want spawn multiple processes even if
     # multiple GPUs are visible
     no_spawn: false
+
+# Configuration for checkpointing including resuming and loading pretrained models
+checkpoint:
+    # If checkpoint.resume is true, MMF will try to load automatically load
+    # checkpoint and state from "current.ckpt" from env.save_dir
+    resume: false
+    # `checkpoint.resume_file` can be used to load a specific checkpoint from a file
+    # Can also be a zoo key
+    resume_file: null
+    # `checkpoint.resume_best` will load the best checkpoint according to
+    # training.early_stop.criteria instead of the last saved ckpt
+    resume_best: false
+    # `checkpoint.resume_pretrained` can be used in conjuction with `resume_file`
+    # or `resume_zoo` where you specify a checkpoint or .pth file to be loaded
+    # but it is mapped based on `checkpoint.pretrained_state_mapping`
+    # For e.g. if you want to resume from visual_bert pretrained on coco
+    # You would set `checkpoint.resume_zoo=visual_bert.pretrained.coco` and
+    # then set `checkpoint.resume_pretrained=True` which will then pick up
+    # only the base which you would define in the `checkpoint.pretrained_state_mapping`
+    resume_pretrained: false
+    # `checkpoint.resume_zoo` can be used to resume from a pretrained model provided
+    # in zoo. Value maps to key from zoo. `checkpoint.resume_file` has higher
+    # priority compared to `checkpoint.resume_zoo`.
+    resume_zoo: null
+    # `checkpoint.zoo_config_override` will override the current model config of trainer
+    # with what is provided from the zoo checkpoint and will load the model
+    # using .from_pretrained of the model passed
+    zoo_config_override: false
+    # `checkpoint.pretrained_state_mapping` specifies how exactly a pretrained
+    # model will be loaded and mapped to which keys of the target model
+    # Only use if the keys on the model in which pretrained model is to be loaded
+    # don't match with those of the pretrained model or you only want to load specific
+    # item from the pretrained model. `checkpoint.resume_pretrained` must be
+    # true to use this mapping. for e.g. you can specify
+    # text_embedding: text_embedding_pythia
+    # for loading `text_embedding` module of your model from `text_embedding_pythia`of
+    # pretrained file specified in `checkpoint.resume_file`.
+    pretrained_state_mapping: {}
+
+    # Whether to save git details or not
+    save_git_details: true
+
+    # `checkpoint.reset` configuration defines what exactly should be reset
+    # in case the file from which we are resuming is .ckpt and not .pth
+    reset:
+        # Everything will be reset except the state_dict of model
+        all: false
+        # Optimizer specifically will be reset
+        optimizer: false
+        # All counts such as best_update, current_iteration etc will be reset
+        counts: false

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -181,20 +181,12 @@ coco:
 
 hateful_memes:
   defaults:
-    version: 1.0_2020_05_04
+    version: 1.0_2020_05_11
     resources:
       features:
       - url: mmf://datasets/hateful_memes/defaults/features/features.tar.gz
         file_name: features.tar.gz
         hashcode: 1eb8e5379fcf8f91fda92aa8f5926a536f3788bf07fe0f72ea7efc2d8427f12d
-      images:
-      - url: mmf://datasets/hateful_memes/defaults/images/images.tar.gz
-        file_name: images.tar.gz
-        hashcode: 6db0c78bdc16bec6a4381d1b2d2a9ac4ac0643d4a329a4562d16c85cfe4b43be
-      annotations:
-      - url: mmf://datasets/hateful_memes/defaults/annotations/annotations.tar.gz
-        file_name: annotations.tar.gz
-        hashcode: 452486b03083b0912874215a58b3df8227bafb8635904faae4e4ae402baaf13f
       extras:
       - url: mmf://datasets/hateful_memes/defaults/extras.tar.gz
         file_name: extras.tar.gz

--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -16,13 +16,13 @@ visual_bert:
         - url: mmf://models/visual_bert/visual_bert.finetuned.hateful_memes_direct.tar.gz
           file_name: visual_bert.finetuned.hateful_memes_direct.tar.gz
           hashcode: 1780582b65c0e5ab383bbf862f140daaa828963c38710f9cc004a7d883b219f8
-      coco:
+      from_coco:
         version: 1.0_2020_05_10
         resources:
         - url: mmf://models/visual_bert/visual_bert.finetuned.hateful_memes_from_coco.tar.gz
           file_name: visual_bert.finetuned.hateful_memes_from_coco.tar.gz
           hashcode: 462d34eb35d7d00f50f14b8e06577b9f89074313761f3f94fd5161dc67b28525
-      defaults: ${visual_bert.finetuned.hateful_memes.coco}
+      defaults: ${visual_bert.finetuned.hateful_memes.from_coco}
 
 detectron:
   vmb_weights:
@@ -89,13 +89,14 @@ m4c_captioner:
 
 vilbert:
   pretrained:
-    cc_original:
-      version: 1.0_2020_05_10
-      resources:
-      - url: mmf://models/vilbert/vilbert.pretrained.cc_original.tar.gz
-        file_name: vilbert.pretrained.cc_original.tar.gz
-        hashcode: 85e6354fcf2583e03def4dff02125e268b3732c152f87cfbd2ad34c0e4f47b53
-    defaults: ${vilbert.pretrained.cc_original}
+    cc:
+      original:
+        version: 1.0_2020_05_10
+        resources:
+        - url: mmf://models/vilbert/vilbert.pretrained.cc_original.tar.gz
+          file_name: vilbert.pretrained.cc_original.tar.gz
+          hashcode: 85e6354fcf2583e03def4dff02125e268b3732c152f87cfbd2ad34c0e4f47b53
+    defaults: ${vilbert.pretrained.cc.original}
 
   finetuned:
     hateful_memes:
@@ -105,13 +106,13 @@ vilbert:
         - url: mmf://models/vilbert/vilbert.finetuned.hateful_memes_direct.tar.gz
           file_name: vilbert.finetuned.hateful_memes_direct.tar.gz
           hashcode: 8d2c9b2c580a8086012887013ebe3edb2e803ea26f5f7674281f2d5eb066d320
-      cc_original:
+      from_cc_original:
         version: 1.0_2020_05_10
         resources:
         - url: mmf://models/vilbert/vilbert.finetuned.hateful_memes_from_cc.tar.gz
           file_name: vilbert.finetuned.hateful_memes_from_cc.tar.gz
           hashcode: c7c505e1012f48bddc77dc0140dbfd0a0dab83b3b57ed565fe76fb3d350fd030
-      defaults: ${vilbert.finetuned.hateful_memes.cc_original}
+      defaults: ${vilbert.finetuned.hateful_memes.from_cc_original}
 
 mmbt:
   hateful_memes:

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -49,7 +49,6 @@ from torch import nn
 from mmf.common.registry import registry
 from mmf.modules.losses import Losses
 from mmf.utils.checkpoint import load_pretrained_model
-from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.download import download_pretrained_model
 
 
@@ -174,13 +173,11 @@ class BaseModel(nn.Module):
         return model_output
 
     def load_requirements(self, *args, **kwargs):
-        if is_master():
-            requirements = self.config.get("zoo_requirements", [])
-            if isinstance(requirements, str):
-                requirements = [requirements]
-            for item in requirements:
-                download_pretrained_model(item, *args, **kwargs)
-        synchronize()
+        requirements = self.config.get("zoo_requirements", [])
+        if isinstance(requirements, str):
+            requirements = [requirements]
+        for item in requirements:
+            download_pretrained_model(item, *args, **kwargs)
 
     @classmethod
     def from_pretrained(cls, model_name, *args, **kwargs):

--- a/mmf/models/pythia.py
+++ b/mmf/models/pythia.py
@@ -28,6 +28,10 @@ class Pythia(BaseModel):
     def config_path(cls):
         return "configs/models/pythia/defaults.yaml"
 
+    @classmethod
+    def format_state_key(cls, key):
+        return key.replace("fa_history", "fa_context")
+
     def build(self):
         self._build_word_embedding()
         self._init_text_embeddings("text")

--- a/mmf/utils/configuration.py
+++ b/mmf/utils/configuration.py
@@ -202,6 +202,8 @@ class Configuration:
 
         self.config = self._merge_with_dotlist(self.config, args.opts)
         self._update_specific(self.config)
+        self.upgrade(self.config)
+
         registry.register("config", self.config)
 
     def _build_default_config(self):
@@ -530,6 +532,20 @@ class Configuration:
             config.training.device = "cpu"
 
         return config
+
+    def upgrade(self, config):
+        mapping = {
+            "training.resume_file": "checkpoint.resume_file",
+            "training.resume": "checkpoint.resume",
+            "training.resume_best": "checkpoint.resume_best",
+            "training.load_pretrained": "checkpoint.resume_pretrained",
+            "training.pretrained_state_mapping": "checkpoint.pretrained_state_mapping",
+        }
+
+        for old, new in mapping.items():
+            value = OmegaConf.select(config, old)
+            if value:
+                OmegaConf.update(config, new, value)
 
 
 # This is still here due to legacy reasons around

--- a/mmf/utils/download.py
+++ b/mmf/utils/download.py
@@ -20,6 +20,7 @@ import time
 import requests
 import tqdm
 
+from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
 from mmf.utils.general import get_absolute_path
 
@@ -352,7 +353,10 @@ def download_pretrained_model(model_name, *args, **kwargs):
     version = model_config.version
     resources = model_config.resources
 
-    download_resources(resources, download_path, version)
+    if is_master():
+        download_resources(resources, download_path, version)
+    synchronize()
+
     return download_path
 
 

--- a/projects/lorra/configs/textvqa/defaults.yaml
+++ b/projects/lorra/configs/textvqa/defaults.yaml
@@ -31,25 +31,27 @@ evaluation:
   - vqa_accuracy
 
 training:
-    clip_norm_mode: all
-    clip_gradients: true
-    max_grad_l2_norm: 0.25
-    lr_scheduler: true
-    lr_steps:
-    - 14000
-    lr_ratio: 0.01
-    use_warmup: true
-    warmup_factor: 0.2
-    warmup_iterations: 1000
-    max_updates: 24000
-    batch_size: 128
-    num_workers: 7
-    task_size_proportional_sampling: true
-    early_stop:
-      criteria: textvqa/vqa_accuracy
-      minimize: false
-    pretrained_mapping:
-      text_embeddings: text_embeddings
-      image_feature_encoders: image_feature_encoders
-      image_feature_embeddings_list: image_feature_embeddings_list
-      image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.25
+  lr_scheduler: true
+  lr_steps:
+  - 14000
+  lr_ratio: 0.01
+  use_warmup: true
+  warmup_factor: 0.2
+  warmup_iterations: 1000
+  max_updates: 24000
+  batch_size: 128
+  num_workers: 7
+  task_size_proportional_sampling: true
+  early_stop:
+    criteria: textvqa/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    text_embeddings: text_embeddings
+    image_feature_encoders: image_feature_encoders
+    image_feature_embeddings_list: image_feature_embeddings_list
+    image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer

--- a/projects/lorra/configs/vizwiz/defaults.yaml
+++ b/projects/lorra/configs/vizwiz/defaults.yaml
@@ -28,29 +28,31 @@ evaluation:
   - vqa_accuracy
 
 training:
-    clip_norm_mode: all
-    clip_gradients: true
-    max_grad_l2_norm: 0.25
-    lr_scheduler: true
-    lr_steps:
-    - 14000
-    lr_ratio: 0.01
-    use_warmup: true
-    warmup_factor: 0.2
-    warmup_iterations: 1000
-    max_updates: 24000
-    batch_size: 128
-    num_workers: 7
-    task_size_proportional_sampling: true
-    early_stop:
-      criteria: vizwiz/vqa_accuracy
-      minimize: false
-    pretrained_mapping:
-      word_embedding: word_embedding
-      text_embeddings: text_embeddings
-      context_feature_encoders: context_feature_encoders
-      context_embeddings: context_embeddings
-      context_feature_embeddings_list: context_feature_embeddings_list
-      image_feature_encoders: image_feature_encoders
-      image_feature_embeddings_list: image_feature_embeddings_list
-      image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.25
+  lr_scheduler: true
+  lr_steps:
+  - 14000
+  lr_ratio: 0.01
+  use_warmup: true
+  warmup_factor: 0.2
+  warmup_iterations: 1000
+  max_updates: 24000
+  batch_size: 128
+  num_workers: 7
+  task_size_proportional_sampling: true
+  early_stop:
+    criteria: vizwiz/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    word_embedding: word_embedding
+    text_embeddings: text_embeddings
+    context_feature_encoders: context_feature_encoders
+    context_embeddings: context_embeddings
+    context_feature_embeddings_list: context_feature_embeddings_list
+    image_feature_encoders: image_feature_encoders
+    image_feature_embeddings_list: image_feature_embeddings_list
+    image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer

--- a/projects/lorra/configs/vqa2/defaults.yaml
+++ b/projects/lorra/configs/vqa2/defaults.yaml
@@ -54,7 +54,9 @@ training:
   early_stop:
     criteria: vqa2/vqa_accuracy
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     text_embeddings: text_embeddings
     context_embeddings: context_embeddings
     image_feature_encoders: image_feature_encoders

--- a/projects/mmbt/configs/hateful_memes/defaults.yaml
+++ b/projects/mmbt/configs/hateful_memes/defaults.yaml
@@ -27,5 +27,7 @@ training:
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     bert: bert

--- a/projects/mmbt/configs/masked_coco/defaults.yaml
+++ b/projects/mmbt/configs/masked_coco/defaults.yaml
@@ -18,5 +18,7 @@ training:
   batch_size: 128
   lr_scheduler: true
   max_updates: 22000
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     bert: bert

--- a/projects/others/concat_bert/hateful_memes/defaults.yaml
+++ b/projects/others/concat_bert/hateful_memes/defaults.yaml
@@ -35,5 +35,7 @@ training:
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     base: base

--- a/projects/others/concat_bow/hateful_memes/defaults.yaml
+++ b/projects/others/concat_bow/hateful_memes/defaults.yaml
@@ -32,5 +32,7 @@ training:
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     base: base

--- a/projects/others/late_fusion/hateful_memes/defaults.yaml
+++ b/projects/others/late_fusion/hateful_memes/defaults.yaml
@@ -39,5 +39,7 @@ training:
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     base: base

--- a/projects/others/mmf_bert/configs/vqa2/defaults.yaml
+++ b/projects/others/mmf_bert/configs/vqa2/defaults.yaml
@@ -58,7 +58,9 @@ training:
   early_stop:
     criteria: vqa2/vqa_accuracy
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     word_embedding: word_embedding
     text_embedding: text_embedding
     image_feature_projection: image_feature_projection

--- a/projects/others/unimodal/configs/hateful_memes/image.yaml
+++ b/projects/others/unimodal/configs/hateful_memes/image.yaml
@@ -32,5 +32,7 @@ training:
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     base: base

--- a/projects/others/unimodal/configs/hateful_memes/text.yaml
+++ b/projects/others/unimodal/configs/hateful_memes/text.yaml
@@ -32,5 +32,7 @@ training:
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     base: base

--- a/projects/pretrain_vl_right/README.md
+++ b/projects/pretrain_vl_right/README.md
@@ -52,7 +52,7 @@ python tools/run.py config=projects/visual_bert/configs/masked_coco/pretrain.yam
 
 Example : To finetune VisualBERT model on the VQA2.0 dataset, run the following command
 ```
-python tools/run.py config=projects/visual_bert/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=visual_bert training.resume_file=<path_to_pretrained_visual_bert_model> training.load_pretrained=true
+python tools/run.py config=projects/visual_bert/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=visual_bert checkpoint.resume_file=<path_to_pretrained_visual_bert_model> checkpoint.resume_pretrained=true
 ```
 
 Configs for different settings and pretraining datasets are provided in the next section.

--- a/projects/pythia/configs/textvqa/defaults.yaml
+++ b/projects/pythia/configs/textvqa/defaults.yaml
@@ -10,25 +10,27 @@ evaluation:
   - vqa_accuracy
 
 training:
-    clip_norm_mode: all
-    clip_gradients: false
-    max_grad_l2_norm: 0.25
-    lr_scheduler: true
-    lr_steps:
-    - 14000
-    lr_ratio: 0.01
-    use_warmup: true
-    warmup_factor: 0.2
-    warmup_iterations: 1000
-    max_updates: 24000
-    batch_size: 128
-    num_workers: 7
-    task_size_proportional_sampling: true
-    early_stop:
-      criteria: textvqa/vqa_accuracy
-      minimize: false
-    pretrained_mapping:
-      text_embeddings: text_embeddings
-      image_feature_encoders: image_feature_encoders
-      image_feature_embeddings_list: image_feature_embeddings_list
-      image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer
+  clip_norm_mode: all
+  clip_gradients: false
+  max_grad_l2_norm: 0.25
+  lr_scheduler: true
+  lr_steps:
+  - 14000
+  lr_ratio: 0.01
+  use_warmup: true
+  warmup_factor: 0.2
+  warmup_iterations: 1000
+  max_updates: 24000
+  batch_size: 128
+  num_workers: 7
+  task_size_proportional_sampling: true
+  early_stop:
+    criteria: textvqa/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    text_embeddings: text_embeddings
+    image_feature_encoders: image_feature_encoders
+    image_feature_embeddings_list: image_feature_embeddings_list
+    image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer

--- a/projects/pythia/configs/vizwiz/defaults.yaml
+++ b/projects/pythia/configs/vizwiz/defaults.yaml
@@ -8,26 +8,28 @@ evaluation:
   - vqa_accuracy
 
 training:
-    clip_norm_mode: all
-    clip_gradients: true
-    max_grad_l2_norm: 0.25
-    lr_scheduler: true
-    lr_steps:
-    - 14000
-    lr_ratio: 0.01
-    use_warmup: true
-    warmup_factor: 0.2
-    warmup_iterations: 1000
-    max_updates: 24000
-    batch_size: 128
-    num_workers: 7
-    task_size_proportional_sampling: true
-    early_stop:
-      criteria: vizwiz/vqa_accuracy
-      minimize: false
-    pretrained_mapping:
-      word_embedding: word_embedding
-      text_embeddings: text_embeddings
-      image_feature_encoders: image_feature_encoders
-      image_feature_embeddings_list: image_feature_embeddings_list
-      image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.25
+  lr_scheduler: true
+  lr_steps:
+  - 14000
+  lr_ratio: 0.01
+  use_warmup: true
+  warmup_factor: 0.2
+  warmup_iterations: 1000
+  max_updates: 24000
+  batch_size: 128
+  num_workers: 7
+  task_size_proportional_sampling: true
+  early_stop:
+    criteria: vizwiz/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    word_embedding: word_embedding
+    text_embeddings: text_embeddings
+    image_feature_encoders: image_feature_encoders
+    image_feature_embeddings_list: image_feature_embeddings_list
+    image_text_multi_modal_combine_layer: image_text_multi_modal_combine_layer

--- a/projects/pythia/configs/vqa2/defaults.yaml
+++ b/projects/pythia/configs/vqa2/defaults.yaml
@@ -47,7 +47,9 @@ training:
   early_stop:
     criteria: vqa2/vqa_accuracy
     minimize: false
-  pretrained_mapping:
+
+checkpoint:
+  pretrained_state_mapping:
     word_embedding: word_embedding
     text_embeddings: text_embeddings
     image_feature_encoders: image_feature_encoders

--- a/projects/vilbert/configs/hateful_memes/defaults.yaml
+++ b/projects/vilbert/configs/hateful_memes/defaults.yaml
@@ -44,9 +44,11 @@ training:
   batch_size: 32
   lr_scheduler: true
   max_updates: 22000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/vilbert/configs/hateful_memes/from_cc.yaml
+++ b/projects/vilbert/configs/hateful_memes/from_cc.yaml
@@ -1,10 +1,6 @@
 includes:
 - ./defaults.yaml
 
-model_config:
-  vilbert:
-    zoo_requirements: vilbert.pretrained.cc_original
-
-training:
-  load_pretrained: true
-  resume_file: ${env.cache_dir}/data/models/vilbert.pretrained.cc_original/model.pth
+checkpoint:
+  resume_pretrained: true
+  resume_zoo: vilbert.pretrained.cc.original

--- a/projects/vilbert/configs/mmimdb/defaults.yaml
+++ b/projects/vilbert/configs/mmimdb/defaults.yaml
@@ -42,9 +42,11 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: mmimdb/multilabel_micro_f1
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/vilbert/configs/nlvr2/defaults.yaml
+++ b/projects/vilbert/configs/nlvr2/defaults.yaml
@@ -40,9 +40,11 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: nlvr2/accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/vilbert/configs/visual_entailment/defaults.yaml
+++ b/projects/vilbert/configs/visual_entailment/defaults.yaml
@@ -40,9 +40,11 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: visual_entailment/accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/vilbert/configs/vizwiz/defaults.yaml
+++ b/projects/vilbert/configs/vizwiz/defaults.yaml
@@ -53,9 +53,11 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: vizwiz/vqa_accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/vilbert/configs/vqa2/defaults.yaml
+++ b/projects/vilbert/configs/vqa2/defaults.yaml
@@ -56,9 +56,11 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: vqa2/vqa_accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/hateful_memes/defaults.yaml
+++ b/projects/visual_bert/configs/hateful_memes/defaults.yaml
@@ -44,9 +44,11 @@ training:
   batch_size: 64
   lr_scheduler: true
   max_updates: 22000
-  pretrained_mapping:
-    model.bert: model.bert
   find_unused_parameters: true
   early_stop:
     criteria: hateful_memes/roc_auc
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/hateful_memes/from_coco.yaml
+++ b/projects/visual_bert/configs/hateful_memes/from_coco.yaml
@@ -1,10 +1,6 @@
 includes:
 - ./defaults.yaml
 
-model_config:
-  visual_bert:
-    zoo_requirements: visual_bert.pretrained.coco
-
-training:
-  load_pretrained: true
-  resume_file: ${env.cache_dir}/data/models/visual_bert.pretrained.coco/model.pth
+checkpoint:
+  resume_pretrained: true
+  resume_zoo: visual_bert.pretrained.coco

--- a/projects/visual_bert/configs/mmimdb/defaults.yaml
+++ b/projects/visual_bert/configs/mmimdb/defaults.yaml
@@ -44,8 +44,10 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   early_stop:
     criteria: mmimdb/multilabel_micro_f1
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/nlvr2/defaults.yaml
+++ b/projects/visual_bert/configs/nlvr2/defaults.yaml
@@ -42,8 +42,10 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   early_stop:
     criteria: nlvr2/accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/visual_entailment/defaults.yaml
+++ b/projects/visual_bert/configs/visual_entailment/defaults.yaml
@@ -45,8 +45,10 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   early_stop:
     criteria: visual_entailment/accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/vizwiz/defaults.yaml
+++ b/projects/visual_bert/configs/vizwiz/defaults.yaml
@@ -55,8 +55,10 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   early_stop:
     criteria: vizwiz/vqa_accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/vqa2/defaults.yaml
+++ b/projects/visual_bert/configs/vqa2/defaults.yaml
@@ -58,8 +58,10 @@ training:
   lr_scheduler: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000
-  pretrained_mapping:
-    model.bert: model.bert
   early_stop:
     criteria: vqa2/vqa_accuracy
     minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/tests/datasets/test_processors.py
+++ b/tests/datasets/test_processors.py
@@ -59,8 +59,9 @@ class TestDatasetProcessors(unittest.TestCase):
         processed = answer_processor({"answers": ["helmet"]})
         answers_indices = processed["answers_indices"]
         answers_scores = processed["answers_scores"]
+
         self.assertTrue(
-            compare_tensors(answers_indices, torch.tensor([5], dtype=torch.long))
+            compare_tensors(answers_indices, torch.tensor([5] * 10, dtype=torch.long))
         )
         expected_answers_scores = torch.zeros(19, dtype=torch.float)
         expected_answers_scores[5] = 1.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import torch
 
 
 def compare_tensors(a, b):
-    return torch.all(a.eq(b))
+    return torch.equal(a, b)
 
 
 def dummy_args(model="cnn_lstm", dataset="clevr"):
@@ -36,3 +36,22 @@ NETWORK_AVAILABLE = is_network_reachable()
 
 def skip_if_no_network(testfn, reason="Network is not available"):
     return unittest.skipUnless(NETWORK_AVAILABLE, reason)(testfn)
+
+
+def compare_state_dicts(a, b):
+    same = True
+    same = same and (list(a.keys()) == list(b.keys()))
+    if not same:
+        return same
+
+    for val1, val2 in zip(a.values(), b.values()):
+        if isinstance(val1, torch.Tensor):
+            same = same and compare_tensors(val1, val2)
+        elif not isinstance(val2, torch.Tensor):
+            same = same and val1 == val2
+        else:
+            same = False
+        if not same:
+            return same
+
+    return same

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -1,0 +1,533 @@
+import contextlib
+import os
+import tempfile
+import unittest
+from copy import deepcopy
+from io import StringIO
+from unittest.mock import Mock, patch
+
+import torch
+from omegaconf import OmegaConf
+
+from mmf.common.registry import registry
+from mmf.models.base_model import BaseModel
+from mmf.utils.checkpoint import Checkpoint
+from mmf.utils.configuration import load_yaml
+from mmf.utils.early_stopping import EarlyStopping
+from mmf.utils.file_io import PathManager
+from mmf.utils.logger import Logger
+from tests.test_utils import compare_state_dicts
+
+
+@contextlib.contextmanager
+def mock_env_with_temp():
+    d = tempfile.TemporaryDirectory()
+    patched = patch("mmf.utils.checkpoint.get_mmf_env", return_value=d.name)
+    patched.start()
+    yield d.name
+    d.cleanup()
+    patched.stop()
+
+
+class SimpleModule(BaseModel):
+    def __init__(self, config={}):
+        super().__init__(config)
+        self.base = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+        self.classifier = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+        self.loss = torch.nn.CrossEntropyLoss()
+
+    def forward(self, x, target):
+        x = self.classifier(self.base(x))
+        return {"losses": {"total_loss": self.loss(x, target)}}
+
+
+class OnlyBase(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.base_test = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+    def format_state_key(self, key):
+        return key
+
+
+class TestUtilsCheckpoint(unittest.TestCase):
+    def setUp(self):
+        import argparse
+
+        torch.manual_seed(1234)
+        # An easy way to get a AttributeDict object
+        self.trainer = argparse.Namespace()
+        self.config = OmegaConf.create(
+            {
+                "model": "simple",
+                "model_config": {},
+                "checkpoint": {
+                    "save_git_details": False,
+                    "reset": {"optimizer": False, "counts": False, "all": False},
+                    "pretrained_state_mapping": {"base_test": "base"},
+                },
+                "config_override": "test",
+            }
+        )
+        # Keep original copy for testing purposes
+        self.trainer.config = deepcopy(self.config)
+        self.trainer.writer = Mock(spec=Logger)
+
+        self.trainer.model = SimpleModule()
+
+        self.trainer.optimizer = torch.optim.Adam(
+            self.trainer.model.parameters(), lr=1e-01
+        )
+
+    def test_save_config(self):
+        with mock_env_with_temp() as d:
+            Checkpoint(self.trainer)
+            config = load_yaml(os.path.join(d, "config.yaml"))
+            self.assertFalse(config == self.config)
+            self.assertTrue(config == self.trainer.config)
+
+    def test_save_and_load_state_dict(self):
+        with mock_env_with_temp() as d:
+            checkpoint = Checkpoint(self.trainer)
+            self._init_early_stopping(checkpoint)
+            self._do_a_pass()
+            # Test normal case
+            checkpoint.save(1500)
+
+            self.assertTrue(
+                PathManager.exists(os.path.join(d, "models", "model_1500.ckpt"))
+            )
+            self.assertTrue(PathManager.exists(os.path.join(d, "current.ckpt")))
+            self.assertFalse(PathManager.exists(os.path.join(d, "best.ckpt")))
+            os.remove(os.path.join(d, "models", "model_1500.ckpt"))
+            os.remove(os.path.join(d, "current.ckpt"))
+
+            best_model = deepcopy(self.trainer.model)
+            best_optimizer = deepcopy(self.trainer.optimizer)
+            # Test with update_best
+            checkpoint.save(2000, update_best=True)
+
+            self.assertTrue(
+                PathManager.exists(os.path.join(d, "models", "model_2000.ckpt"))
+            )
+            self.assertTrue(PathManager.exists(os.path.join(d, "best.ckpt")))
+            self.assertTrue(PathManager.exists(os.path.join(d, "current.ckpt")))
+
+            self._do_a_pass()
+            checkpoint.save(2500)
+
+            # Test resume
+            self.trainer.config.checkpoint.resume = True
+
+            current_model = deepcopy(self.trainer.model)
+            current_optimizer = deepcopy(self.trainer.optimizer)
+            checkpoint.load_state_dict()
+
+            self.assertFalse(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), best_model.state_dict()
+                )
+            )
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), current_model.state_dict()
+                )
+            )
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, best_optimizer)
+            )
+            self.assertFalse(
+                self._compare_optimizers(
+                    self.trainer.optimizer, best_optimizer, skip_keys=True
+                )
+            )
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, current_optimizer)
+            )
+            self.assertTrue(
+                self._compare_optimizers(
+                    self.trainer.optimizer, current_optimizer, skip_keys=True
+                )
+            )
+
+            base_0_weight_current = self.trainer.model.base[0].weight.data.clone()
+
+            # Test resume_best
+            self.trainer.config.checkpoint.resume = True
+            self.trainer.config.checkpoint.resume_best = True
+
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), best_model.state_dict()
+                )
+            )
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, best_optimizer)
+            )
+            self.assertTrue(
+                self._compare_optimizers(
+                    self.trainer.optimizer, best_optimizer, skip_keys=True
+                )
+            )
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, current_optimizer)
+            )
+            self.assertFalse(
+                self._compare_optimizers(
+                    self.trainer.optimizer, current_optimizer, skip_keys=True
+                )
+            )
+            base_0_weight_best = self.trainer.model.base[0].weight.data.clone()
+
+            self.trainer.config.checkpoint.resume_best = False
+            # Test distributed settings
+            self.trainer.model = torch.nn.DataParallel(self.trainer.model)
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                torch.equal(
+                    self.trainer.model.module.base[0].weight, base_0_weight_current
+                )
+            )
+            self.assertFalse(
+                torch.equal(
+                    self.trainer.model.module.base[0].weight, base_0_weight_best
+                )
+            )
+
+    def test_finalize_and_restore_from_it(self):
+        with mock_env_with_temp():
+            checkpoint = Checkpoint(self.trainer)
+            self._init_early_stopping(checkpoint)
+            original_model = deepcopy(self.trainer.model)
+            self._do_a_pass()
+            model_1500 = deepcopy(self.trainer.model)
+            checkpoint.save(1500)
+
+            swap = self.trainer.model
+            self.trainer.model = original_model
+            checkpoint.restore()
+            # First test without best.ckpt
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original_model.state_dict()
+                )
+            )
+            self.assertFalse(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), model_1500.state_dict()
+                )
+            )
+
+            self.trainer.model = swap
+
+            self._do_a_pass()
+            model_2000 = deepcopy(self.trainer.model)
+            checkpoint.save(2000, update_best=True)
+
+            self._do_a_pass()
+            model_2500 = deepcopy(self.trainer.model)
+            checkpoint.save(2500)
+
+            checkpoint.restore()
+
+            self.assertFalse(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original_model.state_dict()
+                )
+            )
+            self.assertFalse(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), model_1500.state_dict()
+                )
+            )
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), model_2000.state_dict()
+                )
+            )
+            self.assertFalse(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), model_2500.state_dict()
+                )
+            )
+
+    def test_finalize_and_resume_file(self):
+        with mock_env_with_temp() as d:
+            checkpoint = Checkpoint(self.trainer)
+            self._init_early_stopping(checkpoint)
+            self._do_a_pass()
+            checkpoint.finalize()
+            original = deepcopy(self.trainer.model)
+            pth_path = os.path.join(d, "simple_final.pth")
+            self.assertTrue(PathManager.exists(pth_path))
+
+            self._do_a_pass()
+
+            after_a_pass = deepcopy(self.trainer.model)
+            original_optimizer = deepcopy(self.trainer.optimizer)
+            self.trainer.config.checkpoint.resume_file = pth_path
+
+            with contextlib.redirect_stdout(StringIO()):
+                checkpoint.load_state_dict()
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original.state_dict()
+                )
+            )
+            self.assertFalse(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), after_a_pass.state_dict()
+                )
+            )
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
+            )
+            # Keys will not be same as we just updated the model
+            self.assertTrue(
+                self._compare_optimizers(
+                    self.trainer.optimizer, original_optimizer, skip_keys=True
+                )
+            )
+
+    def test_resets(self):
+        with mock_env_with_temp():
+            checkpoint = Checkpoint(self.trainer)
+            self._init_early_stopping(checkpoint)
+            self._do_a_pass()
+
+            original_optimizer = deepcopy(self.trainer.optimizer)
+            original_model = deepcopy(self.trainer.model)
+
+            self.trainer.current_epoch = 3
+            checkpoint.save(2000, update_best=True)
+            self.trainer.current_epoch = 4
+            # Test reset all
+            self.trainer.config.checkpoint.resume = True
+            self.trainer.config.checkpoint.reset.all = True
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original_model.state_dict()
+                )
+            )
+
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
+            )
+            self.assertTrue(
+                self._compare_optimizers(
+                    self.trainer.optimizer, original_optimizer, skip_keys=True
+                )
+            )
+            self.assertEqual(self.trainer.num_updates, 0)
+            self.assertEqual(self.trainer.current_iteration, 0)
+            self.assertEqual(self.trainer.current_epoch, 4)
+
+            # Test reset_optimizer
+            self._init_early_stopping(checkpoint)
+            self.trainer.config.checkpoint.reset.all = False
+            self.trainer.config.checkpoint.reset.optimizer = True
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original_model.state_dict()
+                )
+            )
+
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
+            )
+            self.assertTrue(
+                self._compare_optimizers(
+                    self.trainer.optimizer, original_optimizer, skip_keys=True
+                )
+            )
+
+            self.assertEqual(self.trainer.num_updates, 2000)
+            self.assertEqual(self.trainer.current_iteration, 2000)
+            self.assertEqual(self.trainer.current_epoch, 3)
+
+            self._init_early_stopping(checkpoint)
+            # Test reset_counts
+            self.trainer.config.checkpoint.reset.all = False
+            self.trainer.config.checkpoint.reset.optimizer = False
+            self.trainer.config.checkpoint.reset.counts = True
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original_model.state_dict()
+                )
+            )
+
+            self.assertTrue(
+                self._compare_optimizers(
+                    self.trainer.optimizer, original_optimizer, skip_keys=True
+                )
+            )
+            self.assertEqual(self.trainer.num_updates, 0)
+            self.assertEqual(self.trainer.current_iteration, 0)
+            self.assertEqual(self.trainer.current_epoch, 2)
+
+            # Test with resume_best
+            self._do_a_pass()
+            checkpoint.save(3000)
+            self._init_early_stopping(checkpoint)
+            self.trainer.config.checkpoint.reset.all = False
+            self.trainer.config.checkpoint.resume_best = True
+            self.trainer.config.checkpoint.reset.optimizer = True
+            self.trainer.config.checkpoint.reset.counts = False
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.state_dict(), original_model.state_dict()
+                )
+            )
+
+            self.assertFalse(
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
+            )
+            self.assertFalse(
+                self._compare_optimizers(
+                    self.trainer.optimizer, original_optimizer, skip_keys=True
+                )
+            )
+            self.assertEqual(self.trainer.num_updates, 1000)
+            self.assertEqual(self.trainer.current_iteration, 1000)
+            self.assertEqual(self.trainer.current_epoch, 3)
+
+    def test_zoo_load(self):
+        with mock_env_with_temp():
+            checkpoint = Checkpoint(self.trainer)
+            self._init_early_stopping(checkpoint)
+            self._do_a_pass()
+
+            original_model = deepcopy(self.trainer.model)
+            ret_load_pretrained_zoo = {
+                "config": self.config.model_config,
+                "checkpoint": deepcopy(self.trainer.model.state_dict()),
+                "full_config": self.config,
+            }
+
+            self._do_a_pass()
+
+            with patch(
+                "mmf.utils.checkpoint.load_pretrained_model",
+                return_value=ret_load_pretrained_zoo,
+            ):
+                self.trainer.config.checkpoint.resume_zoo = "random"
+                with contextlib.redirect_stdout(StringIO()):
+                    checkpoint.load_state_dict()
+                self.assertTrue(
+                    compare_state_dicts(
+                        self.trainer.model.state_dict(), original_model.state_dict()
+                    )
+                )
+
+                # Now, test zoo override
+                self.trainer.config.checkpoint.zoo_config_override = True
+                SimpleModule.from_pretrained = Mock(
+                    return_value=deepcopy(original_model)
+                )
+                registry.register_model("simple")(SimpleModule)
+                with contextlib.redirect_stdout(StringIO()):
+                    checkpoint.load_state_dict()
+                self.assertTrue(
+                    compare_state_dicts(
+                        self.trainer.model.state_dict(), original_model.state_dict()
+                    )
+                )
+
+    def test_pretrained_load(self):
+        with mock_env_with_temp() as d:
+            checkpoint = Checkpoint(self.trainer)
+            self._init_early_stopping(checkpoint)
+            self._do_a_pass()
+            original_model = deepcopy(self.trainer.model)
+            # Test with zoo now
+            ret_load_pretrained_zoo = {
+                "config": self.config.model_config,
+                "checkpoint": deepcopy(self.trainer.model.state_dict()),
+                "full_config": self.config,
+            }
+
+            checkpoint.save(2000)
+            self.trainer.config.checkpoint.resume_file = os.path.join(d, "current.ckpt")
+            self.trainer.config.checkpoint.resume_pretrained = True
+            self.trainer.model = OnlyBase()
+            checkpoint.load_state_dict()
+
+            self.assertTrue(
+                compare_state_dicts(
+                    self.trainer.model.base_test.state_dict(),
+                    original_model.base.state_dict(),
+                )
+            )
+
+            with patch(
+                "mmf.utils.checkpoint.load_pretrained_model",
+                return_value=ret_load_pretrained_zoo,
+            ):
+                self.trainer.config.checkpoint.resume_zoo = "random"
+                self.trainer.config.checkpoint.resume_file = None
+                self.trainer.model = OnlyBase()
+                checkpoint.load_state_dict()
+
+                self.assertTrue(
+                    compare_state_dicts(
+                        self.trainer.model.base_test.state_dict(),
+                        original_model.base.state_dict(),
+                    )
+                )
+
+    def _init_early_stopping(self, checkpoint):
+        self.trainer.num_updates = 0
+        self.trainer.current_iteration = 0
+        self.trainer.current_epoch = 0
+        self.trainer.early_stopping = EarlyStopping(self.trainer.model, checkpoint)
+        self.trainer.early_stopping.best_monitored_iteration = 1000
+        self.trainer.early_stopping.best_monitored_update = 1000
+        self.trainer.early_stopping.best_monitored_value = 0.1
+        self.trainer.current_epoch = 2
+
+    def _do_a_pass(self):
+        self.trainer.optimizer.zero_grad()
+        self.trainer.model.train()
+        with contextlib.redirect_stdout(StringIO()):
+            loss = self.trainer.model(
+                torch.rand(5, 5, requires_grad=True),
+                torch.empty(5, dtype=torch.long).random_(5),
+            )
+
+        loss["losses"]["total_loss"].sum().backward()
+        self.trainer.optimizer.step()
+
+    def _compare_optimizers(self, a, b, skip_keys=False):
+        state_dict_a = a.state_dict()
+        state_dict_b = b.state_dict()
+        state_a = state_dict_a["state"]
+        state_b = state_dict_b["state"]
+
+        same = True
+        if not skip_keys:
+            same = same and list(state_a.keys()) == list(state_b.keys())
+            same = same and state_dict_a["param_groups"] == state_dict_b["param_groups"]
+
+        for item1, item2 in zip(state_a.values(), state_b.values()):
+            same = same and compare_state_dicts(item1, item2)
+
+        return same


### PR DESCRIPTION
- Directly load from a zoo model with `resume_zoo` option
- Optionally, reset optimizers or counts
- Use `load_pretrained` to load using `zoo_override` otherwise correct
config must be known
- `resume_pretrained` added to clarify confusion on loading pretrained
mapping
- `pretrained_mapping` -> `pretrained_state_mapping`
- Complete some pending TODOs in checkpoint class

Test Plan:

Yet to be added
Also need to update some configs