### PR TITLE
[mmf] Fblearner changes for Hateful Memes, HM sweep script, some fixes (#121)

### DIFF
--- a/tools/sweeps/lib/__init__.py
+++ b/tools/sweeps/lib/__init__.py
@@ -99,6 +99,11 @@ def get_args():
         help="secure group to use",
         default="fair_research_and_engineering",
     )
+    parser.add_argument(
+        "--torch_home",
+        help="torch cache path",
+        default="/mnt/vol/gfsfblearner-oregon/users/vedanuj/torch/",
+    )
 
     # Slurm params
     parser.add_argument(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/mmf-internal/pull/121

- Added new squashfs hateful_memes.img to `/mnt/fair/hateful_memes.img` and `/mnt/fair-flash3-east/hateful_memes.img` . This contains all data files necessary for hateful memes v5
- Added Hateful Memes sweep script for mmbt. This can be modified to run with other models
- set env variable for `TORCH_HOME` to read cached files for models, tokenizer configs etc.
- add `projects` files to target so that fblearner can find relative configs
- fblearner fixes after file name was changed

Reviewed By: mamhamed

Differential Revision: D21759302

