### PR TITLE
[fix] Sdist build and add bypass_checksum feature for hm_convert

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include LICENSE
+include NOTICES

--- a/mmf_cli/hm_convert.py
+++ b/mmf_cli/hm_convert.py
@@ -58,6 +58,12 @@ class HMConverter:
         parser.add_argument(
             "--mmf_data_folder", required=None, type=str, help="MMF Data folder"
         )
+        parser.add_argument(
+            "--bypass_checksum",
+            required=None,
+            type=int,
+            help="Pass 1 if you want to skip checksum",
+        )
         return parser
 
     def convert(self):
@@ -67,6 +73,10 @@ class HMConverter:
         if self.args.mmf_data_folder:
             data_dir = self.args.mmf_data_folder
 
+        bypass_checksum = False
+        if self.args.bypass_checksum:
+            bypass_checksum = bool(self.args.bypass_checksum)
+
         print(f"Data folder is {data_dir}")
         print(f"Zip path is {self.args.zip_file}")
 
@@ -75,8 +85,10 @@ class HMConverter:
         images_path = os.path.join(base_path, "images")
         PathManager.mkdirs(images_path)
 
+        if not bypass_checksum:
+            self.checksum(self.args.zip_file, self.POSSIBLE_CHECKSUMS)
+
         src = self.args.zip_file
-        self.checksum(self.args.zip_file, self.POSSIBLE_CHECKSUMS)
         print(f"Moving {src}")
         dest = images_path
         move(src, dest)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch==1.5.0
 torchvision==0.6.0
-numpy==1.16.6
-tqdm==4.43.0
+numpy>=1.16.6
+tqdm>=4.43.0
 demjson==2.2.4
 torchtext==0.5.0
 GitPython==3.1.0


### PR DESCRIPTION
- We need Manifest.in for now; later we should move requirements
to setup.py directly
- Because of missing manifest, requirements.txt wasn't copied and caused
issue #299. Fixes #299 properly
- Updates requirements for numpy and tqdm to be more lenient
- Add bypass_checksum option for people who are having issues with
checksum. Thus, fixes #261

Test Plan:

Both options that were added have been tested properly locally on
devfair