### PR TITLE
[WIP] Adding VirTex model into MMF core.

### DIFF
--- a/mmf/modules/decoders.py
+++ b/mmf/modules/decoders.py
@@ -4,6 +4,7 @@ from torch import nn
 from torch.nn.utils.weight_norm import weight_norm
 
 from mmf.common.registry import registry
+from mmf.modules.embeddings import TextEmbedding
 
 
 class VisDialDiscriminator(nn.Module):
@@ -81,3 +82,124 @@ class LanguageDecoder(nn.Module):
         state["lm_hidden"] = (h2, c2)
 
         return predictions
+
+
+class PyTorchTransformerDecoder(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        num_layers: int,
+        attention_heads: int,
+        feedforward_size: int,
+        dropout: float = 0.1,
+        padding_idx: int = 0,
+        max_sequence_length: int = 30,
+    ):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.attention_heads = attention_heads
+        self.feedforward_size = feedforward_size
+        self.dropout = dropout
+        self.padding_idx = padding_idx
+
+        # Create a randomly initialized word + positional embedding.
+        self.embedding = TextEmbedding(
+            "wordandpos",
+            vocab_size=self.vocab_size,
+            embedding_dim=self.hidden_size,
+            max_sequence_length=max_sequence_length,
+            dropout=dropout,
+            padding_idx=padding_idx,
+        )
+        self.transformer = nn.TransformerDecoder(
+            nn.TransformerDecoderLayer(
+                self.hidden_size,
+                self.attention_heads,
+                dim_feedforward=self.feedforward_size,
+                dropout=dropout,
+                activation="gelu",
+            ),
+            self.num_layers
+        )
+        self.apply(self.init_weights)
+
+        # Create an output linear layer and tie the input and output word
+        # embeddings to reduce parameters.
+        self.output = nn.Linear(self.textual_feature_size, vocab_size)
+        self.output.weight = self.embedding.words.weight
+
+    @staticmethod
+    def init_weights(module):
+        r"""Initialize weights like BERT - N(0.0, 0.02), bias = 0."""
+
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=0.02)
+        elif isinstance(module, nn.MultiheadAttention):
+            module.in_proj_weight.data.normal_(mean=0.0, std=0.02)
+            module.out_proj.weight.data.normal_(mean=0.0, std=0.02)
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=0.02)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    def forward(
+        self,
+        encoded_features: torch.Tensor,
+        sequence_tokens: torch.Tensor,
+        sequence_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, max_sequence_length = sequence_tokens.size()
+
+        # Create a mask based on sequence lengths, shape: (batch_size, )
+        # Form a binary mask: it is True for padding positions.
+        # These positions will be ignored for multi-headed attention.
+        ones = torch.ones_like(sequence_tokens)
+        sequence_mask = sequence_lengths.unsqueeze(1) < ones.cumsum(dim=1)
+
+        # shape: (batch_size, max_sequence_length, textual_feature_size)
+        embeddings = self.embedding(sequence_tokens)
+
+        # An additive mask for masking the future (one direction).
+        unidirectional_mask = self._generate_future_mask(
+            max_sequence_length, embeddings.dtype, embeddings.device
+        )
+        # We transpose the first two dimensions of tokens embeddings and encoded
+        # features, as required by transformer.
+        embeddings = embeddings.transpose(0, 1)
+        encoded_features = encoded_features.transpose(0, 1)
+
+        # shape: (max_sequence_length, batch_size, hidden_size)
+        textual_features = self.transformer(
+            embeddings,
+            encoded_features,
+            tgt_mask=unidirectional_mask,
+            tgt_key_padding_mask=sequence_mask,
+        )
+        # Undo the transpose and bring batch to dim 0.
+        # shape: (batch_size, max_sequence_length, hidden_size)
+        textual_features = textual_features.transpose(0, 1)
+
+        # shape: (batch_size, max_sequence_length, vocab_size)
+        output_logits = self.output(textual_features)
+        return output_logits
+
+    def _generate_future_mask(
+        self, size: int, dtype: torch.dtype, device: torch.device
+    ) -> torch.Tensor:
+        r"""
+        Generate a mask for "future" positions, useful when using this module
+        for language modeling.
+
+        Parameters
+        ----------
+        size: int
+        """
+        # Default mask is for forward direction. Flip for backward direction.
+        mask = torch.triu(
+            torch.ones(size, size, device=device, dtype=dtype), diagonal=1
+        )
+        mask = mask.masked_fill(mask == 1, float("-inf"))
+        return mask

--- a/mmf/modules/embeddings.py
+++ b/mmf/modules/embeddings.py
@@ -43,6 +43,9 @@ class TextEmbedding(nn.Module):
             embedding_dim = kwargs["embedding_dim"]
             self.module = nn.Embedding(vocab_size, embedding_dim)
             self.module.text_out_dim = self.embedding_dim
+        elif emb_type == "wordandpos":
+            self.module = WordAndPositionalEmbedding(**kwargs)
+            self.module.text_out_dim = self.embedding_dim
         else:
             raise NotImplementedError("Unknown question embedding '%s'" % emb_type)
 
@@ -424,3 +427,95 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
         embeddings = self.LayerNorm(embeddings)
         embeddings = self.dropout(embeddings)
         return embeddings
+
+
+class WordAndPositionalEmbedding(nn.Module):
+    r"""
+    A :class:`~torch.nn.Module` for learned word embeddings and position
+    embeddings for input tokens. Each token is mapped to a fixed dimensional
+    word embedding; and corresponding positional embedding based on its index.
+    These are summed together followed by layer normalization and an optional
+    dropout.
+
+    Parameters
+    ----------
+    vocab_size: int
+        Size of token vocabulary.
+    embedding_dim: int
+        Dimension of token embedding vectors.
+    max_sequence_length: int, optional (default = 30)
+        Maximum length of input sequence; this is used to create a fixed
+        positional embedding lookup table.
+    dropout: float, optional (default = 0.1)
+        Dropout probability for final dropout applied after layer normalization.
+    padding_idx: int, optional (default = 0)
+        Token index of ``[PAD]`` token, word embedding for these tokens will
+        be a vector of zeroes (and not trainable).
+    """
+    def __init__(
+        self,
+        vocab_size: int,
+        embedding_dim: int,
+        max_sequence_length: int = 30,
+        dropout: float = 0.0,
+        padding_idx: int = 0,
+    ):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.padding_idx = padding_idx
+
+        self.words = nn.Embedding(vocab_size, hidden_size, padding_idx=padding_idx)
+
+        # We provide no "padding index" for positional embeddings. We zero out
+        # the positional embeddings of padded positions as a post-processing.
+        self.positions = nn.Embedding(max_sequence_length, hidden_size)
+        self.layer_norm = nn.LayerNorm(
+            hidden_size, eps=1e-8, elementwise_affine=True
+        )
+        self.dropout = nn.Dropout(p=dropout)
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        r"""
+        Get combined word and positional embeddings for input tokens.
+
+        Parameters
+        ----------
+        tokens: torch.Tensor
+            A tensor of shape ``(batch_size, max_sequence_length)`` containing
+            a batch of sequence tokens, with values in ``[0, vocab_size)``.
+
+        Returns
+        -------
+        torch.Tensor
+            A tensor of shape ``(batch_size, max_sequence_length, hidden_size)``
+            containing corresponding token embeddings.
+        """
+        position_indices = self._create_position_indices(tokens)
+
+        # shape: (batch_size, max_caption_length, hidden_size)
+        word_embeddings = self.words(tokens)
+        position_embeddings = self.positions(position_indices)
+
+        # shape: (batch_size, max_caption_length, hidden_size)
+        embeddings = self.layer_norm(word_embeddings + position_embeddings)
+        embeddings = self.dropout(embeddings)
+
+        # Zero-out embeddings for positions which have padding tokens.
+        # shape: (batch_size, max_caption_length, 1)
+        token_mask = (tokens != self.padding_idx).unsqueeze(-1)
+
+        # shape: (batch_size, max_caption_length, hidden_size)
+        embeddings = embeddings * token_mask.type(embeddings.dtype)
+        return embeddings
+
+    @functools.lru_cache(maxsize=128)
+    def _create_position_indices(self, tokens: torch.Tensor):
+
+        # Create position indices of the same size as token indices.
+        batch_size, max_caption_length = tokens.size()
+        positions = torch.arange(
+            max_caption_length, dtype=tokens.dtype, device=tokens.device
+        )
+        # shape: (batch_size, max_caption_length)
+        positions = positions.unsqueeze(0).expand(batch_size, max_caption_length)
+        return positions

--- a/mmf/modules/encoders.py
+++ b/mmf/modules/encoders.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import pickle
+from typing import Dict, Union
 
 import torch
 import torchvision
@@ -85,6 +86,15 @@ class ImageEncoder(nn.Module):
             self.module.out_dim = params.in_dim
         elif self._type == "resnet152":
             self.module = ResNet152ImageEncoder(params)
+        elif self._type.startswith("torchvision"):
+            # Get model name, e.g. "torchvision::resnet50" -> "resnet50"
+            torchvision_model_name = self._type.split("::")[1]
+
+            self.module = TorchvisionImageEncoder(
+                torchvision_model_name,
+                pretrained=config.get("pretrained", False),
+                frozen=config.get("frozen", False),
+            )
         else:
             raise NotImplementedError("Unknown Image Encoder: %s" % self._type)
 
@@ -131,6 +141,112 @@ class ResNet152ImageEncoder(nn.Module):
         out = torch.flatten(out, start_dim=2)
         out = out.transpose(1, 2).contiguous()
         return out  # BxNx2048
+
+
+class TorchvisionImageEncoder(nn.Module):
+    r"""
+    An image encoder from `Torchvision model zoo
+    <https://pytorch.org/docs/stable/torchvision/models.html>`_. Any model can
+    be specified using corresponding method name from the model zoo.
+
+    Parameters
+    ----------
+    name: str, optional (default = "resnet50")
+        Name of the model from Torchvision model zoo.
+    pretrained: bool, optional (default = False)
+        Whether to load ImageNet pretrained weights from Torchvision.
+    frozen: float, optional (default = False)
+        Whether to keep all weights frozen during training.
+    """
+
+    def __init__(
+        self,
+        name: str = "resnet50",
+        pretrained: bool = False,
+        frozen: bool = False,
+    ):
+        super().__init__()
+
+        # Instantiate a model from torchvision.
+        self.cnn = getattr(torchvision.models, name)(
+            pretrained, zero_init_residual=True,
+        )
+        # Do nothing after the final residual stage.
+        self.cnn.fc = nn.Identity()
+
+        # Freeze all weights if specified.
+        if frozen:
+            for param in self.cnn.parameters():
+                param.requires_grad = False
+            self.cnn.eval()
+
+        # Keep a list of intermediate residual stage names.
+        # NOTE: only work for ResNet-like models (do not work for VGG).
+        self._stage_names = [f"layer{i}" for i in range(1, 5)]
+
+        # Get visual feature size (channel dimension) by passing a 
+        # random input tensor.
+        with torch.no_grad():
+            # Global average pooled features.
+            output_vector = self.cnn(torch.randn(1, 3, 224, 224))
+            self.visual_feature_size = output_vector.size(1)
+
+    @property
+    def out_dim(self):
+        return self.visual_feature_size
+
+    def forward(
+        self, image: torch.Tensor, return_intermediate_outputs: bool = False
+    ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
+        r"""
+        Compute visual features for a batch of input images.
+
+        Parameters
+        ----------
+        image: torch.Tensor
+            Batch of input images. A tensor of shape
+            ``(batch_size, 3, image_height, image_width)``.
+        return_intermediate_outputs: bool, optional (default = False)
+            Whether to return feaures extracted from all intermediate stages
+            or just the last one. This should only be set ``True`` when using
+            a ResNet-like model.
+ 
+        Returns
+        -------
+        Union[torch.Tensor, Dict[str, torch.Tensor]]
+            - If ``return_intermediate_outputs = False``, this will be a tensor
+              of shape ``(batch_size, grid_height * grid_width, out_dim)``.
+              For example it will be ``(batch_size, 49, 2048)`` for ResNet-50.
+            - If ``return_intermediate_outputs = True``, this will be a dict
+              with keys ``{"layer1", "layer2", "layer3", "layer4", "avgpool"}``
+              containing features from all intermediate layers and global
+              average pooling layer.
+        """
+
+        # Iterate through the modules in sequence and collect feature
+        # vectors for last layers in each stage.
+        intermediate_outputs: Dict[str, torch.Tensor] = {}
+        for idx, (name, layer) in enumerate(self.cnn.named_children()):
+            # shape: (batch_size, feature_dim, feature_height, feature_width)
+            out = layer(image) if idx == 0 else layer(out)
+
+            if name in self._stage_names:
+                # Bring channels to last dim and collapse rest of the dims,
+                # except batch dim.
+                # shape: (batch_size, grid_size, feature_dim)
+                out = torch.flatten(out, start_dim=2)
+                out = out.transpose(1, 2).contiguous()
+                intermediate_outputs[name] = out
+
+        # Add global average pooled spatial grid features.
+        intermediate_outputs["avgpool"] = torch.mean(
+            intermediate_outputs["layer4"], dim=1
+        )
+        if return_intermediate_outputs:
+            return intermediate_outputs
+        else:
+            # shape: (batch_size, grid_size, out_dim)
+            return intermediate_outputs["layer4"]
 
 
 class TextEncoder(nn.Module):


### PR DESCRIPTION
Tracking all progress on adding complete support of VirTex models in MMF. VirTex comprises of a CNN "visual backbone" and a transformer decoder based "textual head". In terms of implementation, it would require adding image encoder and a text decode; followed by integrating with the registry and model zoo.

![virtex model](https://kdexd.github.io/virtex/_images/system_figure.jpg)

**Canonical Implementation from Authors:** https://github.com/kdexd/virtex
**Paper:** https://arxiv.org/abs/2006.06666

Some of the modules I add here might be reusable for other supported models (e.g. `TorchvisionImageEncoder`), but require careful refactor in a backward compatible manner. Happy to get any feedback along the way!
