### PR TITLE
[tests] Fix device error in checkpoint test

### DIFF
--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -195,15 +195,18 @@ class TestUtilsCheckpoint(unittest.TestCase):
             # Test distributed settings
             self.trainer.model = torch.nn.DataParallel(self.trainer.model)
             checkpoint.load_state_dict()
-
+            
+            weight_to_be_tested = self.trainer.model.module.base[0].weight
+            weight_device = weight_to_be_tested.device
+            
             self.assertTrue(
                 torch.equal(
-                    self.trainer.model.module.base[0].weight, base_0_weight_current.cuda()
+                    weight_to_be_tested, base_0_weight_current.to(weight_device)
                 )
             )
             self.assertFalse(
                 torch.equal(
-                    self.trainer.model.module.base[0].weight, base_0_weight_best.cuda()
+                    weight_to_be_tested, base_0_weight_best.to(weight_device)
                 )
             )
 

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -198,12 +198,12 @@ class TestUtilsCheckpoint(unittest.TestCase):
 
             self.assertTrue(
                 torch.equal(
-                    self.trainer.model.module.base[0].weight, base_0_weight_current
+                    self.trainer.model.module.base[0].weight, base_0_weight_current.cuda()
                 )
             )
             self.assertFalse(
                 torch.equal(
-                    self.trainer.model.module.base[0].weight, base_0_weight_best
+                    self.trainer.model.module.base[0].weight, base_0_weight_best.cuda()
                 )
             )
 

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -195,19 +195,17 @@ class TestUtilsCheckpoint(unittest.TestCase):
             # Test distributed settings
             self.trainer.model = torch.nn.DataParallel(self.trainer.model)
             checkpoint.load_state_dict()
-            
+
             weight_to_be_tested = self.trainer.model.module.base[0].weight
             weight_device = weight_to_be_tested.device
-            
+
             self.assertTrue(
                 torch.equal(
                     weight_to_be_tested, base_0_weight_current.to(weight_device)
                 )
             )
             self.assertFalse(
-                torch.equal(
-                    weight_to_be_tested, base_0_weight_best.to(weight_device)
-                )
+                torch.equal(weight_to_be_tested, base_0_weight_best.to(weight_device))
             )
 
     def test_finalize_and_restore_from_it(self):


### PR DESCRIPTION
There was an error in running pytest ./tests that it expected cuda object but received cpu object.