### PR TITLE
[chores] Upgrade to Pytorch 1.5, torchvision 0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ install_dep_windows: &install_dep_windows
       command: |
         source activate mmf
         pip install --upgrade setuptools certifi
-        pip install -f https://download.pytorch.org/whl/torch_stable.html -r requirements.txt
+        pip install --progress-bar off torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install -r requirements.txt
         pip install --progress-bar off flake8
         pip install --progress-bar off black
         pip install --progress-bar off isort

--- a/docs/source/notes/installation.md
+++ b/docs/source/notes/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-MMF is tested on Python 3.6+ and PyTorch 1.4.
+MMF is tested on Python 3.6+ and PyTorch 1.5.
 
 ## Install using pip
 

--- a/mmf/version.py
+++ b/mmf/version.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "1.0.0rc5"
+__version__ = "1.0.0rc6"
 
 msg = "MMF is only compatible with Python 3.6 and newer."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.4.0
-torchvision==0.5.0
+torch==1.5.0
+torchvision==0.6.0
 numpy==1.16.6
 tqdm==4.43.0
 demjson==2.2.4

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ if "READTHEDOCS" in os.environ:
     CMD_CLASS.pop("build_ext", None)
     # use CPU build of PyTorch
     DEPENDENCY_LINKS.append(
-        "https://download.pytorch.org/whl/cpu/torch-1.4.0%2B"
+        "https://download.pytorch.org/whl/cpu/torch-1.5.0%2B"
         + "cpu-cp36-cp36m-linux_x86_64.whl"
     )
 


### PR DESCRIPTION
- Upgrade to Pytorch 1.5, torchvision 0.6
- Update setup.py and hence rc version
- Update CircleCI for windows build test. Since windows instance we are using does not have GPU enabled we install cpu version of torch only.


Tests:
- Tests passing
- Tested with VisualBERT model training