### PR TITLE
[fix] Naming of OCR bounding box positions in utils/dataset level

### DIFF
--- a/mmf/utils/dataset.py
+++ b/mmf/utils/dataset.py
@@ -20,8 +20,8 @@ def build_bbox_tensors(infos, max_length):
 
     for idx, info in enumerate(infos):
         bbox = info["bounding_box"]
-        x = bbox["topLeftX"]
-        y = bbox["topLeftY"]
+        x = bbox.get("top_left_x", bbox["topLeftX"])
+        y = bbox.get("top_left_y", bbox["topLeftY"])
         width = bbox["width"]
         height = bbox["height"]
 

--- a/mmf/utils/dataset.py
+++ b/mmf/utils/dataset.py
@@ -20,8 +20,8 @@ def build_bbox_tensors(infos, max_length):
 
     for idx, info in enumerate(infos):
         bbox = info["bounding_box"]
-        x = bbox["top_left_x"]
-        y = bbox["top_left_y"]
+        x = bbox["topLeftX"]
+        y = bbox["topLeftY"]
         width = bbox["width"]
         height = bbox["height"]
 


### PR DESCRIPTION
Related issue: #328

I ran into an error when I extended the default config file (mmf/projects/lorra/configs/textvqa/defaults.yaml) by the following properties:

```
dataset_config:
  textvqa:
    use_ocr: true
    use_order_vectors: true
    return_features_info: true
    use_ocr_info: true
```

The corresponding command:
```
python mmf/mmf_cli/run.py config=mmf/projects/lorra/configs/textvqa/defaults.yaml \
    datasets=textvqa \
    model=lorra \
    run_type=train_val
```

The solution aims to fix the naming issue. 