### PR TITLE
[feature, fix] added support for update_frequency (v2)

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -42,6 +42,10 @@ training:
     # Size of each batch. If distributed or data_parallel
     # is used, this will be divided equally among GPUs
     batch_size: 512
+    # Run update_frequency=K batches with batch_size=N, accumulate gradients, then do
+    # one update (one optimizer step). The effect is a large effective batch size of
+    # KxN (without incurring the memory overhead of setting batch_size to KxN).
+    update_frequency: 1
     # Number of workers to be used in dataloaders
     num_workers: 4
     # Some datasets allow fast reading by loading everything in the memory

--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -183,7 +183,10 @@ class MultiDatasetLoader:
 
     def __len__(self):
         # Since, this is iterator, we need to return total length == number of batches
-        return self._total_length // get_batch_size()
+        batch_size = get_batch_size()
+        # This assumes drop_last=False for all loaders. See also
+        # build_dataloader_and_sampler().
+        return (self._total_length + batch_size - 1) // batch_size
 
     def __iter__(self):
         if self._num_datasets == 1:

--- a/mmf/trainers/callbacks/base.py
+++ b/mmf/trainers/callbacks/base.py
@@ -46,13 +46,13 @@ class Callback:
         """
         pass
 
-    def on_batch_start(self, **kwargs) -> None:
+    def on_update_start(self, **kwargs) -> None:
         """
         Called before each train iteration.
         """
         pass
 
-    def on_batch_end(self, **kwargs) -> None:
+    def on_update_end(self, **kwargs) -> None:
         """
         Called after each train iteration.
         """

--- a/mmf/trainers/callbacks/base.py
+++ b/mmf/trainers/callbacks/base.py
@@ -46,15 +46,27 @@ class Callback:
         """
         pass
 
+    def on_batch_start(self, **kwargs) -> None:
+        """
+        Called before each train forward pass of a batch.
+        """
+        pass
+
+    def on_batch_end(self, **kwargs) -> None:
+        """
+        Called after each train forward pass of a batch.
+        """
+        pass
+
     def on_update_start(self, **kwargs) -> None:
         """
-        Called before each train iteration.
+        Called before each train update.
         """
         pass
 
     def on_update_end(self, **kwargs) -> None:
         """
-        Called after each train iteration.
+        Called after each train update.
         """
         pass
 

--- a/mmf/trainers/callbacks/checkpoint.py
+++ b/mmf/trainers/callbacks/checkpoint.py
@@ -30,7 +30,7 @@ class CheckpointCallback(Callback):
     def on_init_start(self, **kwargs):
         self._checkpoint.load_state_dict()
 
-    def on_batch_end(self, **kwargs):
+    def on_update_end(self, **kwargs):
         if self.trainer.num_updates % self.checkpoint_interval == 0:
             logger.info("Checkpoint time. Saving a checkpoint.")
             self._checkpoint.save(

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -49,7 +49,7 @@ class LogisticsCallback(Callback):
         self.train_timer = Timer()
         self.snapshot_timer = Timer()
 
-    def on_batch_end(self, **kwargs):
+    def on_update_end(self, **kwargs):
         if not kwargs["should_log"]:
             return
         extra = {}

--- a/mmf/trainers/callbacks/lr_scheduler.py
+++ b/mmf/trainers/callbacks/lr_scheduler.py
@@ -21,6 +21,6 @@ class LRSchedulerCallback(Callback):
         if self.training_config.lr_scheduler is True:
             self._scheduler = build_scheduler(self.trainer.optimizer, self.config)
 
-    def on_batch_end(self, **kwargs):
+    def on_update_end(self, **kwargs):
         if self._scheduler is not None:
             self._scheduler.step()

--- a/mmf/trainers/core/callback_hook.py
+++ b/mmf/trainers/core/callback_hook.py
@@ -29,6 +29,16 @@ class TrainerCallbackHookMixin(ABC):
         for callback in self.callbacks:
             callback.on_train_end(**kwargs)
 
+    def on_batch_start(self, **kwargs) -> None:
+        """Called when a forward pass begins."""
+        for callback in self.callbacks:
+            callback.on_batch_start(**kwargs)
+
+    def on_batch_end(self, **kwargs) -> None:
+        """Called when a forward pass ends."""
+        for callback in self.callbacks:
+            callback.on_batch_end(**kwargs)
+
     def on_update_start(self, **kwargs) -> None:
         """Called when the training update begins."""
         for callback in self.callbacks:

--- a/mmf/trainers/core/callback_hook.py
+++ b/mmf/trainers/core/callback_hook.py
@@ -29,15 +29,15 @@ class TrainerCallbackHookMixin(ABC):
         for callback in self.callbacks:
             callback.on_train_end(**kwargs)
 
-    def on_batch_start(self, **kwargs) -> None:
-        """Called when the training batch begins."""
+    def on_update_start(self, **kwargs) -> None:
+        """Called when the training update begins."""
         for callback in self.callbacks:
-            callback.on_batch_start(**kwargs)
+            callback.on_update_start(**kwargs)
 
-    def on_batch_end(self, **kwargs) -> None:
-        """Called when the training batch ends."""
+    def on_update_end(self, **kwargs) -> None:
+        """Called when the training update ends."""
         for callback in self.callbacks:
-            callback.on_batch_end(**kwargs)
+            callback.on_update_end(**kwargs)
 
     def on_validation_start(self, **kwargs) -> None:
         """Called when the validation loop begins."""

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -10,7 +10,7 @@ import torch
 from mmf.common.registry import registry
 from mmf.common.report import Report
 from mmf.common.sample import to_device
-from mmf.utils.general import clip_gradients
+from mmf.utils.general import assert_iterator_finished, clip_gradients
 from torch import Tensor
 
 
@@ -56,12 +56,57 @@ class TrainerTrainingLoopMixin(ABC):
             # Seed the sampler in case if it is distributed
             self.dataset_loader.seed_sampler("train", self.current_epoch)
 
-            for batch in self.train_loader:
-                self.profile("Batch load time")
-                self.current_iteration += 1
-                logger.debug(self.num_updates + 1)
+            if self.current_epoch > self.max_epochs:
+                break
 
-                self.run_training_batch(batch)
+            num_remaining_batches = len(self.train_loader)
+            batch_iter = iter(self.train_loader)
+
+            while num_remaining_batches:
+
+                combined_report = None
+                num_batches_for_this_update = min(
+                    self.config.training.update_frequency, num_remaining_batches
+                )
+
+                self._start_update()
+
+                for _ in range(num_batches_for_this_update):
+                    batch = next(batch_iter)
+                    self.profile("Batch load time")
+
+                    report = self.run_training_batch(batch, num_batches_for_this_update)
+
+                    # accumulate necessary params for metric calculation
+                    if combined_report is None:
+                        combined_report = report
+                    else:
+                        combined_report.accumulate_tensor_fields(
+                            report, self.metrics.required_params
+                        )
+                        combined_report.batch_size += report.batch_size
+
+                self._finish_update()
+
+                should_log = False
+                if self.num_updates % self.logistics_callback.log_interval == 0:
+                    should_log = True
+                    # Calculate metrics every log interval for debugging
+                    if self.training_config.evaluate_metrics:
+                        combined_report.metrics = self.metrics(
+                            combined_report, combined_report
+                        )
+                    self.update_meter(combined_report, self.meter)
+
+                self.on_update_end(
+                    report=combined_report, meter=self.meter, should_log=should_log
+                )
+
+                num_remaining_batches -= num_batches_for_this_update
+
+                if num_remaining_batches == 0:
+                    # we expect iterator to be finished, based on len(self.train_loader)
+                    assert_iterator_finished(batch_iter)
 
                 # Check if training should be stopped
                 should_break = False
@@ -95,24 +140,14 @@ class TrainerTrainingLoopMixin(ABC):
                 if should_break:
                     break
 
-    def run_training_batch(self, batch: Tensor) -> None:
-        # Train batch start callbacks
-        self.on_batch_start()
+    def run_training_batch(self, batch: Tensor, loss_divisor: int) -> None:
 
         report = self._forward(batch)
         loss = self._extract_loss(report)
+        loss /= loss_divisor
         self._backward(loss)
 
-        should_log = False
-        if self.num_updates % self.logistics_callback.log_interval == 0:
-            should_log = True
-            # Calculate metrics every log interval for debugging
-            if self.training_config.evaluate_metrics:
-                report.metrics = self.metrics(report, report)
-            self.update_meter(report, self.meter)
-
-        # Train batch end callbacks
-        self.on_batch_end(report=report, meter=self.meter, should_log=should_log)
+        return report
 
     def _forward(self, batch: Tensor) -> Dict[str, Any]:
         prepared_batch = self.dataset_loader.prepare_batch(batch)
@@ -126,10 +161,16 @@ class TrainerTrainingLoopMixin(ABC):
 
         return report
 
-    def _backward(self, loss: Tensor) -> None:
+    def _start_update(self):
+        self.current_iteration += 1
+        logger.debug(self.num_updates + 1)
         self.optimizer.zero_grad()
-        loss.backward()
 
+    def _backward(self, loss: Tensor) -> None:
+        loss.backward()
+        self.profile("Backward time")
+
+    def _finish_update(self):
         if self.training_config.clip_gradients:
             clip_gradients(
                 self.model,
@@ -140,7 +181,7 @@ class TrainerTrainingLoopMixin(ABC):
 
         self.optimizer.step()
         self.num_updates += 1
-        self.profile("Backward time")
+        self.profile("Finish update")
 
     def _extract_loss(self, report: Dict[str, Any]) -> Tensor:
         loss_dict = report.losses

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -151,6 +151,7 @@ def build_dataloader_and_sampler(
             dataset_instance.dataset_name, dataset_instance.dataset_type
         ),
         num_workers=num_workers,
+        drop_last=False,  # see also MultiDatasetLoader.__len__
         **other_args,
     )
 

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -277,3 +277,12 @@ def log_device_names():
     if torch.cuda.is_available():
         device_name = torch.cuda.get_device_name()
         logger.info(f"CUDA Device {get_rank()} is: {device_name}")
+
+
+def assert_iterator_finished(iter):
+    try:
+        _ = next(iter)
+    except StopIteration:
+        pass
+    else:
+        assert False

--- a/tests/trainers/callbacks/test_logistics.py
+++ b/tests/trainers/callbacks/test_logistics.py
@@ -99,12 +99,12 @@ class TestLogisticsCallback(unittest.TestCase):
             int(self.cb.train_timer.get_time_since_start().split("ms")[0]), expected
         )
 
-    def test_on_batch_end(self):
+    def test_on_update_end(self):
         self.cb.on_train_start()
-        self.cb.on_batch_end(meter=self.trainer.meter, should_log=False)
+        self.cb.on_update_end(meter=self.trainer.meter, should_log=False)
         f = PathManager.open(os.path.join(self.tmpdir, "train.log"))
         self.assertFalse(any("time_since_start" in line for line in f.readlines()))
-        self.cb.on_batch_end(meter=self.trainer.meter, should_log=True)
+        self.cb.on_update_end(meter=self.trainer.meter, should_log=True)
         f = PathManager.open(os.path.join(self.tmpdir, "train.log"))
         self.assertTrue(any("time_since_start" in line for line in f.readlines()))
 

--- a/tests/trainers/callbacks/test_lr_scheduler.py
+++ b/tests/trainers/callbacks/test_lr_scheduler.py
@@ -72,9 +72,9 @@ class TestLogisticsCallback(unittest.TestCase):
     def tearDown(self):
         registry.unregister("config")
 
-    def test_on_batch_end(self):
-        self.trainer.lr_scheduler_callback.on_batch_end()
+    def test_on_update_end(self):
+        self.trainer.lr_scheduler_callback.on_update_end()
         self.assertAlmostEqual(self.trainer.optimizer.param_groups[0]["lr"], 1e-02)
 
-        self.trainer.lr_scheduler_callback.on_batch_end()
+        self.trainer.lr_scheduler_callback.on_update_end()
         self.assertAlmostEqual(self.trainer.optimizer.param_groups[0]["lr"], 1e-03)

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -15,7 +15,11 @@ from tests.test_utils import NumbersDataset, SimpleModel
 class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
     def __init__(self, num_train_data, max_updates, max_epochs):
         self.training_config = OmegaConf.create(
-            {"detect_anomaly": False, "evaluation_interval": 10000}
+            {
+                "detect_anomaly": False,
+                "evaluation_interval": 10000,
+                "update_frequency": 1,
+            }
         )
         if max_updates is not None:
             self.training_config["max_updates"] = max_updates
@@ -37,9 +41,11 @@ class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
             dataset=dataset, batch_size=1, shuffle=False, num_workers=1, drop_last=False
         )
         self.on_batch_start = MagicMock(return_value=None)
+        self.on_update_start = MagicMock(return_value=None)
         self.logistics_callback = MagicMock(return_value=None)
         self.logistics_callback.log_interval = MagicMock(return_value=None)
         self.on_batch_end = MagicMock(return_value=None)
+        self.on_update_end = MagicMock(return_value=None)
         self.meter = MagicMock(return_value=None)
         self.after_training_loop = MagicMock(return_value=None)
 


### PR DESCRIPTION
This PR adds support for config.training.update_frequency:
```
# Run update_frequency=K batches with batch_size=N, accumulate gradients, then do 
# one update (one optimizer step). The effect is a large effective batch size of 
# KxN (without incurring the memory overhead of setting batch_size to KxN).
update_frequency: 1
```
https://www.internalfb.com/intern/tasks/?t=66569918

This is a revised approach; see also earlier PR https://github.com/facebookresearch/mmf/pull/292.

With this change, we have to be more clear with naming. Amanpreet and I agreed on this:
- we have no particular term for a single forward/backward pass for a single batch
- "update" == "iteration" == one optimizer step (will be more than one batch when update_frequency > 1)

The update logic in `BaseTrainer._backward` has mostly been moved to `_start_update` and `_finish_update`.

There's also a fix for `MultiDatasetLoader.__len__`. The existing bug is only present for the case that the train set size is not a multiple of per-worker batch size, which is probably rare in practice.

Test Plan:
I did ad-hoc testing of BaseTrainer.train() (`mmf_run config="projects/hateful_memes/configs/late_fusion/defaults.yaml" model="late_fusion" dataset=hateful_memes`) with print statements and varying `[batch_size, update_frequency, train set size]`, including end-of-epoch and completion of the train run. 