### PR TITLE
[feat] Support image features for MMBT on MMIMDB

### DIFF
--- a/mmf/configs/datasets/mmimdb/defaults.yaml
+++ b/mmf/configs/datasets/mmimdb/defaults.yaml
@@ -3,8 +3,15 @@ dataset_config:
     data_dir: ${env.data_dir}
     depth_first: false
     fast_read: false
-    use_images: false
-    use_features: true
+    use_images: true
+    use_features: false
+    images:
+      train:
+      - datasets/mmimdb/defaults/images/mmimdb/dataset/
+      val:
+      - datasets/mmimdb/defaults/images/mmimdb/dataset/
+      test:
+      - datasets/mmimdb/defaults/images/mmimdb/dataset/
     features:
       train:
       - datasets/mmimdb/defaults/features/features.lmdb
@@ -44,4 +51,20 @@ dataset_config:
             preprocessor:
                 type: simple_word
                 params: {}
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: Resize
+              params:
+                size: [256, 256]
+            - type: CenterCrop
+              params:
+                size: [224, 224]
+            - ToTensor
+            - GrayScaleTo3Channels
+            - type: Normalize
+              params:
+                mean: [0.46777044, 0.44531429, 0.40661017]
+                std: [0.12221994, 0.12145835, 0.14380469]
     return_features_info: false

--- a/mmf/configs/datasets/mmimdb/with_features.yaml
+++ b/mmf/configs/datasets/mmimdb/with_features.yaml
@@ -1,0 +1,7 @@
+dataset_config:
+  mmimdb:
+    use_images: false
+    use_features: true
+    # Disable this in your config if you do not need features info
+    # and are running out of memory
+    return_features_info: false

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -46,7 +46,6 @@ mmimdb:
     images:
     - url: https://archive.org/download/mmimdb/mmimdb.tar.gz
       file_name: mmimdb.tar.gz
-      hashcode: 7facb412f84e8e707cf5c15bb58e4cf3ac12d33e6e944e1bdefebada1259a253
     annotations:
     - url: mmf://datasets/mmimdb/defaults/annotations/annotations.tar.gz
       file_name: annotations.tar.gz

--- a/mmf/datasets/builders/mmimdb/builder.py
+++ b/mmf/datasets/builders/mmimdb/builder.py
@@ -6,7 +6,10 @@
 #
 
 from mmf.common.registry import registry
-from mmf.datasets.builders.mmimdb.dataset import MMIMDbDataset
+from mmf.datasets.builders.mmimdb.dataset import (
+    MMIMDbFeaturesDataset,
+    MMIMDbImageDataset,
+)
 from mmf.datasets.builders.vqa2.builder import VQA2Builder
 
 
@@ -15,8 +18,18 @@ class MMIMDbBuilder(VQA2Builder):
     def __init__(self):
         super().__init__()
         self.dataset_name = "mmimdb"
-        self.dataset_class = MMIMDbDataset
+        self.dataset_class = MMIMDbImageDataset
 
     @classmethod
     def config_path(cls):
         return "configs/datasets/mmimdb/defaults.yaml"
+
+    def load(self, config, dataset_type, *args, **kwargs):
+        config = config
+
+        if config.use_features:
+            self.dataset_class = MMIMDbFeaturesDataset
+
+        self.dataset = super().load(config, dataset_type, *args, **kwargs)
+
+        return self.dataset

--- a/mmf/datasets/builders/mmimdb/dataset.py
+++ b/mmf/datasets/builders/mmimdb/dataset.py
@@ -7,11 +7,14 @@ from mmf.common.sample import Sample
 from mmf.datasets.mmf_dataset import MMFDataset
 
 
-class MMIMDbDataset(MMFDataset):
+class MMIMDbFeaturesDataset(MMFDataset):
     def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
         super().__init__(
             "mmimdb", config, dataset_type, imdb_file_index, *args, **kwargs
         )
+        assert (
+            self._use_features
+        ), "config's 'use_features' must be true to use feature dataset"
 
     def __getitem__(self, idx):
         sample_info = self.annotation_db[idx]
@@ -28,6 +31,42 @@ class MMIMDbDataset(MMFDataset):
         if self._use_features is True:
             features = self.features_db[idx]
             current_sample.update(features)
+
+        processed = self.answer_processor({"answers": sample_info["genres"]})
+        current_sample.answers = processed["answers"]
+        current_sample.targets = processed["answers_scores"]
+
+        return current_sample
+
+
+class MMIMDbImageDataset(MMFDataset):
+    def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
+        super().__init__(
+            "mmimdb", config, dataset_type, imdb_file_index, *args, **kwargs
+        )
+        assert (
+            self._use_images
+        ), "config's 'use_images' must be true to use image dataset"
+
+    def init_processors(self):
+        super().init_processors()
+        # Assign transforms to the image_db
+        self.image_db.transform = self.image_processor
+
+    def __getitem__(self, idx):
+        sample_info = self.annotation_db[idx]
+        current_sample = Sample()
+        plot = sample_info["plot"]
+        if isinstance(plot, list):
+            plot = plot[0]
+        processed_sentence = self.text_processor({"text": plot})
+
+        current_sample.text = processed_sentence["text"]
+        if "input_ids" in processed_sentence:
+            current_sample.update(processed_sentence)
+
+        if self._use_images is True:
+            current_sample.image = self.image_db[idx]["images"][0]
 
         processed = self.answer_processor({"answers": sample_info["genres"]})
         current_sample.answers = processed["answers"]

--- a/mmf/datasets/databases/image_database.py
+++ b/mmf/datasets/databases/image_database.py
@@ -185,7 +185,7 @@ class ImageDatabase(torch.utils.data.Dataset):
         if pick == "identifier" and "left_url" in item and "right_url" in item:
             return [image + "-img0.jpg", image + "-img1.jpg"]
         elif pick == "image_name" or pick == "image_id":
-            return [image + ".jpg"]
+            return [image + ".jpeg"]
         else:
             return [image]
 

--- a/projects/mmbt/configs/mmimdb/defaults.yaml
+++ b/projects/mmbt/configs/mmimdb/defaults.yaml
@@ -1,10 +1,5 @@
-includes:
-- configs/datasets/mmimdb/with_features.yaml
-
 model_config:
-  visual_bert:
-    hidden_size: 768
-    hidden_dropout_prob: 0.1
+  mmbt:
     training_head_type: classification
     num_labels: 24
     losses:
@@ -12,7 +7,7 @@ model_config:
 
 dataset_config:
   mmimdb:
-    return_features_info: true
+    return_features_info: false
     processors:
       text_processor:
         type: bert_tokenizer
@@ -24,17 +19,17 @@ dataset_config:
           mask_probability: 0
           max_seq_length: 256
 
-optimizer:
-  type: adam_w
-  params:
-    lr: 5e-5
-    eps: 1e-8
-
 scheduler:
   type: warmup_linear
   params:
     num_warmup_steps: 2000
-    num_training_steps: 88000
+    num_training_steps: ${training.max_updates}
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 1e-5
+    eps: 1e-8
 
 evaluation:
   metrics:
@@ -43,14 +38,13 @@ evaluation:
   - multilabel_micro_f1
 
 training:
-  batch_size: 480
+  batch_size: 32
   lr_scheduler: true
-  # Don't forget to update schedule_attributes if you update this
-  max_updates: 60000
+  max_updates: 22000
   early_stop:
     criteria: mmimdb/multilabel_micro_f1
     minimize: false
 
 checkpoint:
   pretrained_state_mapping:
-    model.bert: model.bert
+    bert: bert

--- a/projects/mmbt/configs/mmimdb/with_features.yaml
+++ b/projects/mmbt/configs/mmimdb/with_features.yaml
@@ -1,0 +1,4 @@
+includes:
+- ./defaults.yaml
+- configs/models/mmbt/with_features.yaml
+- configs/datasets/mmimdb/with_features.yaml

--- a/projects/vilbert/configs/mmimdb/defaults.yaml
+++ b/projects/vilbert/configs/mmimdb/defaults.yaml
@@ -1,3 +1,6 @@
+includes:
+- configs/datasets/mmimdb/with_features.yaml
+
 model_config:
   vilbert:
     training_head_type: classification


### PR DESCRIPTION
Summary:
Support image features for MMBT on the MMIMDB dataset.
I have modified configs for MMIMDB, and make them consistent with configs for Hateful-memes.
defaults.yaml is for image grid features, with_features.yaml is for region features.
To support this, I have made  MMIMDbFeaturesDataset and MMIMDbImageDataset classes

Differential Revision: D22056638

