### PR TITLE
[fix] Reloads in spawned processes shouldn't setup imports again

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -406,4 +406,10 @@ class Registry:
 
 
 registry = Registry()
-setup_imports()
+
+# Only setup imports in main process, this means registry won't be
+# fully available in spawned child processes (such as dataloader processes)
+# but instantiated. This is to prevent issues such as
+# https://github.com/facebookresearch/mmf/issues/355
+if __name__ == "__main__":
+    setup_imports()


### PR DESCRIPTION
- Fixes #355 partially
- In general, only setup_imports in the main processor
- This means that the child processes are using only shallow registry
which is fine as setup imports can cause issues in file not related with
syntax error
- Overall, this can't be fixed completely as by the nature of the spawn,
the child will still reload all of the code and if a syntax error is
there it will still break the worker. General suggestion is to keep two
copies of the code, one for development and one for running and keep
them in sync via GitHub

Test Plan:

Tested with command and reproduction steps provided by Ronghang