### PR TITLE
[feat] Add pre/post processing for predictions (#122)

### DIFF
--- a/mmf/trainers/callbacks/base.py
+++ b/mmf/trainers/callbacks/base.py
@@ -105,3 +105,15 @@ class Callback:
         Called after each test iteration.
         """
         pass
+
+    def on_prediction_start(self, **kwargs) -> None:
+        """
+        Called before prediction loop starts.
+        """
+        pass
+
+    def on_prediction_end(self, **kwargs) -> None:
+        """
+        Called after prediction loop ends.
+        """
+        pass

--- a/mmf/trainers/core/callback_hook.py
+++ b/mmf/trainers/core/callback_hook.py
@@ -78,3 +78,13 @@ class TrainerCallbackHookMixin(ABC):
         """Called when the test batch ends."""
         for callback in self.callbacks:
             callback.on_test_batch_end(**kwargs)
+
+    def on_prediction_start(self, **kwargs) -> None:
+        """Called when the prediction begins."""
+        for callback in self.callbacks:
+            callback.on_prediction_start(**kwargs)
+
+    def on_prediction_end(self, **kwargs) -> None:
+        """Called when the prediction ends."""
+        for callback in self.callbacks:
+            callback.on_prediction_end(**kwargs)

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -115,13 +115,14 @@ class MMFTrainer(
             dataset_type.append("test")
 
         for dataset in dataset_type:
-            self.on_test_start()
             if self.config.evaluation.predict:
+                self.on_prediction_start()
                 self.prediction_loop(dataset)
-                continue
+                self.on_prediction_end()
             else:
+                self.on_test_start()
                 self.writer.write(f"Starting inference on {dataset} set")
                 report, meter = self.evaluation_loop(
                     getattr(self, f"{dataset}_loader"), use_tqdm=True
                 )
-            self.on_test_end(report=report, meter=meter)
+                self.on_test_end(report=report, meter=meter)


### PR DESCRIPTION
Summary:
Adding ```on_prediction_start```and ```on_prediction_end``` for pre/post processing of the predictions

Pull Request resolved: https://github.com/fairinternal/mmf-internal/pull/122

Reviewed By: apsdehal

Differential Revision: D22397973

Pulled By: shirgur

