### PR TITLE
[feat, refactor] Trainer class refactor

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -4,7 +4,7 @@ config_version: 1.0
 # Configuration for training
 training:
     # Name of the trainer class used to define the training/evalution loop
-    trainer: base_trainer
+    trainer: mmf_trainer
     # Seed to be used for training. -1 means random seed between 1 and 100000.
     # Either pass fixed through your config or command line arguments
     # Pass null to the seed if you don't want it seeded anyhow and

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -4,7 +4,7 @@ config_version: 1.0
 # Configuration for training
 training:
     # Name of the trainer class used to define the training/evalution loop
-    trainer: mmf_trainer
+    trainer: mmf
     # Seed to be used for training. -1 means random seed between 1 and 100000.
     # Either pass fixed through your config or command line arguments
     # Pass null to the seed if you don't want it seeded anyhow and

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -1,48 +1,23 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-import gc
-import math
-import time
+from abc import ABC, abstractmethod
 
-import omegaconf
-import torch
-from tqdm import tqdm
-
-from mmf.common.dataset_loader import DatasetLoader
-from mmf.common.meter import Meter
+from mmf.common import typings as mmf_typings
 from mmf.common.registry import registry
-from mmf.common.report import Report
-from mmf.modules.metrics import Metrics
-from mmf.utils.build import build_model, build_optimizer, build_scheduler
-from mmf.utils.checkpoint import Checkpoint
-from mmf.utils.configuration import get_mmf_env
-from mmf.utils.distributed import (
-    broadcast_scalar,
-    get_world_size,
-    is_master,
-    reduce_dict,
-)
-from mmf.utils.early_stopping import EarlyStopping
-from mmf.utils.general import clip_gradients, print_model_parameters
-from mmf.utils.logger import Logger, TensorboardLogger
-from mmf.utils.timer import Timer
+from mmf.utils.logger import Logger
 
 
 @registry.register_trainer("base_trainer")
-class BaseTrainer:
-    def __init__(self, config):
+class BaseTrainer(ABC):
+    def __init__(self, config: mmf_typings.DictConfig):
         self.config = config
-        self.profiler = Timer()
-        self.total_timer = Timer()
+        self.training_config = self.config.training
 
     def load(self):
-        self._set_device()
-
+        # Set run type
         self.run_type = self.config.get("run_type", "train")
-        self.dataset_loader = DatasetLoader(self.config)
-        self._datasets = self.config.datasets
 
-        # Check if loader is already defined, else init it
+        # Check if logger is already defined, else init it
         writer = registry.get("writer", no_warning=True)
         if writer:
             self.writer = writer
@@ -50,490 +25,83 @@ class BaseTrainer:
             self.writer = Logger(self.config)
             registry.register("writer", self.writer)
 
+        # Print configuration
         configuration = registry.get("configuration", no_warning=True)
         if configuration:
             configuration.pretty_print()
 
-        self.config_based_setup()
+        # Configure device and cudnn deterministic
+        self.configure_device()
+        self.configure_seed()
 
+        # Load dataset, model, optimizer and metrics
         self.load_datasets()
-        self.load_model_and_optimizer()
+        self.load_model()
+        self.load_optimizer()
         self.load_metrics()
 
-    def _set_device(self):
-        self.local_rank = self.config.device_id
-        self.device = self.local_rank
-        self.distributed = False
+        # Initialize Callbacks
+        self.configure_callbacks()
 
-        # Will be updated later based on distributed setup
-        registry.register("global_device", self.device)
+    @abstractmethod
+    def configure_device(self):
+        """Warning: this is just empty shell for code implemented in other class.
+        Configure and set device properties here.
+        """
 
-        if self.config.distributed.init_method is not None:
-            self.distributed = True
-            self.device = torch.device("cuda", self.local_rank)
-        elif torch.cuda.is_available():
-            self.device = torch.device("cuda")
-        else:
-            self.device = torch.device("cpu")
+    @abstractmethod
+    def configure_seed(self):
+        """Configure seed and related changes like torch deterministic etc shere.
 
-        registry.register("current_device", self.device)
+        Warning: Empty shell for code to be implemented in other class.
+        """
 
+    @abstractmethod
+    def configure_callbacks(self):
+        """Configure callbacks and add callbacks be executed during
+        different events during training, validation or test.
+
+        Warning: Empty shell for code to be implemented in other class.
+        """
+
+    @abstractmethod
     def load_datasets(self):
-        self.writer.write("Loading datasets", "info")
-        self.dataset_loader.load_datasets()
+        """Loads datasets and dataloaders.
 
-        self.train_dataset = self.dataset_loader.train_dataset
-        self.val_dataset = self.dataset_loader.val_dataset
+        Warning: Empty shell for code to be implemented in other class.
+        """
 
-        # Total iterations for snapshot
-        self.snapshot_iterations = len(self.val_dataset)
-        self.snapshot_iterations //= self.config.training.batch_size
+    @abstractmethod
+    def load_model(self):
+        """Load the model.
 
-        self.test_dataset = self.dataset_loader.test_dataset
+        Warning: Empty shell for code to be implemented in other class.
+        """
 
-        self.train_loader = self.dataset_loader.train_loader
-        self.val_loader = self.dataset_loader.val_loader
-        self.test_loader = self.dataset_loader.test_loader
+    @abstractmethod
+    def load_optimizer(self):
+        """Load optimizers.
 
+        Warning: Empty shell for code to be implemented in other class.
+        """
+
+    @abstractmethod
     def load_metrics(self):
-        metrics = self.config.evaluation.get("metrics", [])
-        self.metrics = Metrics(metrics)
-        self.metrics_params = self.metrics.required_params
+        """Load metrics for evaluation.
 
-    def load_model_and_optimizer(self):
-        attributes = self.config.model_config[self.config.model]
-        # Easy way to point to config for other model
-        if isinstance(attributes, str):
-            attributes = self.config.model_config[attributes]
+        Warning: Empty shell for code to be implemented in other class.
+        """
 
-        with omegaconf.open_dict(attributes):
-            attributes.model = self.config.model
-
-        self.model = build_model(attributes)
-
-        if "cuda" in str(self.device):
-            device_info = "CUDA Device {} is: {}".format(
-                self.config.distributed.rank,
-                torch.cuda.get_device_name(self.local_rank),
-            )
-            registry.register("global_device", self.config.distributed.rank)
-            self.writer.write(device_info, log_all=True)
-
-        self.model = self.model.to(self.device)
-        self.optimizer = build_optimizer(self.model, self.config)
-
-        registry.register("data_parallel", False)
-        registry.register("distributed", False)
-
-        self.load_extras()
-        self.parallelize_model()
-
-    def parallelize_model(self):
-        training = self.config.training
-        if (
-            "cuda" in str(self.device)
-            and torch.cuda.device_count() > 1
-            and not self.distributed
-        ):
-            registry.register("data_parallel", True)
-            self.model = torch.nn.DataParallel(self.model)
-
-        if "cuda" in str(self.device) and self.distributed:
-            registry.register("distributed", True)
-            self.model = torch.nn.parallel.DistributedDataParallel(
-                self.model,
-                device_ids=[self.local_rank],
-                output_device=self.local_rank,
-                check_reduction=True,
-                find_unused_parameters=training.find_unused_parameters,
-            )
-
-    def load_extras(self):
-        self.writer.write("Torch version is: " + torch.__version__)
-        self.checkpoint = Checkpoint(self)
-        self.meter = Meter()
-
-        self.training_config = self.config.training
-
-        early_stop_criteria = self.training_config.early_stop.criteria
-        early_stop_minimize = self.training_config.early_stop.minimize
-        early_stop_enabled = self.training_config.early_stop.enabled
-        early_stop_patience = self.training_config.early_stop.patience
-
-        self.log_interval = self.training_config.log_interval
-        self.evaluation_interval = self.training_config.evaluation_interval
-        self.checkpoint_interval = self.training_config.checkpoint_interval
-        self.max_updates = self.training_config.max_updates
-        self.should_clip_gradients = self.training_config.clip_gradients
-        self.max_epochs = self.training_config.max_epochs
-
-        self.early_stopping = EarlyStopping(
-            self.model,
-            self.checkpoint,
-            early_stop_criteria,
-            patience=early_stop_patience,
-            minimize=early_stop_minimize,
-            should_stop=early_stop_enabled,
-        )
-        self.current_epoch = 0
-        self.current_iteration = 0
-        self.num_updates = 0
-
-        self.checkpoint.load_state_dict()
-
-        self.not_debug = self.training_config.logger_level != "debug"
-
-        self.lr_scheduler = None
-
-        if self.training_config.lr_scheduler is True:
-            self.lr_scheduler = build_scheduler(self.optimizer, self.config)
-
-        self.tb_writer = None
-
-        if self.training_config.tensorboard:
-            log_dir = self.writer.log_folder
-            env_tb_logdir = get_mmf_env(key="tensorboard_logdir")
-            if env_tb_logdir:
-                log_dir = env_tb_logdir
-
-            self.tb_writer = TensorboardLogger(log_dir, self.current_iteration)
-
-    def config_based_setup(self):
-        seed = self.config.training.seed
-        if seed is None:
-            return
-
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-
+    @abstractmethod
     def train(self):
-        self.writer.write("===== Model =====")
-        self.writer.write(self.model)
+        """Runs full training and optimization.
 
-        print_model_parameters(self.model)
+        Warning: Empty shell for code to be implemented in other class.
+        """
 
-        if "train" not in self.run_type:
-            self.inference()
-            return
-
-        should_break = False
-
-        if self.max_epochs is None:
-            self.max_epochs = math.inf
-        else:
-            self.max_updates = math.inf
-
-        self.model.train()
-        self.train_timer = Timer()
-        self.snapshot_timer = Timer()
-
-        self.profile("Setup Time")
-
-        torch.autograd.set_detect_anomaly(True)
-        self.writer.write("Starting training...")
-
-        while self.num_updates < self.max_updates and not should_break:
-            self.current_epoch += 1
-            registry.register("current_epoch", self.current_epoch)
-
-            # Seed the sampler in case if it is distributed
-            self.dataset_loader.seed_sampler("train", self.current_epoch)
-
-            if self.current_epoch > self.max_epochs:
-                break
-
-            for batch in self.train_loader:
-                self.profile("Batch load time")
-                self.current_iteration += 1
-                self.writer.write(self.num_updates + 1, "debug")
-
-                report = self._forward_pass(batch)
-                loss = self._extract_loss(report)
-                self._backward(loss)
-                should_break = self._logistics(report)
-
-                if self.num_updates > self.max_updates:
-                    should_break = True
-
-                if should_break:
-                    break
-
-            # In distributed, each worker will complete one epoch when we reach this
-            # as each worker is an individual instance
-            self.current_epoch += get_world_size() - 1
-        self.finalize()
-
-    def _run_scheduler(self):
-        if self.lr_scheduler is not None:
-            self.lr_scheduler.step(self.num_updates)
-
-    def _forward_pass(self, batch):
-        prepared_batch = self.dataset_loader.prepare_batch(batch)
-        self.profile("Batch prepare time")
-        # Arguments should be a dict at this point
-        model_output = self.model(prepared_batch)
-        report = Report(prepared_batch, model_output)
-        self.profile("Forward time")
-
-        return report
-
-    def _backward(self, loss):
-        self.optimizer.zero_grad()
-        loss.backward()
-
-        if self.should_clip_gradients:
-            clip_gradients(self.model, self.num_updates, self.tb_writer, self.config)
-
-        self.optimizer.step()
-        self._run_scheduler()
-        self.num_updates += 1
-        self.profile("Backward time")
-
-    def _extract_loss(self, report):
-        loss_dict = report.losses
-        loss = sum([loss.mean() for loss in loss_dict.values()])
-        return loss
-
-    def finalize(self):
-        self.writer.write("Stepping into final validation check")
-
-        # Only do when run_type has train as it shouldn't happen on validation and
-        # inference runs. Inference will take care of this anyways. Also, don't run
-        # if current iteration is divisble by snapshot interval as it will just
-        # be a repeat
-        if (
-            "train" in self.run_type
-            and self.num_updates % self.evaluation_interval != 0
-        ):
-            self._try_full_validation(force=True)
-
-        self.checkpoint.restore()
-        self.checkpoint.finalize()
-        self.inference()
-
-        self.writer.write(f"Finished run in {self.total_timer.get_time_since_start()}")
-
-    def _update_meter(self, report, meter=None, eval_mode=False):
-        if meter is None:
-            meter = self.meter
-
-        if hasattr(report, "metrics"):
-            metrics_dict = report.metrics
-            reduced_metrics_dict = reduce_dict(metrics_dict)
-
-        if not eval_mode:
-            loss_dict = report.losses
-            reduced_loss_dict = reduce_dict(loss_dict)
-
-        with torch.no_grad():
-            # Add metrics to meter only when mode is `eval`
-            meter_update_dict = {}
-            if not eval_mode:
-                loss_key = report.dataset_type + "/total_loss"
-                reduced_loss = sum([loss.mean() for loss in reduced_loss_dict.values()])
-                if hasattr(reduced_loss, "item"):
-                    reduced_loss = reduced_loss.item()
-
-                registry.register(loss_key, reduced_loss)
-                meter_update_dict.update({loss_key: reduced_loss})
-                meter_update_dict.update(reduced_loss_dict)
-            if hasattr(report, "metrics"):
-                meter_update_dict.update(reduced_metrics_dict)
-            meter.update(meter_update_dict, report.batch_size)
-
-    def _logistics(self, report):
-        registry.register("current_iteration", self.current_iteration)
-        registry.register("num_updates", self.num_updates)
-
-        should_print = self.num_updates % self.log_interval == 0
-        should_break = False
-        extra = {}
-
-        if should_print is True:
-            if "cuda" in str(self.device):
-                extra["max mem"] = torch.cuda.max_memory_allocated() / 1024
-                extra["max mem"] //= 1024
-
-            if self.training_config.experiment_name:
-                extra["experiment"] = self.training_config.experiment_name
-
-            extra.update(
-                {
-                    "epoch": self.current_epoch,
-                    "num_updates": self.num_updates,
-                    "iterations": self.current_iteration,
-                    "max_updates": self.max_updates,
-                    "lr": "{:.5f}".format(self.optimizer.param_groups[0]["lr"]).rstrip(
-                        "0"
-                    ),
-                    "ups": "{:.2f}".format(
-                        self.log_interval / self.train_timer.unix_time_since_start()
-                    ),
-                    "time": self.train_timer.get_time_since_start(),
-                    "time_since_start": self.total_timer.get_time_since_start(),
-                    "eta": self._calculate_time_left(),
-                }
-            )
-
-            self.train_timer.reset()
-            # Calculate metrics every log interval for debugging
-            if self.training_config.evaluate_metrics:
-                report.metrics = self.metrics(report, report)
-            self._update_meter(report, self.meter)
-
-            self._summarize_report(self.meter, should_print=should_print, extra=extra)
-
-        self._try_snapshot()
-        should_break = self._try_full_validation()
-
-        return should_break
-
-    def _try_snapshot(self):
-        if self.num_updates % self.checkpoint_interval == 0:
-            self.writer.write("Checkpoint time. Saving a checkpoint.")
-            self.checkpoint.save(
-                self.num_updates, self.current_iteration, update_best=False
-            )
-
-    def _try_full_validation(self, force=False):
-        should_break = False
-
-        if self.num_updates % self.evaluation_interval == 0 or force:
-            self.snapshot_timer.reset()
-            self.writer.write("Evaluation time. Running on full validation set...")
-            # Validation and Early stopping
-            # Create a new meter for this case
-            report, meter = self.evaluate(self.val_loader)
-
-            extra = {
-                "num_updates": self.num_updates,
-                "epoch": self.current_epoch,
-                "iterations": self.current_iteration,
-                "max_updates": self.max_updates,
-                "val_time": self.snapshot_timer.get_time_since_start(),
-            }
-
-            stop = self.early_stopping(self.num_updates, self.current_iteration, meter)
-            stop = bool(broadcast_scalar(stop, src=0, device=self.device))
-
-            extra.update(self.early_stopping.get_info())
-
-            self._summarize_report(meter, extra=extra)
-            gc.collect()
-
-            if "cuda" in str(self.device):
-                torch.cuda.empty_cache()
-
-            if stop is True:
-                self.writer.write("Early stopping activated")
-                should_break = True
-
-            self.train_timer.reset()
-
-        return should_break
-
-    def evaluate(self, loader, use_tqdm=False, single_batch=False):
-        meter = Meter()
-
-        with torch.no_grad():
-            self.model.eval()
-            disable_tqdm = not use_tqdm or not is_master()
-            combined_report = None
-
-            for batch in tqdm(loader, disable=disable_tqdm):
-                report = self._forward_pass(batch)
-                self._update_meter(report, meter)
-
-                # accumulate necessary params for metric calculation
-                if combined_report is None:
-                    combined_report = report
-                else:
-                    combined_report.accumulate_tensor_fields(
-                        report, self.metrics.required_params
-                    )
-                    combined_report.batch_size += report.batch_size
-
-                if single_batch is True:
-                    break
-
-            combined_report.metrics = self.metrics(combined_report, combined_report)
-            self._update_meter(combined_report, meter, eval_mode=True)
-
-            self.model.train()
-
-        return combined_report, meter
-
-    def _summarize_report(self, meter, should_print=True, extra=None):
-        if extra is None:
-            extra = {}
-        if not is_master():
-            return
-
-        if self.training_config.tensorboard:
-            scalar_dict = meter.get_scalar_dict()
-            self.tb_writer.add_scalars(scalar_dict, self.current_iteration)
-
-        if not should_print:
-            return
-        log_dict = {"progress": f"{self.num_updates}/{self.max_updates}"}
-        log_dict.update(meter.get_log_dict())
-        log_dict.update(extra)
-
-        self.writer.log_progress(log_dict)
-
+    @abstractmethod
     def inference(self):
-        if "val" in self.run_type:
-            self._inference_run("val")
+        """Runs inference and validation, generate predictions.
 
-        if any(rt in self.run_type for rt in ["inference", "test", "predict"]):
-            self._inference_run("test")
-
-    def _inference_run(self, dataset_type):
-        if self.config.evaluation.predict:
-            self.predict(dataset_type)
-            return
-
-        self.writer.write(f"Starting inference on {dataset_type} set")
-
-        report, meter = self.evaluate(
-            getattr(self, f"{dataset_type}_loader"), use_tqdm=True
-        )
-        prefix = f"{report.dataset_name}: full {dataset_type}"
-        self._summarize_report(meter, prefix)
-
-    def _calculate_time_left(self):
-        time_taken_for_log = time.time() * 1000 - self.train_timer.start
-        iterations_left = self.max_updates - self.num_updates
-        num_logs_left = iterations_left / self.log_interval
-        time_left = num_logs_left * time_taken_for_log
-
-        snapshot_iteration = self.snapshot_iterations / self.log_interval
-        snapshot_iteration *= iterations_left / self.evaluation_interval
-        time_left += snapshot_iteration * time_taken_for_log
-
-        return self.train_timer.get_time_hhmmss(gap=time_left)
-
-    def profile(self, text):
-        if self.not_debug:
-            return
-        self.writer.write(text + ": " + self.profiler.get_time_since_start(), "debug")
-        self.profiler.reset()
-
-    def predict(self, dataset_type):
-        reporter = self.dataset_loader.get_test_reporter(dataset_type)
-        with torch.no_grad():
-            self.model.eval()
-            message = f"Starting {dataset_type} inference predictions"
-            self.writer.write(message)
-
-            while reporter.next_dataset():
-                dataloader = reporter.get_dataloader()
-
-                for batch in tqdm(dataloader):
-                    prepared_batch = reporter.prepare_batch(batch)
-                    model_output = self.model(prepared_batch)
-                    report = Report(prepared_batch, model_output)
-                    reporter.add_to_report(report, self.model)
-
-            self.writer.write("Finished predicting")
-            self.model.train()
+        Warning: Empty shell for code to be implemented in other class.
+        """

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -7,7 +7,7 @@ from mmf.common.registry import registry
 from mmf.utils.logger import Logger
 
 
-@registry.register_trainer("base_trainer")
+@registry.register_trainer("base")
 class BaseTrainer(ABC):
     def __init__(self, config: mmf_typings.DictConfig):
         self.config = config

--- a/mmf/trainers/callbacks/base.py
+++ b/mmf/trainers/callbacks/base.py
@@ -1,0 +1,107 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Type
+
+from mmf.common import typings as mmf_typings
+from mmf.trainers.base_trainer import BaseTrainer
+
+
+class Callback:
+    """
+    Base class for callbacks that can be registered with type :class:`BaseTrainer`
+
+    Attr:
+        config(mmf_typings.DictConfig): Config for the callback
+        trainer(Type[BaseTrainer]): Trainer object
+    """
+
+    def __init__(
+        self, config: mmf_typings.DictConfig, trainer: Type[BaseTrainer]
+    ) -> None:
+        self.config = config
+        self.trainer = trainer
+        self.training_config = self.config.training
+
+    def on_init_start(self, **kwargs) -> None:
+        """
+        Called when the trainer initialization begins.
+        """
+        pass
+
+    def on_init_end(self, **kwargs) -> None:
+        """
+        Called when the trainer initialization ends.
+        """
+        pass
+
+    def on_train_start(self, **kwargs) -> None:
+        """
+        Called before training starts.
+        """
+        pass
+
+    def on_train_end(self, **kwargs) -> None:
+        """
+        Called after training ends.
+        """
+        pass
+
+    def on_batch_start(self, **kwargs) -> None:
+        """
+        Called before each train iteration.
+        """
+        pass
+
+    def on_batch_end(self, **kwargs) -> None:
+        """
+        Called after each train iteration.
+        """
+        pass
+
+    def on_validation_start(self, **kwargs) -> None:
+        """
+        Called before validation starts.
+        """
+        pass
+
+    def on_validation_end(self, **kwargs) -> None:
+        """
+        Called after validation ends.
+        """
+        pass
+
+    def on_validation_batch_start(self, **kwargs) -> None:
+        """
+        Called before each validation iteration.
+        """
+        pass
+
+    def on_validation_batch_end(self, **kwargs) -> None:
+        """
+        Called after each validation iteration.
+        """
+        pass
+
+    def on_test_start(self, **kwargs) -> None:
+        """
+        Called before test starts.
+        """
+        pass
+
+    def on_test_end(self, **kwargs) -> None:
+        """
+        Called after test ends.
+        """
+        pass
+
+    def on_test_batch_start(self, **kwargs) -> None:
+        """
+        Called before each test iteration.
+        """
+        pass
+
+    def on_test_batch_end(self, **kwargs) -> None:
+        """
+        Called after each test iteration.
+        """
+        pass

--- a/mmf/trainers/callbacks/checkpoint.py
+++ b/mmf/trainers/callbacks/checkpoint.py
@@ -1,0 +1,42 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.common.registry import registry
+from mmf.trainers.callbacks.base import Callback
+from mmf.utils.checkpoint import Checkpoint
+
+
+class CheckpointCallback(Callback):
+    """Callback for executing different checkpoint requirements.
+    """
+
+    def __init__(self, config, trainer):
+        """
+        Attr:
+            config(mmf_typings.DictConfig): Config for the callback
+            trainer(Type[BaseTrainer]): Trainer object
+        """
+        super().__init__(config, trainer)
+
+        self._checkpoint = Checkpoint(trainer)
+        self.checkpoint_interval = self.config.training.checkpoint_interval
+        self.writer = registry.get("writer")
+
+    @property
+    def checkpoint(self):
+        return self._checkpoint
+
+    def on_init_end(self, **kwargs):
+        self._checkpoint.load_state_dict()
+
+    def on_batch_end(self, **kwargs):
+        if self.trainer.num_updates % self.checkpoint_interval == 0:
+            self.writer.write("Checkpoint time. Saving a checkpoint.")
+            self._checkpoint.save(
+                self.trainer.num_updates,
+                self.trainer.current_iteration,
+                update_best=False,
+            )
+
+    def on_train_end(self, **kwargs):
+        self._checkpoint.restore()
+        self._checkpoint.finalize()

--- a/mmf/trainers/callbacks/early_stopping.py
+++ b/mmf/trainers/callbacks/early_stopping.py
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.trainers.callbacks.base import Callback
+from mmf.utils.distributed import broadcast_scalar
+from mmf.utils.early_stopping import EarlyStopping
+
+
+class EarlyStoppingCallback(Callback):
+    """Callback for Early Stopping mechanism and checks if it training
+    should continue or stop.
+    """
+
+    def __init__(self, config, trainer):
+        """
+        Attr:
+            config(mmf_typings.DictConfig): Config for the callback
+            trainer(Type[BaseTrainer]): Trainer object
+        """
+        super().__init__(config, trainer)
+
+        early_stop_criteria = self.training_config.early_stop.criteria
+        early_stop_minimize = self.training_config.early_stop.minimize
+        early_stop_enabled = self.training_config.early_stop.enabled
+        early_stop_patience = self.training_config.early_stop.patience
+        self.early_stopping = EarlyStopping(
+            self.trainer.model,
+            self.trainer.checkpoint_callback.checkpoint,
+            early_stop_criteria,
+            patience=early_stop_patience,
+            minimize=early_stop_minimize,
+            should_stop=early_stop_enabled,
+        )
+
+    def on_validation_end(self, **kwargs):
+        stop = self.early_stopping(
+            self.trainer.num_updates, self.trainer.current_iteration, kwargs["meter"]
+        )
+        stop = bool(broadcast_scalar(stop, src=0, device=self.trainer.device))
+        return stop

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -1,0 +1,139 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import time
+
+import torch
+
+from mmf.common.registry import registry
+from mmf.trainers.callbacks.base import Callback
+from mmf.utils.configuration import get_mmf_env
+from mmf.utils.distributed import is_master
+from mmf.utils.logger import TensorboardLogger
+from mmf.utils.timer import Timer
+
+
+class LogisticsCallback(Callback):
+    """Callback for handling train/validation logistics, report summarization,
+    logging etc.
+    """
+
+    def __init__(self, config, trainer):
+        """
+        Attr:
+            config(mmf_typings.DictConfig): Config for the callback
+            trainer(Type[BaseTrainer]): Trainer object
+        """
+        super().__init__(config, trainer)
+
+        self.total_timer = Timer()
+        self.log_interval = self.training_config.log_interval
+        self.evaluation_interval = self.training_config.evaluation_interval
+        self.checkpoint_interval = self.training_config.checkpoint_interval
+
+        # Total iterations for snapshot
+        self.snapshot_iterations = len(self.trainer.val_dataset)
+        self.snapshot_iterations //= self.training_config.batch_size
+
+        self.writer = registry.get("writer")
+        self.tb_writer = None
+
+        if self.training_config.tensorboard:
+            log_dir = self.writer.log_folder
+            env_tb_logdir = get_mmf_env(key="tensorboard_logdir")
+            if env_tb_logdir:
+                log_dir = env_tb_logdir
+
+            self.tb_writer = TensorboardLogger(log_dir, self.trainer.current_iteration)
+
+    def on_train_start(self):
+        self.train_timer = Timer()
+        self.snapshot_timer = Timer()
+
+    def on_batch_end(self, **kwargs):
+        if not kwargs["should_log"]:
+            return
+        extra = {}
+        if "cuda" in str(self.trainer.device):
+            extra["max mem"] = torch.cuda.max_memory_allocated() / 1024
+            extra["max mem"] //= 1024
+
+        if self.training_config.experiment_name:
+            extra["experiment"] = self.training_config.experiment_name
+
+        extra.update(
+            {
+                "epoch": self.trainer.current_epoch,
+                "num_updates": self.trainer.num_updates,
+                "iterations": self.trainer.current_iteration,
+                "max_updates": self.trainer.max_updates,
+                "lr": "{:.5f}".format(
+                    self.trainer.optimizer.param_groups[0]["lr"]
+                ).rstrip("0"),
+                "ups": "{:.2f}".format(
+                    self.log_interval / self.train_timer.unix_time_since_start()
+                ),
+                "time": self.train_timer.get_time_since_start(),
+                "time_since_start": self.total_timer.get_time_since_start(),
+                "eta": self._calculate_time_left(),
+            }
+        )
+        self.train_timer.reset()
+        self._summarize_report(kwargs["meter"], extra=extra)
+
+    def on_validation_start(self, **kwargs):
+        self.snapshot_timer.reset()
+
+    def on_validation_end(self, **kwargs):
+        extra = {
+            "num_updates": self.trainer.num_updates,
+            "epoch": self.trainer.current_epoch,
+            "iterations": self.trainer.current_iteration,
+            "max_updates": self.trainer.max_updates,
+            "val_time": self.snapshot_timer.get_time_since_start(),
+        }
+        extra.update(self.trainer.early_stop_callback.early_stopping.get_info())
+        self.train_timer.reset()
+        self._summarize_report(kwargs["meter"], extra=extra)
+
+    def on_test_end(self, **kwargs):
+        prefix = "{}: full {}".format(
+            kwargs["report"].dataset_name, kwargs["report"].dataset_type
+        )
+        self._summarize_report(kwargs["meter"], prefix)
+        self.writer.write(f"Finished run in {self.total_timer.get_time_since_start()}")
+
+    def _summarize_report(self, meter, should_print=True, extra=None):
+        if extra is None:
+            extra = {}
+        if not is_master():
+            return
+
+        if self.training_config.tensorboard:
+            scalar_dict = meter.get_scalar_dict()
+            self.tb_writer.add_scalars(scalar_dict, self.trainer.current_iteration)
+
+        if not should_print:
+            return
+        log_dict = {}
+        if hasattr(self.trainer, "num_updates") and hasattr(
+            self.trainer, "max_updates"
+        ):
+            log_dict.update(
+                {"progress": f"{self.trainer.num_updates}/{self.trainer.max_updates}"}
+            )
+        log_dict.update(meter.get_log_dict())
+        log_dict.update(extra)
+
+        self.writer.log_progress(log_dict)
+
+    def _calculate_time_left(self):
+        time_taken_for_log = time.time() * 1000 - self.train_timer.start
+        iterations_left = self.trainer.max_updates - self.trainer.num_updates
+        num_logs_left = iterations_left / self.log_interval
+        time_left = num_logs_left * time_taken_for_log
+
+        snapshot_iteration = self.snapshot_iterations / self.log_interval
+        snapshot_iteration *= iterations_left / self.evaluation_interval
+        time_left += snapshot_iteration * time_taken_for_log
+
+        return self.train_timer.get_time_hhmmss(gap=time_left)

--- a/mmf/trainers/callbacks/lr_scheduler.py
+++ b/mmf/trainers/callbacks/lr_scheduler.py
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.trainers.callbacks.base import Callback
+from mmf.utils.build import build_scheduler
+
+
+class LRSchedulerCallback(Callback):
+    """Callback which executes a LR scheduler. It is executed after every
+    batch iteration.
+    """
+
+    def __init__(self, config, trainer):
+        """
+        Attr:
+            config(mmf_typings.DictConfig): Config for the callback
+            trainer(Type[BaseTrainer]): Trainer object
+        """
+        super().__init__(config, trainer)
+
+        self._scheduler = None
+        if self.training_config.lr_scheduler is True:
+            self._scheduler = build_scheduler(self.trainer.optimizer, self.config)
+
+    def on_batch_end(self, **kwargs):
+        if self._scheduler is not None:
+            self._scheduler.step()

--- a/mmf/trainers/core/callback_hook.py
+++ b/mmf/trainers/core/callback_hook.py
@@ -1,0 +1,80 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from abc import ABC
+from typing import List
+
+from mmf.trainers.callbacks.base import Callback
+
+
+class TrainerCallbackHookMixin(ABC):
+    callbacks: List[Callback] = []
+
+    def on_init_start(self, **kwargs) -> None:
+        """Called when the trainer initialization begins."""
+        for callback in self.callbacks:
+            callback.on_init_start(**kwargs)
+
+    def on_init_end(self, **kwargs) -> None:
+        """Called when the trainer initialization ends."""
+        for callback in self.callbacks:
+            callback.on_init_end(**kwargs)
+
+    def on_train_start(self, **kwargs) -> None:
+        """Called when training begins."""
+        for callback in self.callbacks:
+            callback.on_train_start(**kwargs)
+
+    def on_train_end(self, **kwargs) -> None:
+        """Called when training ends."""
+        for callback in self.callbacks:
+            callback.on_train_end(**kwargs)
+
+    def on_batch_start(self, **kwargs) -> None:
+        """Called when the training batch begins."""
+        for callback in self.callbacks:
+            callback.on_batch_start(**kwargs)
+
+    def on_batch_end(self, **kwargs) -> None:
+        """Called when the training batch ends."""
+        for callback in self.callbacks:
+            callback.on_batch_end(**kwargs)
+
+    def on_validation_start(self, **kwargs) -> None:
+        """Called when the validation loop begins."""
+        for callback in self.callbacks:
+            callback.on_validation_start(**kwargs)
+
+    def on_validation_end(self, **kwargs) -> None:
+        """Called when the validation loop ends."""
+        for callback in self.callbacks:
+            callback.on_validation_end(**kwargs)
+
+    def on_validation_batch_start(self, **kwargs) -> None:
+        """Called when the validation batch begins."""
+        for callback in self.callbacks:
+            callback.on_validation_batch_start(**kwargs)
+
+    def on_validation_batch_end(self, **kwargs) -> None:
+        """Called when the validation batch ends."""
+        for callback in self.callbacks:
+            callback.on_validation_batch_end(**kwargs)
+
+    def on_test_start(self, **kwargs) -> None:
+        """Called when the test begins."""
+        for callback in self.callbacks:
+            callback.on_test_start(**kwargs)
+
+    def on_test_end(self, **kwargs) -> None:
+        """Called when the test ends."""
+        for callback in self.callbacks:
+            callback.on_test_end(**kwargs)
+
+    def on_test_batch_start(self, **kwargs) -> None:
+        """Called when the test batch begins."""
+        for callback in self.callbacks:
+            callback.on_test_batch_start(**kwargs)
+
+    def on_test_batch_end(self, **kwargs) -> None:
+        """Called when the test batch ends."""
+        for callback in self.callbacks:
+            callback.on_test_batch_end(**kwargs)

--- a/mmf/trainers/core/device.py
+++ b/mmf/trainers/core/device.py
@@ -1,0 +1,64 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from abc import ABC
+
+import torch
+
+from mmf.common.registry import registry
+
+
+class TrainerDeviceMixin(ABC):
+    def configure_seed(self) -> None:
+        seed = self.config.training.seed
+        if seed is None:
+            return
+
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    def configure_device(self) -> None:
+        self.local_rank = self.config.device_id
+        self.device = self.local_rank
+        self.distributed = False
+
+        # Will be updated later based on distributed setup
+        registry.register("global_device", self.device)
+
+        if self.config.distributed.init_method is not None:
+            self.distributed = True
+            self.device = torch.device("cuda", self.local_rank)
+        elif torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        else:
+            self.device = torch.device("cpu")
+
+        registry.register("current_device", self.device)
+
+        if "cuda" in str(self.device):
+            device_info = "CUDA Device {} is: {}".format(
+                self.config.distributed.rank,
+                torch.cuda.get_device_name(self.local_rank),
+            )
+            registry.register("global_device", self.config.distributed.rank)
+            self.writer.write(device_info, log_all=True)
+
+    def parallelize_model(self) -> None:
+        registry.register("data_parallel", False)
+        registry.register("distributed", False)
+        if (
+            "cuda" in str(self.device)
+            and torch.cuda.device_count() > 1
+            and not self.distributed
+        ):
+            registry.register("data_parallel", True)
+            self.model = torch.nn.DataParallel(self.model)
+
+        if "cuda" in str(self.device) and self.distributed:
+            registry.register("distributed", True)
+            self.model = torch.nn.parallel.DistributedDataParallel(
+                self.model,
+                device_ids=[self.local_rank],
+                output_device=self.local_rank,
+                check_reduction=True,
+                find_unused_parameters=self.config.training.find_unused_parameters,
+            )

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -1,0 +1,66 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from abc import ABC
+from typing import Any, Dict, Tuple, Type
+
+import torch
+import tqdm
+
+from mmf.common.meter import Meter
+from mmf.common.report import Report
+from mmf.utils.distributed import is_master
+
+
+class TrainerEvaluationLoopMixin(ABC):
+    def evaluation_loop(
+        self, loader, use_tqdm: bool = False, single_batch: bool = False
+    ) -> Tuple[Dict[str, Any], Type[Meter]]:
+        meter = Meter()
+
+        with torch.no_grad():
+            self.model.eval()
+            disable_tqdm = not use_tqdm or not is_master()
+            combined_report = None
+
+            for batch in tqdm.tqdm(loader, disable=disable_tqdm):
+                report = self._forward(batch)
+                self.update_meter(report, meter)
+
+                # accumulate necessary params for metric calculation
+                if combined_report is None:
+                    combined_report = report
+                else:
+                    combined_report.accumulate_tensor_fields(
+                        report, self.metrics.required_params
+                    )
+                    combined_report.batch_size += report.batch_size
+
+                if single_batch is True:
+                    break
+
+            combined_report.metrics = self.metrics(combined_report, combined_report)
+            self.update_meter(combined_report, meter, eval_mode=True)
+
+            # enable train mode again
+            self.model.train()
+
+        return combined_report, meter
+
+    def prediction_loop(self, dataset_type: str) -> None:
+        reporter = self.dataset_loader.get_test_reporter(dataset_type)
+        with torch.no_grad():
+            self.model.eval()
+            message = f"Starting {dataset_type} inference predictions"
+            self.writer.write(message)
+
+            while reporter.next_dataset():
+                dataloader = reporter.get_dataloader()
+
+                for batch in tqdm.tqdm(dataloader):
+                    prepared_batch = reporter.prepare_batch(batch)
+                    model_output = self.model(prepared_batch)
+                    report = Report(prepared_batch, model_output)
+                    reporter.add_to_report(report, self.model)
+
+            self.writer.write("Finished predicting")
+            self.model.train()

--- a/mmf/trainers/core/profiling.py
+++ b/mmf/trainers/core/profiling.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from abc import ABC
+from typing import Type
+
+from mmf.utils.timer import Timer
+
+
+class TrainerProfilingMixin(ABC):
+    profiler: Type[Timer] = Timer()
+
+    def profile(self, text: str) -> None:
+        if self.training_config.logger_level != "debug":
+            return
+        self.writer.write(text + ": " + self.profiler.get_time_since_start(), "debug")
+        self.profiler.reset()

--- a/mmf/trainers/core/reporting.py
+++ b/mmf/trainers/core/reporting.py
@@ -1,0 +1,44 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from abc import ABC
+from typing import Any, Dict, Type
+
+import torch
+
+from mmf.common.meter import Meter
+from mmf.common.registry import registry
+from mmf.utils.distributed import reduce_dict
+
+
+class TrainerReportingMixin(ABC):
+    meter: Type[Meter] = Meter()
+
+    def update_meter(
+        self, report: Dict[str, Any], meter: Type[Meter] = None, eval_mode: bool = False
+    ) -> None:
+        if meter is None:
+            meter = self.meter
+
+        if hasattr(report, "metrics"):
+            metrics_dict = report.metrics
+            reduced_metrics_dict = reduce_dict(metrics_dict)
+
+        if not eval_mode:
+            loss_dict = report.losses
+            reduced_loss_dict = reduce_dict(loss_dict)
+
+        with torch.no_grad():
+            # Add metrics to meter only when mode is `eval`
+            meter_update_dict = {}
+            if not eval_mode:
+                loss_key = report.dataset_type + "/total_loss"
+                reduced_loss = sum([loss.mean() for loss in reduced_loss_dict.values()])
+                if hasattr(reduced_loss, "item"):
+                    reduced_loss = reduced_loss.item()
+
+                registry.register(loss_key, reduced_loss)
+                meter_update_dict.update({loss_key: reduced_loss})
+                meter_update_dict.update(reduced_loss_dict)
+            if hasattr(report, "metrics"):
+                meter_update_dict.update(reduced_metrics_dict)
+            meter.update(meter_update_dict, report.batch_size)

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -1,0 +1,151 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import gc
+import math
+from abc import ABC
+from typing import Any, Dict
+
+import torch
+from torch import Tensor
+
+from mmf.common.registry import registry
+from mmf.common.report import Report
+from mmf.utils.distributed import get_world_size
+from mmf.utils.general import clip_gradients
+
+
+class TrainerTrainingLoopMixin(ABC):
+    current_epoch: int = 0
+    current_iteration: int = 0
+    num_updates: int = 0
+
+    def training_loop(self) -> None:
+        self.max_updates = self.training_config.max_updates
+        self.max_epochs = self.training_config.max_epochs
+        if self.max_epochs is None:
+            self.max_epochs = math.inf
+        else:
+            self.max_updates = math.inf
+
+        torch.autograd.set_detect_anomaly(True)
+
+        self.writer.write("Starting training...")
+        self.model.train()
+        self.run_training_epoch()
+        self.after_training_loop()
+
+    def after_training_loop(self) -> None:
+        self.writer.write("Stepping into final validation check")
+        # Only do when run_type has train as it shouldn't happen on validation and
+        # inference runs. Inference will take care of this anyways. Also, don't run
+        # if current iteration is divisble by snapshot interval as it will just
+        # be a repeat
+        if (
+            "train" in self.run_type
+            and self.num_updates % self.training_config.evaluation_interval != 0
+        ):
+            # Create a new meter for this case
+            report, meter = self.evaluation_loop(self.val_loader)
+
+            # Validation end callbacks
+            self.on_validation_end(report=report, meter=meter)
+
+    def run_training_epoch(self) -> None:
+        should_break = False
+        while self.num_updates < self.max_updates and not should_break:
+            self.current_epoch += 1
+            registry.register("current_epoch", self.current_epoch)
+
+            # Seed the sampler in case if it is distributed
+            self.dataset_loader.seed_sampler("train", self.current_epoch)
+
+            if self.current_epoch > self.max_epochs:
+                break
+
+            for batch in self.train_loader:
+                self.profile("Batch load time")
+                self.current_iteration += 1
+                self.writer.write(self.num_updates + 1, "debug")
+
+                self.run_training_batch(batch)
+
+                # Check if training should be stopped
+                should_break = False
+
+                if self.num_updates % self.training_config.evaluation_interval == 0:
+                    # Validation begin callbacks
+                    self.on_validation_start()
+
+                    self.writer.write(
+                        "Evaluation time. Running on full validation set..."
+                    )
+                    # Validation and Early stopping
+                    # Create a new meter for this case
+                    report, meter = self.evaluation_loop(self.val_loader)
+
+                    # Validation end callbacks
+                    stop = self.early_stop_callback.on_validation_end(
+                        report=report, meter=meter
+                    )
+                    self.on_validation_end(report=report, meter=meter)
+
+                    gc.collect()
+
+                    if "cuda" in str(self.device):
+                        torch.cuda.empty_cache()
+
+                    if stop is True:
+                        self.writer.write("Early stopping activated")
+                        should_break = True
+                if self.num_updates > self.max_updates:
+                    should_break = True
+                if should_break:
+                    break
+
+            # In distributed, each worker will complete one epoch when we reach this
+            # as each worker is an individual instance
+            self.current_epoch += get_world_size() - 1
+
+    def run_training_batch(self, batch: Tensor) -> None:
+        # Train batch start callbacks
+        self.on_batch_start()
+
+        report = self._forward(batch)
+        loss = self._extract_loss(report)
+        self._backward(loss)
+
+        if self.num_updates % self.logistics_callback.log_interval == 0:
+            should_log = True
+            # Calculate metrics every log interval for debugging
+            if self.training_config.evaluate_metrics:
+                report.metrics = self.metrics(report, report)
+            self.update_meter(report, self.meter)
+
+        # Train batch end callbacks
+        self.on_batch_end(report=report, meter=self.meter, should_log=should_log)
+
+    def _forward(self, batch: Tensor) -> Dict[str, Any]:
+        prepared_batch = self.dataset_loader.prepare_batch(batch)
+        self.profile("Batch prepare time")
+        # Arguments should be a dict at this point
+        model_output = self.model(prepared_batch)
+        report = Report(prepared_batch, model_output)
+        self.profile("Forward time")
+
+        return report
+
+    def _backward(self, loss: Tensor) -> None:
+        self.optimizer.zero_grad()
+        loss.backward()
+
+        if self.training_config.clip_gradients:
+            clip_gradients(self.model, self.num_updates, self.tb_writer, self.config)
+
+        self.optimizer.step()
+        self.num_updates += 1
+        self.profile("Backward time")
+
+    def _extract_loss(self, report: Dict[str, Any]) -> Tensor:
+        loss_dict = report.losses
+        loss = sum([loss.mean() for loss in loss_dict.values()])
+        return loss

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -1,0 +1,126 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import omegaconf
+
+from mmf.common import typings as mmf_typings
+from mmf.common.dataset_loader import DatasetLoader
+from mmf.common.registry import registry
+from mmf.modules.metrics import Metrics
+from mmf.trainers.base_trainer import BaseTrainer
+from mmf.trainers.callbacks.checkpoint import CheckpointCallback
+from mmf.trainers.callbacks.early_stopping import EarlyStoppingCallback
+from mmf.trainers.callbacks.logistics import LogisticsCallback
+from mmf.trainers.callbacks.lr_scheduler import LRSchedulerCallback
+from mmf.trainers.core.callback_hook import TrainerCallbackHookMixin
+from mmf.trainers.core.device import TrainerDeviceMixin
+from mmf.trainers.core.evaluation_loop import TrainerEvaluationLoopMixin
+from mmf.trainers.core.profiling import TrainerProfilingMixin
+from mmf.trainers.core.reporting import TrainerReportingMixin
+from mmf.trainers.core.training_loop import TrainerTrainingLoopMixin
+from mmf.utils.build import build_model, build_optimizer
+from mmf.utils.general import print_model_parameters
+
+
+@registry.register_trainer("mmf_trainer")
+class MMFTrainer(
+    TrainerCallbackHookMixin,
+    TrainerTrainingLoopMixin,
+    TrainerDeviceMixin,
+    TrainerEvaluationLoopMixin,
+    TrainerReportingMixin,
+    TrainerProfilingMixin,
+    BaseTrainer,
+):
+    def __init__(self, config: mmf_typings.DictConfig):
+        super().__init__(config)
+
+    def load(self):
+        super().load()
+
+        # Parallize model
+        self.parallelize_model()
+
+        # Callbacks
+        self.on_init_end()
+
+    def configure_callbacks(self):
+        self.checkpoint_callback = CheckpointCallback(self.config, self)
+        self.early_stop_callback = EarlyStoppingCallback(self.config, self)
+        # self.callbacks.append(self.early_stop_callback)
+        self.logistics_callback = LogisticsCallback(self.config, self)
+        self.lr_scheduler_callback = LRSchedulerCallback(self.config, self)
+
+        # Add callbacks for execution during events
+        self.callbacks.append(self.checkpoint_callback)
+        self.callbacks.append(self.logistics_callback)
+        self.callbacks.append(self.lr_scheduler_callback)
+
+    def load_datasets(self):
+        self.writer.write("Loading datasets", "info")
+        self.dataset_loader = DatasetLoader(self.config)
+        self.dataset_loader.load_datasets()
+
+        self.train_dataset = self.dataset_loader.train_dataset
+        self.val_dataset = self.dataset_loader.val_dataset
+        self.test_dataset = self.dataset_loader.test_dataset
+
+        self.train_loader = self.dataset_loader.train_loader
+        self.val_loader = self.dataset_loader.val_loader
+        self.test_loader = self.dataset_loader.test_loader
+
+    def load_model(self):
+        self.writer.write("Loading model", "info")
+        attributes = self.config.model_config[self.config.model]
+        # Easy way to point to config for other model
+        if isinstance(attributes, str):
+            attributes = self.config.model_config[attributes]
+
+        with omegaconf.open_dict(attributes):
+            attributes.model = self.config.model
+
+        self.model = build_model(attributes)
+        self.model = self.model.to(self.device)
+
+    def load_optimizer(self):
+        self.writer.write("Loading optimizer", "info")
+        self.optimizer = build_optimizer(self.model, self.config)
+
+    def load_metrics(self) -> None:
+        self.writer.write("Loading metrics", "info")
+        metrics = self.config.evaluation.get("metrics", [])
+        self.metrics = Metrics(metrics)
+        self.metrics_params = self.metrics.required_params
+
+    def train(self):
+        self.writer.write("===== Model =====")
+        self.writer.write(self.model)
+        print_model_parameters(self.model)
+
+        if "train" not in self.run_type:
+            self.inference()
+            return
+
+        self.on_train_start()
+        self.training_loop()
+        self.on_train_end()
+
+        self.inference()
+
+    def inference(self):
+        dataset_type = []
+        if "val" in self.run_type:
+            dataset_type.append("val")
+        if any(rt in self.run_type for rt in ["inference", "test", "predict"]):
+            dataset_type.append("test")
+
+        for dataset in dataset_type:
+            self.on_test_start()
+            if self.config.evaluation.predict:
+                self.prediction_loop(dataset)
+                continue
+            else:
+                self.writer.write(f"Starting inference on {dataset} set")
+                report, meter = self.evaluation_loop(
+                    getattr(self, f"{dataset}_loader"), use_tqdm=True
+                )
+            self.on_test_end(report=report, meter=meter)

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -21,7 +21,7 @@ from mmf.utils.build import build_model, build_optimizer
 from mmf.utils.general import print_model_parameters
 
 
-@registry.register_trainer("mmf_trainer")
+@registry.register_trainer("mmf")
 class MMFTrainer(
     TrainerCallbackHookMixin,
     TrainerTrainingLoopMixin,

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -199,7 +199,7 @@ class Checkpoint:
             if not reset_optimizer:
                 self._load_optimizer(ckpt)
 
-            self.trainer.early_stopping.init_from_checkpoint(ckpt)
+            self.trainer.early_stop_callback.early_stopping.init_from_checkpoint(ckpt)
 
             self.trainer.writer.write("Checkpoint loaded")
 
@@ -370,9 +370,15 @@ class Checkpoint:
             self.ckpt_foldername, self.ckpt_prefix + "current.ckpt"
         )
 
-        best_iteration = self.trainer.early_stopping.best_monitored_iteration
-        best_update = self.trainer.early_stopping.best_monitored_update
-        best_metric = self.trainer.early_stopping.best_monitored_value
+        best_iteration = (
+            self.trainer.early_stop_callback.early_stopping.best_monitored_iteration
+        )
+        best_update = (
+            self.trainer.early_stop_callback.early_stopping.best_monitored_update
+        )
+        best_metric = (
+            self.trainer.early_stop_callback.early_stopping.best_monitored_value
+        )
         model = self.trainer.model
         data_parallel = registry.get("data_parallel") or registry.get("distributed")
 

--- a/tests/trainers/__init__.py
+++ b/tests/trainers/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/tests/trainers/callbacks/test_logistics.py
+++ b/tests/trainers/callbacks/test_logistics.py
@@ -1,0 +1,127 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import argparse
+import os
+import tempfile
+import unittest
+from copy import deepcopy
+from unittest.mock import Mock
+
+import torch
+from omegaconf import OmegaConf
+
+import tests.test_utils as test_utils
+from mmf.common.meter import Meter
+from mmf.common.registry import registry
+from mmf.common.report import Report
+from mmf.models.base_model import BaseModel
+from mmf.trainers.callbacks.logistics import LogisticsCallback
+from mmf.utils.file_io import PathManager
+from mmf.utils.logger import Logger
+
+
+class SimpleModule(BaseModel):
+    def __init__(self, config={}):
+        super().__init__(config)
+        self.base = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+        self.classifier = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+        self.loss = torch.nn.CrossEntropyLoss()
+
+    def forward(self, x, target):
+        x = self.classifier(self.base(x))
+        return {"losses": {"total_loss": self.loss(x, target)}}
+
+
+class NumbersDataset(torch.utils.data.Dataset):
+    def __init__(self):
+        self.samples = list(range(1, 1001))
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+    def __len__(self):
+        return len(self.samples)
+
+
+class TestLogisticsCallback(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.trainer = argparse.Namespace()
+        self.config = OmegaConf.create(
+            {
+                "model": "simple",
+                "model_config": {},
+                "training": {
+                    "checkpoint_interval": 1,
+                    "evaluation_interval": 10,
+                    "early_stop": {"criteria": "val/total_loss"},
+                    "batch_size": 16,
+                    "log_interval": 10,
+                    "logger_level": "info",
+                },
+                "env": {"save_dir": self.tmpdir},
+            }
+        )
+        # Keep original copy for testing purposes
+        self.trainer.config = deepcopy(self.config)
+        registry.register("config", self.trainer.config)
+        self.trainer.writer = Logger(self.config)
+        registry.register("writer", self.trainer.writer)
+        self.report = Mock(spec=Report)
+        self.report.dataset_name = "abcd"
+        self.report.dataset_type = "test"
+
+        self.trainer.model = SimpleModule()
+        self.trainer.val_dataset = NumbersDataset()
+
+        self.trainer.optimizer = torch.optim.Adam(
+            self.trainer.model.parameters(), lr=1e-01
+        )
+        self.trainer.device = "cpu"
+        self.trainer.num_updates = 0
+        self.trainer.current_iteration = 0
+        self.trainer.current_epoch = 0
+        self.trainer.max_updates = 0
+        self.trainer.meter = Meter()
+        self.cb = LogisticsCallback(self.config, self.trainer)
+
+    def tearDown(self):
+        registry.unregister("config")
+        registry.unregister("writer")
+
+    def test_on_train_start(self):
+        self.cb.on_train_start()
+        expected = 0
+        self.assertEqual(
+            int(self.cb.train_timer.get_time_since_start().split("ms")[0]), expected,
+        )
+
+    @test_utils.skip_if_windows
+    def test_on_batch_end(self):
+        self.cb.on_train_start()
+        self.cb.on_batch_end(meter=self.trainer.meter, should_log=False)
+        f = PathManager.open(os.path.join(self.tmpdir, "train.log"))
+        self.assertFalse(any("time_since_start" in line for line in f.readlines()))
+        self.cb.on_batch_end(meter=self.trainer.meter, should_log=True)
+        f = PathManager.open(os.path.join(self.tmpdir, "train.log"))
+        self.assertTrue(any("time_since_start" in line for line in f.readlines()))
+
+    def test_on_validation_start(self):
+        self.cb.on_train_start()
+        self.cb.on_validation_start()
+        expected = 0
+        self.assertEqual(
+            int(self.cb.snapshot_timer.get_time_since_start().split("ms")[0]), expected,
+        )
+
+    @test_utils.skip_if_windows
+    def test_on_test_end(self):
+        self.cb.on_test_end(report=self.report, meter=self.trainer.meter)
+        f = PathManager.open(os.path.join(self.tmpdir, "train.log"))
+        self.assertTrue(any("Finished run in" in line for line in f.readlines()))

--- a/tests/trainers/callbacks/test_lr_scheduler.py
+++ b/tests/trainers/callbacks/test_lr_scheduler.py
@@ -1,0 +1,81 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import argparse
+import unittest
+from copy import deepcopy
+
+import torch
+from omegaconf import OmegaConf
+
+from mmf.common.registry import registry
+from mmf.models.base_model import BaseModel
+from mmf.trainers.callbacks.lr_scheduler import LRSchedulerCallback
+
+
+class SimpleModule(BaseModel):
+    def __init__(self, config={}):
+        super().__init__(config)
+        self.base = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+        self.classifier = torch.nn.Sequential(
+            torch.nn.Linear(5, 4), torch.nn.Tanh(), torch.nn.Linear(4, 5)
+        )
+
+        self.loss = torch.nn.CrossEntropyLoss()
+
+    def forward(self, x, target):
+        x = self.classifier(self.base(x))
+        return {"losses": {"total_loss": self.loss(x, target)}}
+
+
+class NumbersDataset(torch.utils.data.Dataset):
+    def __init__(self):
+        self.samples = list(range(1, 1001))
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+    def __len__(self):
+        return len(self.samples)
+
+
+class TestLogisticsCallback(unittest.TestCase):
+    def setUp(self):
+        self.trainer = argparse.Namespace()
+        self.config = OmegaConf.create(
+            {
+                "model": "simple",
+                "model_config": {},
+                "training": {
+                    "lr_scheduler": True,
+                    "lr_ratio": 0.1,
+                    "lr_steps": [1, 2],
+                    "use_warmup": False,
+                },
+            }
+        )
+        # Keep original copy for testing purposes
+        self.trainer.config = deepcopy(self.config)
+        registry.register("config", self.trainer.config)
+
+        self.trainer.model = SimpleModule()
+        self.trainer.val_dataset = NumbersDataset()
+
+        self.trainer.optimizer = torch.optim.Adam(
+            self.trainer.model.parameters(), lr=1e-01,
+        )
+        self.trainer.lr_scheduler_callback = LRSchedulerCallback(
+            self.config, self.trainer
+        )
+
+    def tearDown(self):
+        registry.unregister("config")
+
+    def test_on_batch_end(self):
+        self.trainer.lr_scheduler_callback.on_batch_end()
+        self.assertAlmostEqual(self.trainer.optimizer.param_groups[0]["lr"], 1e-02)
+
+        self.trainer.lr_scheduler_callback.on_batch_end()
+        self.assertAlmostEqual(self.trainer.optimizer.param_groups[0]["lr"], 1e-03)


### PR DESCRIPTION
PR refactors the trainer class providing flexibility to extend from the BaseTrainer class and customize it. We also introduce a callback mechanism that can be executed at different events during training, validation or inference. Hence separates most of the logic of core training/optimization from other logistics.

- Create an abstract base trainer class, and core functionalities like loading dataset, model, optimizer, metrics are abstract methods that has to be implemented  by derived classes.  
- Create a new `MMFTrainer` class which keeps the same behavior as the current trainer but derived from the `BaseTrainer`.
- Move core logic of training loop, evaluation loop and prediction loop to Mixin classes and can be easily used in trainer classes.
- Create a callback mechanism similar to `PytorchLightning` with different types of events when callbacks can happen. With this it will be easier to have `PytorchLightning` supported trainer classes for `mmf`
- Callbacks are executed before or after events like training, validation, test, batch, epoch etc.
- Typing introduced in the trainer classes
- There can be some additional refactoring around how to include some additional callbacks like Early Stopping in the hooks, but that can be done  in future diffs.


Test Plan:
- Tested training, inference, validation runs, checked if events are happening in correct order with the new callback mechanism.
