### PR TITLE
[fix] Call load_state_dict in on_init_start and call it in trainer.load

### DIFF
--- a/mmf/trainers/callbacks/checkpoint.py
+++ b/mmf/trainers/callbacks/checkpoint.py
@@ -25,7 +25,7 @@ class CheckpointCallback(Callback):
     def checkpoint(self):
         return self._checkpoint
 
-    def on_init_end(self, **kwargs):
+    def on_init_start(self, **kwargs):
         self._checkpoint.load_state_dict()
 
     def on_batch_end(self, **kwargs):

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -36,6 +36,8 @@ class MMFTrainer(
 
     def load(self):
         super().load()
+        # Callbacks
+        self.on_init_start()
 
         # Parallize model
         self.parallelize_model()
@@ -46,7 +48,6 @@ class MMFTrainer(
     def configure_callbacks(self):
         self.checkpoint_callback = CheckpointCallback(self.config, self)
         self.early_stop_callback = EarlyStoppingCallback(self.config, self)
-        # self.callbacks.append(self.early_stop_callback)
         self.logistics_callback = LogisticsCallback(self.config, self)
         self.lr_scheduler_callback = LRSchedulerCallback(self.config, self)
 


### PR DESCRIPTION
- This fixes the issue with loading distributed or data parallel models
using checkpoint as model would parallelize but still won't have
checkpoint loaded
- A missing call to on_init_start has also been added

Test Plan:
Tested by Omkar