### PR TITLE
[fix] VQA Answer Processor in case of predict; vocab path

### DIFF
--- a/mmf/datasets/builders/textvqa/dataset.py
+++ b/mmf/datasets/builders/textvqa/dataset.py
@@ -198,6 +198,8 @@ class TextVQADataset(MMFDataset):
         return sample
 
     def add_answer_info(self, sample_info, sample):
+        if "answers" not in sample_info:
+            return sample
         # Load real answers from sample_info
         answers = sample_info.get("answers", None)
         answer_processor_arg = {"answers": answers}

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -507,6 +507,14 @@ class VQAAnswerProcessor(BaseProcessor):
             )
 
         self.answer_vocab = VocabDict(config.vocab_file, *args, **kwargs)
+        self.PAD_IDX = self.answer_vocab.word2idx("<pad>")
+        self.BOS_IDX = self.answer_vocab.word2idx("<s>")
+        self.EOS_IDX = self.answer_vocab.word2idx("</s>")
+        self.UNK_IDX = self.answer_vocab.UNK_INDEX
+
+        # Set EOS to something not achievable if it is not there
+        if self.EOS_IDX == self.UNK_IDX:
+            self.EOS_IDX = len(self.answer_vocab)
 
         self.preprocessor = None
 

--- a/mmf/utils/text.py
+++ b/mmf/utils/text.py
@@ -23,7 +23,7 @@ import torch
 
 from mmf.common.registry import registry
 from mmf.utils.file_io import PathManager
-from mmf.utils.general import get_mmf_root
+from mmf.utils.general import get_absolute_path
 
 SENTENCE_SPLIT_REGEX = re.compile(r"(\W+)")
 
@@ -111,8 +111,7 @@ class VocabDict:
 
     def __init__(self, vocab_file, data_dir=None):
         if not os.path.isabs(vocab_file) and data_dir is not None:
-            mmf_root = get_mmf_root()
-            vocab_file = os.path.abspath(os.path.join(mmf_root, data_dir, vocab_file))
+            vocab_file = get_absolute_path(os.path.join(data_dir, vocab_file))
 
         if not PathManager.exists(vocab_file):
             raise RuntimeError(f"Vocab file {vocab_file} for vocab dict doesn't exist")

--- a/mmf/utils/vocab.py
+++ b/mmf/utils/vocab.py
@@ -9,7 +9,7 @@ from torchtext import vocab
 from mmf.utils.configuration import get_mmf_cache_dir
 from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
-from mmf.utils.general import get_mmf_root
+from mmf.utils.general import get_absolute_path
 
 EMBEDDING_NAME_CLASS_MAPPING = {"glove": "GloVe", "fasttext": "FastText"}
 
@@ -119,8 +119,9 @@ class BaseVocab:
 
         if vocab_file is not None:
             if not os.path.isabs(vocab_file) and data_dir is not None:
-                mmf_root = get_mmf_root()
-                vocab_file = os.path.join(mmf_root, data_dir, vocab_file)
+                vocab_file = os.path.join(data_dir, vocab_file)
+                vocab_file = get_absolute_path(vocab_file)
+
             if not PathManager.exists(vocab_file):
                 raise RuntimeError("Vocab not found at " + vocab_file)
 
@@ -230,8 +231,8 @@ class CustomVocab(BaseVocab):
         self.type = "custom"
 
         if not os.path.isabs(embedding_file) and data_dir is not None:
-            mmf_root = get_mmf_root()
-            embedding_file = os.path.join(mmf_root, data_dir, embedding_file)
+            embedding_file = os.path.join(data_dir, embedding_file)
+            embedding_file = get_absolute_path(embedding_file)
 
         if not PathManager.exists(embedding_file):
             from mmf.common.registry import registry


### PR DESCRIPTION
- In case answers are not present, don't call answer processor
- Predcition now requires EOS_IDX, which is not present in
VQAAnswerProcessor, so let's add that
- Use `get_absolute_path` for proper path search of vocabs
- Fixes #341

Test Plan:
Tested predict end to end for lorra model