### PR TITLE
[fix] VisualBERT regression of pooler; provide pooler strategy option

### DIFF
--- a/mmf/configs/models/visual_bert/classification.yaml
+++ b/mmf/configs/models/visual_bert/classification.yaml
@@ -1,0 +1,3 @@
+model_config:
+  visual_bert:
+    training_head_type: classification

--- a/mmf/configs/models/visual_bert/defaults.yaml
+++ b/mmf/configs/models/visual_bert/defaults.yaml
@@ -11,3 +11,6 @@ model_config:
     random_initialize: false
     freeze_base: false
     finetune_lr_multiplier: 1
+    # Default points to BERT pooler strategy which is to take
+    # representation of CLS token after passing it through a dense layer
+    pooler_strategy: default

--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -157,7 +157,7 @@ visual_bert:
         resources:
         - url: mmf://models/visual_bert/visual_bert.finetuned.vqa2.train.tar.gz
           file_name: visual_bert.finetuned.vqa2.train.tar.gz
-          hashcode: e786351503f0e19abd916cc9063b427adc60a0f98f6686e58b296672e90b74c
+          hashcode: e786351503f0e19abd916cc9063b427adc60a0f98f6686e58b296672e90b74c8
       from_coco_train_val:
         version: 1.0_2020_05_21
         resources:

--- a/projects/visual_bert/configs/vizwiz/defaults.yaml
+++ b/projects/visual_bert/configs/vizwiz/defaults.yaml
@@ -4,6 +4,7 @@ model_config:
     hidden_dropout_prob: 0.1
     training_head_type: classification
     num_labels: 7371
+    pooler_strategy: vqa
     losses:
     - type: logit_bce
 

--- a/projects/visual_bert/configs/vqa2/defaults.yaml
+++ b/projects/visual_bert/configs/vqa2/defaults.yaml
@@ -4,6 +4,7 @@ model_config:
     hidden_dropout_prob: 0.1
     training_head_type: classification
     num_labels: 3129
+    pooler_strategy: vqa
     losses:
     - type: logit_bce
 


### PR DESCRIPTION
- In VQA2 and general question answering, original codebase has a
different pooler strategy of taking hidden state from second last token
- The regression was causing issue with mismatch  of accuracies on
pretraining it right paper's checkpoint

Test Plan:
Testing on the best checkpoint and estimated the accuracy to be same.