### PR TITLE
[feature] HM prediction support, new predict cli cmd, support for csv predict file etc

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -20,12 +20,6 @@ training:
     # completed first. Default: null means epochs won't be used
     max_epochs: null
 
-    # Type of run, train+inference by default means both training and inference
-    # (test) stage will be run, if run_type contains 'val',
-    # inference will be run on val set also.
-    run_type: train_inference
-
-
     # After `log_interval` iterations, current iteration's training loss will be
     # reported. This will also report validation on a single batch from validation set
     # to provide an estimate on validation side
@@ -147,6 +141,11 @@ model: null
 
 # Config file to be optionally passed by the user
 config: null
+
+# Type of run, train+inference by default means both training and inference
+# (test) stage will be run, if run_type contains 'val',
+# inference will be run on val set also.
+run_type: train_inference
 
 # Configuration for optimizer, examples can be found in models' configs in
 # configs folder

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -51,8 +51,6 @@ training:
     # Some datasets allow fast reading by loading everything in the memory
     # Use this to enable it
     fast_read: false
-    # Whether JSON files for evalai evaluation should be generated
-    evalai_inference: false
     # Use in multi-tasking, when you want to sample tasks proportional to their sizes
     dataset_size_proportional_sampling: true
     # Whether to pin memory in dataloader
@@ -126,6 +124,10 @@ training:
 evaluation:
     # Metrics for evaluation
     metrics: []
+    # Generate predictions in a file
+    predict: false
+    # Prediction file format, default is json
+    predict_file_format: json
 
 # Configuration for models, default configuration files for various models
 # included in MMF can be found under configs directory in root folder

--- a/mmf/datasets/base_dataset.py
+++ b/mmf/datasets/base_dataset.py
@@ -107,7 +107,7 @@ class BaseDataset(Dataset):
     def dataset_name(self, name):
         self._dataset_name = name
 
-    def format_for_evalai(self, report):
+    def format_for_prediction(self, report):
         return []
 
     def verbose_dump(self, *args, **kwargs):

--- a/mmf/datasets/builders/coco/dataset.py
+++ b/mmf/datasets/builders/coco/dataset.py
@@ -64,7 +64,7 @@ class COCODataset(VQA2Dataset):
 
         return sample
 
-    def format_for_evalai(self, report):
+    def format_for_prediction(self, report):
         captions = report.captions.tolist()
         predictions = []
         remove_unk_from_caption_prediction = getattr(

--- a/mmf/datasets/builders/hateful_memes/dataset.py
+++ b/mmf/datasets/builders/hateful_memes/dataset.py
@@ -46,6 +46,9 @@ class HatefulMemesFeaturesDataset(MMFDataset):
         current_sample.targets = torch.tensor(sample_info["label"], dtype=torch.long)
         return current_sample
 
+    def format_for_prediction(self, report):
+        return generate_prediction(report)
+
 
 class HatefulMemesImageDataset(MMFDataset):
     def __init__(self, config, *args, dataset_name="hateful_memes", **kwargs):
@@ -74,3 +77,22 @@ class HatefulMemesImageDataset(MMFDataset):
         current_sample.image = self.image_db[idx]["images"][0]
         current_sample.targets = torch.tensor(sample_info["label"], dtype=torch.long)
         return current_sample
+
+    def format_for_prediction(self, report):
+        return generate_prediction(report)
+
+
+def generate_prediction(report):
+    probabilities, labels = torch.max(
+        torch.nn.functional.softmax(report.scores, dim=1), 1
+    )
+
+    predictions = []
+
+    for idx, image_id in enumerate(report.id):
+        proba = probabilities[idx].item()
+        label = labels[idx].item()
+        predictions.append(
+            {"id": image_id.item(), "proba": proba, "label": label,}
+        )
+    return predictions

--- a/mmf/datasets/builders/textvqa/dataset.py
+++ b/mmf/datasets/builders/textvqa/dataset.py
@@ -25,7 +25,7 @@ class TextVQADataset(MMFDataset):
     def postprocess_evalai_entry(self, entry):
         return entry  # Do nothing
 
-    def format_for_evalai(self, report):
+    def format_for_prediction(self, report):
         answer_processor = self.answer_processor
 
         batch_size = len(report.question_id)

--- a/mmf/datasets/builders/vizwiz/dataset.py
+++ b/mmf/datasets/builders/vizwiz/dataset.py
@@ -26,7 +26,7 @@ class VizWizDataset(VQA2Dataset):
 
         return sample
 
-    def format_for_evalai(self, report):
+    def format_for_prediction(self, report):
         answers = report.scores.argmax(dim=1)
 
         predictions = []

--- a/mmf/datasets/builders/vqa2/dataset.py
+++ b/mmf/datasets/builders/vqa2/dataset.py
@@ -133,7 +133,7 @@ class VQA2Dataset(MMFDataset):
     def idx_to_answer(self, idx):
         return self.answer_processor.convert_idx_to_answer(idx)
 
-    def format_for_evalai(self, report):
+    def format_for_prediction(self, report):
         answers = report.scores.argmax(dim=1)
 
         predictions = []

--- a/mmf/datasets/builders/vqa2/ocr_dataset.py
+++ b/mmf/datasets/builders/vqa2/ocr_dataset.py
@@ -10,7 +10,7 @@ class VQA2OCRDataset(VizWizDataset):
         )
         self.name = "vqa2_ocr"
 
-    def format_for_evalai(self, batch, answers):
+    def format_for_prediction(self, batch, answers):
         answers = answers.argmax(dim=1)
 
         predictions = []

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -179,6 +179,13 @@ class BaseModel(nn.Module):
         for item in requirements:
             download_pretrained_model(item, *args, **kwargs)
 
+    def format_for_prediction(self, results, report):
+        """Implement this method in models if it requires to modify prediction
+        results using report fields. Note that the required fields in report
+        should already be gathered in report.
+        """
+        return results
+
     @classmethod
     def from_pretrained(cls, model_name, *args, **kwargs):
         model_key = model_name.split(".")[0]

--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -68,8 +68,7 @@ class Losses(nn.Module):
     def __init__(self, loss_list):
         super().__init__()
         self.losses = []
-        tp = registry.get("config").training
-        self._evalai_inference = tp.evalai_inference
+        self._evaluation_predict = registry.get("config").evaluation.predict
         for loss in loss_list:
             self.losses.append(MMFLoss(loss))
 
@@ -88,11 +87,11 @@ class Losses(nn.Module):
         """
         output = {}
         if not hasattr(sample_list, "targets"):
-            if not self._evalai_inference:
+            if not self._evaluation_predict:
                 warnings.warn(
                     "Sample list has not field 'targets', are you "
                     "sure that your ImDB has labels? you may have "
-                    "wanted to run with --evalai_inference 1"
+                    "wanted to run with evaluation.predict=true"
                 )
             return output
 

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -494,8 +494,8 @@ class BaseTrainer:
             self._inference_run("test")
 
     def _inference_run(self, dataset_type):
-        if self.config.training.evalai_inference is True:
-            self.predict_for_evalai(dataset_type)
+        if self.config.evaluation.predict:
+            self.predict(dataset_type)
             return
 
         self.writer.write("Starting inference on {} set".format(dataset_type))
@@ -524,7 +524,7 @@ class BaseTrainer:
         self.writer.write(text + ": " + self.profiler.get_time_since_start(), "debug")
         self.profiler.reset()
 
-    def predict_for_evalai(self, dataset_type):
+    def predict(self, dataset_type):
         reporter = self.dataset_loader.get_test_reporter(dataset_type)
         with torch.no_grad():
             self.model.eval()
@@ -538,7 +538,7 @@ class BaseTrainer:
                     prepared_batch = reporter.prepare_batch(batch)
                     model_output = self.model(prepared_batch)
                     report = Report(prepared_batch, model_output)
-                    reporter.add_to_report(report)
+                    reporter.add_to_report(report, self.model)
 
             self.writer.write("Finished predicting")
             self.model.train()

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -41,7 +41,7 @@ class BaseTrainer:
     def load(self):
         self._set_device()
 
-        self.run_type = self.config.training.get("run_type", "train")
+        self.run_type = self.config.get("run_type", "train")
         self.dataset_loader = DatasetLoader(self.config)
         self._datasets = self.config.datasets
 
@@ -490,7 +490,7 @@ class BaseTrainer:
         if "val" in self.run_type:
             self._inference_run("val")
 
-        if "inference" in self.run_type or "predict" in self.run_type:
+        if any(rt in self.run_type for rt in ["inference", "test", "predict"]):
             self._inference_run("test")
 
     def _inference_run(self, dataset_type):
@@ -528,7 +528,7 @@ class BaseTrainer:
         reporter = self.dataset_loader.get_test_reporter(dataset_type)
         with torch.no_grad():
             self.model.eval()
-            message = "Starting {} inference for evalai".format(dataset_type)
+            message = "Starting {} inference predictions".format(dataset_type)
             self.writer.write(message)
 
             while reporter.next_dataset():

--- a/mmf/utils/configuration.py
+++ b/mmf/utils/configuration.py
@@ -540,6 +540,7 @@ class Configuration:
             "training.resume_best": "checkpoint.resume_best",
             "training.load_pretrained": "checkpoint.resume_pretrained",
             "training.pretrained_state_mapping": "checkpoint.pretrained_state_mapping",
+            "training.run_type": "run_type",
         }
 
         for old, new in mapping.items():

--- a/mmf/version.py
+++ b/mmf/version.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 
 msg = "MMF is only compatible with Python 3.6 and newer."
 

--- a/mmf/version.py
+++ b/mmf/version.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "1.0.0rc2"
+__version__ = "1.0.0rc1"
 
 msg = "MMF is only compatible with Python 3.6 and newer."
 

--- a/projects/ban/README.md
+++ b/projects/ban/README.md
@@ -24,5 +24,5 @@ python setup.py build develop
 ## Training
 To train BAN model on the VQA2 dataset, run the following command
 ```
-python tools/run.py config=projects/ban/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=ban
+python tools/run.py config=projects/ban/configs/vqa2/defaults.yaml run_type=train_val dataset=vqa2 model=ban
 ```

--- a/projects/butd/README.md
+++ b/projects/butd/README.md
@@ -23,7 +23,7 @@ python setup.py build develop
 ## Training
 To train BUTD model on the COCO Captions dataset, run the following command
 ```
-python tools/run.py config=projects/butd/configs/coco/defaults.yaml training.run_type=train_val dataset=coco model=butd
+python tools/run.py config=projects/butd/configs/coco/defaults.yaml run_type=train_val dataset=coco model=butd
 ```
 
 For training BUTD model use the config `defaults.yaml` only. Training uses greedy decoding for validation. Currently we do not have support to train the model using beam search or nucleus sampling decoding. For inference, any of the following methods can be used:

--- a/projects/lorra/README.md
+++ b/projects/lorra/README.md
@@ -23,5 +23,5 @@ python setup.py build develop
 ## Training
 To train LoRRA model on the TextVQA dataset, run the following command
 ```
-python tools/run.py config=projects/lorra/configs/textvqa/defaults.yaml training.run_type=train_val dataset=textvqa model=lorra
+python tools/run.py config=projects/lorra/configs/textvqa/defaults.yaml run_type=train_val dataset=textvqa model=lorra
 ```

--- a/projects/pretrain_vl_right/README.md
+++ b/projects/pretrain_vl_right/README.md
@@ -45,14 +45,14 @@ Below are the download links to the imdbs and features used for this project. **
 
 Example : To pretrain VisualBERT model on the COCO Captions dataset, run the following command
 ```
-python tools/run.py config=projects/visual_bert/configs/masked_coco/pretrain.yaml training.run_type=train_val dataset=masked_coco model=visual_bert
+python tools/run.py config=projects/visual_bert/configs/masked_coco/pretrain.yaml run_type=train_val dataset=masked_coco model=visual_bert
 ```
 
 ### Finetuning
 
 Example : To finetune VisualBERT model on the VQA2.0 dataset, run the following command
 ```
-python tools/run.py config=projects/visual_bert/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=visual_bert checkpoint.resume_file=<path_to_pretrained_visual_bert_model> checkpoint.resume_pretrained=true
+python tools/run.py config=projects/visual_bert/configs/vqa2/defaults.yaml run_type=train_val dataset=vqa2 model=visual_bert checkpoint.resume_file=<path_to_pretrained_visual_bert_model> checkpoint.resume_pretrained=true
 ```
 
 Configs for different settings and pretraining datasets are provided in the next section.

--- a/projects/pythia/README.md
+++ b/projects/pythia/README.md
@@ -38,5 +38,5 @@ python setup.py build develop
 ## Training
 To train Pythia model on the VQA2.0 dataset, run the following command
 ```
-python tools/run.py config=projects/mmf/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=pythia
+python tools/run.py config=projects/mmf/configs/vqa2/defaults.yaml run_type=train_val dataset=vqa2 model=pythia
 ```

--- a/projects/vilbert/README.md
+++ b/projects/vilbert/README.md
@@ -36,7 +36,7 @@ python setup.py build develop
 ## Training
 To train ViLBERT model on the VQA2.0 dataset, run the following command
 ```
-python tools/run.py config=projects/vilbert/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=vilbert
+python tools/run.py config=projects/vilbert/configs/vqa2/defaults.yaml run_type=train_val dataset=vqa2 model=vilbert
 ```
 
 Based on the config used and `training_head_type` defined in the config, the model can use either pretraining head or donwstream task specific heads(VQA, Vizwiz, SNLI-VE, MM IMDB or NLVR2).

--- a/projects/visual_bert/README.md
+++ b/projects/visual_bert/README.md
@@ -35,7 +35,7 @@ python setup.py build develop
 ## Training
 To train VisualBERT model on the VQA2.0 dataset, run the following command
 ```
-python tools/run.py config=projects/visual_bert/configs/vqa2/defaults.yaml training.run_type=train_val dataset=vqa2 model=visual_bert
+python tools/run.py config=projects/visual_bert/configs/vqa2/defaults.yaml run_type=train_val dataset=vqa2 model=visual_bert
 ```
 
 Based on the config used and `training_head_type` defined in the config, the model can use either pretraining head or donwstream task specific heads(VQA, Vizwiz, SNLI-VE, MM IMDB or NLVR2).

--- a/setup.py
+++ b/setup.py
@@ -112,5 +112,10 @@ if __name__ == "__main__":
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
             "Operating System :: OS Independent",
         ],
-        entry_points={"console_scripts": ["mmf_run = tools.run:run"]},
+        entry_points={
+            "console_scripts": [
+                "mmf_run = tools.run:run",
+                "mmf_predict = tools.predict:predict",
+            ]
+        },
     )

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3 -u
+# Copyright (c) Facebook, Inc. and its affiliates.
+from tools.run import run
+
+
+def predict():
+    run(predict=True)
+
+
+if __name__ == "__main__":
+    predict()

--- a/tools/predict.py
+++ b/tools/predict.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3 -u
 # Copyright (c) Facebook, Inc. and its affiliates.
+
+import sys
+
 from tools.run import run
 
 
 def predict():
+    sys.argv.extend(["evaluation.predict=true"])
     run(predict=True)
 
 

--- a/tools/sweeps/sweep_visual_bert.py
+++ b/tools/sweeps/sweep_visual_bert.py
@@ -8,7 +8,7 @@ def get_grid(args):
     max_update = 22000
 
     return [
-        hyperparam("training.run_type", "train_val"),
+        hyperparam("run_type", "train_val"),
         hyperparam("config", "projects/visual_bert/configs/vqa2/defaults.yaml"),
         # hyperparam("--fp16", save_dir_key=lambda val: "fp16"),
         hyperparam("training.num_workers", 5),


### PR DESCRIPTION
PR adds the following capabilities :
- New `mmf_predict` cli command for pypi. Can also be run as `python tools/predict.py .. `
- Support for saving predictions to a `csv` file in addition to default `json`
- New config keys `evaluation.predict` and `evalaution.predict_file_format`. Removes `evalai_inference`
- Predictions can be modified from models as well
- Add HM predict support 



Test Plan : 

```
mmf_predict config=projects/visual_bert/configs/hateful_memes/defaults.yaml dataset=hateful_memes model=visual_bert evaluation.predict=true evaluation.predict_file_format=csv
```