### PR TITLE
[feature, fix] Capture stdout in logger, fix logger initialization

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -33,6 +33,8 @@ training:
     # Whether MMF should log or not, Default: False, which means
     # mmf will log by default
     should_not_log: false
+    # Whether to capture stdout logs by the logger. Default: True
+    stdout_capture: true
 
     # Tensorboard control, by default tensorboard is disabled
     tensorboard: false

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -30,13 +30,10 @@ from mmf.utils.timer import Timer
 
 @registry.register_trainer("base_trainer")
 class BaseTrainer:
-    def __init__(self, configuration):
-        self.configuration = configuration
-        self.config = self.configuration.get_config()
+    def __init__(self, config):
+        self.config = config
         self.profiler = Timer()
         self.total_timer = Timer()
-        if self.configuration is not None:
-            self.args = self.configuration.args
 
     def load(self):
         self._set_device()
@@ -53,7 +50,9 @@ class BaseTrainer:
             self.writer = Logger(self.config)
             registry.register("writer", self.writer)
 
-        self.configuration.pretty_print()
+        configuration = registry.get("configuration", no_warning=True)
+        if configuration:
+            configuration.pretty_print()
 
         self.config_based_setup()
 

--- a/mmf/utils/visualize.py
+++ b/mmf/utils/visualize.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
 from typing import Any, List, Optional, Tuple
 
 import torch

--- a/mmf_cli/run.py
+++ b/mmf_cli/run.py
@@ -5,7 +5,7 @@ import random
 import torch
 
 from mmf.common.registry import registry
-from mmf.utils.build import build_trainer
+from mmf.utils.build import build_config, build_trainer
 from mmf.utils.configuration import Configuration
 from mmf.utils.distributed import distributed_init, infer_init_method
 from mmf.utils.env import set_seed, setup_imports
@@ -30,9 +30,11 @@ def main(configuration, init_distributed=False, predict=False):
     registry.register("seed", config.training.seed)
     print(f"Using seed {config.training.seed}")
 
-    registry.register("writer", Logger(config, name="mmf.train"))
+    config = build_config(configuration)
 
-    trainer = build_trainer(configuration)
+    # Logger should be registered after config is registered
+    registry.register("writer", Logger(config, name="mmf.train"))
+    trainer = build_trainer(config)
     trainer.load()
     if predict:
         trainer.inference()

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,0 +1,48 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import argparse
+import os
+import shutil
+import tempfile
+import unittest
+from typing import Optional
+
+from mmf.common.registry import registry
+from mmf.utils.configuration import Configuration
+from mmf.utils.file_io import PathManager
+from mmf.utils.logger import Logger
+
+
+class TestLogger(unittest.TestCase):
+
+    _tmpdir: Optional[str] = None
+    _tmpfile_write_contents: str = "print writer contents"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmpdir = tempfile.mkdtemp()
+        args = argparse.Namespace()
+        args.opts = [f"env.save_dir={cls._tmpdir}", f"model=cnn_lstm", f"dataset=clevr"]
+        args.config_override = None
+        configuration = Configuration(args)
+        configuration.freeze()
+        cls.config = configuration.get_config()
+        registry.register("config", cls.config)
+        cls.writer = Logger(cls.config)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Cleanup temp working dir.
+        if cls._tmpdir is not None:
+            shutil.rmtree(cls._tmpdir)
+
+    def test_logger_files(self) -> None:
+        self.assertTrue(PathManager.exists(os.path.join(self._tmpdir, "train.log")))
+        self.assertTrue(PathManager.exists(os.path.join(self._tmpdir, "logs")))
+
+    def test_log_writer(self) -> None:
+        self.writer.write(self._tmpfile_write_contents)
+        f = PathManager.open(os.path.join(self._tmpdir, "train.log"))
+        self.assertTrue(
+            any(self._tmpfile_write_contents in line for line in f.readlines())
+        )

--- a/tools/sweeps/lib/slurm.py
+++ b/tools/sweeps/lib/slurm.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-# Copied from fairseq. Mostly written by @myleott. Adapted accordingly for pythia
+# Copied from fairseq. Mostly written by @myleott. Adapted accordingly for mmf
 import datetime
 import itertools
 import os
@@ -49,7 +49,7 @@ def copy_all_python_files(source, snapshot_main_dir, code_snapshot_hash):
     """
     Copies following files from source to destination:
         a) all *.py files at direct source location.
-        b) all fairseq/*.py recursively.
+        b) all mmf/*.py recursively.
     """
     os.makedirs(snapshot_main_dir, exist_ok=True)
     destination = os.path.join(snapshot_main_dir, code_snapshot_hash)
@@ -58,7 +58,7 @@ def copy_all_python_files(source, snapshot_main_dir, code_snapshot_hash):
     ), f"Code snapshot: {code_snapshot_hash} alredy exists"
     os.makedirs(destination)
     all_pys = (
-        glob(os.path.join(source, "pythia/**/*.py"), recursive=True)
+        glob(os.path.join(source, "mmf/**/*.py"), recursive=True)
         + glob(os.path.join(source, "tools/**/*.py"), recursive=True)
         + glob(os.path.join(source, "*.py"))
     )
@@ -139,7 +139,7 @@ def launch_train(args, config):
         return
 
     # generate train command
-    train_cmd = ["python", "-u", os.path.join(destination, "tools/run.py")]
+    train_cmd = ["python", "-u", os.path.join(destination, "mmf_cli/run.py")]
     train_cmd.extend(["distributed.world_size", str(args.num_nodes * args.num_gpus)])
     if args.num_nodes > 1:
         train_cmd.extend(["distributed.port", str(get_random_port())])


### PR DESCRIPTION
This PR addresses several logger related issues 

- Capture `stdout` by the logger. Adds a StreamToLogger class to write `stdout` to logger. Behavior can be overridden using config `training.stdout_capture`.
- Remove sending the writer/warning logs to stdout when we are capturing stdout logs in the logger
- Refactor out `build_config` as a separate method and decouple from `build_trainer`.
- Adds basic tests to check log files are created in proper place
- Fixes slurm script
