### PR TITLE
[feature, fix] added support for update_frequency

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -42,6 +42,10 @@ training:
     # Size of each batch. If distributed or data_parallel
     # is used, this will be divided equally among GPUs
     batch_size: 512
+    # Run update_frequency=K batches with batch_size=N, accumulate gradients, then do 
+    # one update (one optimizer step). The effect is a large effective batch size of 
+    # KxN (without incurring the memory overhead of setting batch_size to KxN).
+    update_frequency: 1
     # Number of workers to be used in dataloaders
     num_workers: 4
     # Some datasets allow fast reading by loading everything in the memory

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -42,8 +42,8 @@ training:
     # Size of each batch. If distributed or data_parallel
     # is used, this will be divided equally among GPUs
     batch_size: 512
-    # Run update_frequency=K batches with batch_size=N, accumulate gradients, then do 
-    # one update (one optimizer step). The effect is a large effective batch size of 
+    # Run update_frequency=K batches with batch_size=N, accumulate gradients, then do
+    # one update (one optimizer step). The effect is a large effective batch size of
     # KxN (without incurring the memory overhead of setting batch_size to KxN).
     update_frequency: 1
     # Number of workers to be used in dataloaders

--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -178,7 +178,10 @@ class MultiDatasetLoader:
 
     def __len__(self):
         # Since, this is iterator, we need to return total length == number of batches
-        return self._total_length // get_batch_size()
+        batch_size = get_batch_size()
+        # This assumes drop_last=False for all loaders. See also 
+        # build_dataloader_and_sampler().
+        return (self._total_length + batch_size - 1) // batch_size
 
     def __iter__(self):
         if self._num_datasets == 1:

--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -179,7 +179,7 @@ class MultiDatasetLoader:
     def __len__(self):
         # Since, this is iterator, we need to return total length == number of batches
         batch_size = get_batch_size()
-        # This assumes drop_last=False for all loaders. See also 
+        # This assumes drop_last=False for all loaders. See also
         # build_dataloader_and_sampler().
         return (self._total_length + batch_size - 1) // batch_size
 

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -260,7 +260,7 @@ class BaseTrainer:
 
                 epoch_batch_index += 1
 
-            assert(epoch_batch_index == epoch_num_batches)
+            assert epoch_batch_index == epoch_num_batches
             # In distributed, each worker will complete one epoch when we reach this
             # as each worker is an individual instance
             self.current_epoch += get_world_size() - 1
@@ -290,11 +290,16 @@ class BaseTrainer:
         # When epoch_num_batches is not a multiple of the effective batch size, the last few batches
         # will be discarded. I.e., they won't contribute to an update.
         epoch_num_updates = epoch_num_batches // self.config.training.update_frequency
-        is_batch_discarded = (epoch_batch_index >= epoch_num_updates * self.config.training.update_frequency)
+        is_batch_discarded = (
+            epoch_batch_index
+            >= epoch_num_updates * self.config.training.update_frequency
+        )
         if is_batch_discarded:
             return
 
-        is_first_batch_for_update = epoch_batch_index % self.config.training.update_frequency == 0
+        is_first_batch_for_update = (
+            epoch_batch_index % self.config.training.update_frequency == 0
+        )
         if is_first_batch_for_update:
             self.current_iteration += 1
             self.writer.write(self.num_updates + 1, "debug")
@@ -302,10 +307,14 @@ class BaseTrainer:
 
     def _check_finish_update(self, epoch_batch_index, report):
         should_break = False
-        is_last_batch_for_update = (epoch_batch_index + 1) % self.config.training.update_frequency == 0
+        is_last_batch_for_update = (
+            epoch_batch_index + 1
+        ) % self.config.training.update_frequency == 0
         if is_last_batch_for_update:
             if self.should_clip_gradients:
-                clip_gradients(self.model, self.num_updates, self.tb_writer, self.config)
+                clip_gradients(
+                    self.model, self.num_updates, self.tb_writer, self.config
+                )
             self.optimizer.step()
             self._run_scheduler()
             self.num_updates += 1

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -260,7 +260,6 @@ class BaseTrainer:
 
                 epoch_batch_index += 1
 
-            assert epoch_batch_index == epoch_num_batches
             # In distributed, each worker will complete one epoch when we reach this
             # as each worker is an individual instance
             self.current_epoch += get_world_size() - 1
@@ -281,13 +280,15 @@ class BaseTrainer:
         return report
 
     def _backward(self, loss):
-        # for update_frequency > 1, scale the loss so that accumulated gradients are the expected magnitude
+        # for update_frequency > 1, scale the loss so that accumulated gradients are the
+        # expected magnitude
         loss = loss / self.config.training.update_frequency
         loss.backward()
         self.profile("Backward time")
 
     def _check_start_update(self, epoch_batch_index, epoch_num_batches):
-        # When epoch_num_batches is not a multiple of the effective batch size, the last few batches
+        # When epoch_num_batches is not a multiple of the effective batch size, the last
+        # few batches
         # will be discarded. I.e., they won't contribute to an update.
         epoch_num_updates = epoch_num_batches // self.config.training.update_frequency
         is_batch_discarded = (

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -139,6 +139,7 @@ def build_dataloader_and_sampler(
             dataset_instance.dataset_name, dataset_instance.dataset_type
         ),
         num_workers=num_workers,
+        drop_last=False,  # see also MultiDatasetLoader.__len__
         **other_args,
     )
 


### PR DESCRIPTION
This PR adds support for config.training.update_frequency:
```
# Run update_frequency=K batches with batch_size=N, accumulate gradients, then do 
# one update (one optimizer step). The effect is a large effective batch size of 
# KxN (without incurring the memory overhead of setting batch_size to KxN).
update_frequency: 1
```
https://www.internalfb.com/intern/tasks/?t=66569918

With this change, we have to be more clear with naming. Amanpreet and I agreed on this:
- we have no particular term for a single forward/backward pass for a single batch
- "update" == "iteration" == one optimizer step (will be more than one batch when update_frequency > 1)

The update logic in `BaseTrainer._backward` has mostly been moved to `_check_start_update` and `_check_finish_update`.

There's also a fix for `MultiDatasetLoader.__len__`. The existing bug is only present for the case that the train set size is not a multiple of per-worker batch size, which is probably rare in practice.

Test Plan:
I did ad-hoc testing of BaseTrainer.train() with print statements and varying `[batch_size, update_frequency, train set size, max_updates, log_interval]`, including end-of-epoch and completion of the train run. 

I took at stab at comparing histograms of gradients used in each update. In theory, the we should see similar results between, say, `[batch_size=2, update_frequency=8]` and `[batch_size=16, update_frequency=1]` because these are the same effective batch size. In practice, the results were too noisy and thus inconclusive. I'm open to other suggestions for testing here.