### PR TITLE
[feat] Add Base transformer class for modular multimodal transformers

### DIFF
--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -1,0 +1,222 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Type
+
+from omegaconf import OmegaConf
+from torch import Tensor, nn
+from transformers import AutoConfig, AutoModel
+
+from mmf.models import BaseModel
+from mmf.utils.configuration import get_mmf_cache_dir
+from mmf.utils.modeling import get_optimizer_parameters_for_bert
+
+
+@dataclass
+class BaseTransformerInput:
+    input_ids: Dict[str, Tensor]  # dict of input ids for all modalities
+    position_ids: Dict[str, Tensor]  # dict of position ids for all modalities
+    segment_ids: Dict[str, Tensor]  # dict of segment/token type ids for all modalities
+    masks: Dict[str, Tensor]  # dict of masks for all modalities
+
+
+@dataclass
+class BaseTransformerConfigType:
+    transformer_base: str  # name of transformer base model
+    training_head_type: str  # training head type used for initializing head
+    modalities: List[str]  # list of modalities for the model input
+    initializer_range: float  # std dev of the normal distribution to initialize layers
+    initializer_mean: float  # mean of the normal distribution to initialize layers
+    layer_norm_weight_fill: float  # layer norm weight initialization
+    random_initialize: bool  # random initialize whole network
+    freeze_base: bool  # freeze the base transformer
+    finetune_lr_multiplier: float  # finetune lr multiplier for base transformer
+
+
+class BaseTransformer(BaseModel):
+    def __init__(self, config: BaseTransformerConfigType):
+        """Initialize the config which is the model configuration and transformer_config
+        which is the config for the `transformer` base model.
+        """
+        super().__init__(config)
+        self.config = config
+        self.transformer_config = AutoConfig.from_pretrained(
+            config.transformer_base, **OmegaConf.to_container(config)
+        )
+
+    def build(self):
+        """Build the different parts of the multimodal transformer model and
+        initializes weights.
+        """
+        self.build_transformer()
+        self.build_encoders()
+        self.build_embeddings()
+        self.build_heads()
+        self.build_losses()
+
+        self.init_weights()
+
+    def get_optimizer_parameters(self, config: BaseTransformerConfigType):
+        return get_optimizer_parameters_for_bert(self, config)
+
+    def build_encoders(self):
+        """Build any encoders for different input modalities. Encoders are used while
+        preprocessing a sample. We the visual_encoder by default for raw image input.
+
+        Example ::
+
+            # For image
+            self.image_encoder = ImageEncoder(self.config)
+
+        """
+        return
+
+    def build_embeddings(self):
+        """Build the embeddings for the different input modalities.
+
+        Example ::
+
+            # For text
+            self.word_embeddings = nn.Embedding(
+                config.vocab_size, config.hidden_size, padding_idx=0
+            )
+            self.position_embeddings = nn.Embedding(
+                config.max_position_embeddings, config.hidden_size
+            )
+
+            # For image
+            self.img_embeddings = nn.Sequential(
+                nn.Linear(img_dim, config.hidden_size),
+                torch.nn.LayerNorm(config.hidden_size, eps=1e-12),
+            )
+        """
+        return
+
+    def build_transformer(self):
+        """Build the transformer encoder. This uses transformers AutoModel to load a
+        pretrained model given the name of the transformer based model. All the layers
+        in the transformer model will be available (encoder, embeddings etc.) for use.
+        Different HUggingface transformer models have different naming conventions for
+        the layers. Adjust your derived class based on the transformer base you want to
+        use.
+
+        Example ::
+
+            self.transformer = AutoModel.from_pretrained(
+                "bert-base-uncased",
+                config=self.transformer_config,
+            )
+        """
+        self.transformer = AutoModel.from_pretrained(
+            self.config.transformer_base,
+            config=self.transformer_config,
+            cache_dir=os.path.join(get_mmf_cache_dir(), "distributed_{}".format(-1)),
+        )
+
+    def build_heads(self):
+        """Build the different heads for the model. It can be either the pretraining
+        head or the classifier heads.
+
+        Example ::
+
+            # For pretraining
+            self.classifier = nn.Sequential(
+                BertPredictionHeadTransform(self.transformer_config),
+                nn.Linear(self.transformer_config.hidden_size, self.config.num_labels),
+            )
+
+            # For classification
+            self.classifier = nn.Sequential(
+                BertPredictionHeadTransform(self.transformer_config),
+                nn.Linear(self.transformer_config.hidden_size, self.config.num_labels),
+            )
+        """
+        return
+
+    def build_losses(self):
+        """Initialize the losses for pretraining. For example MLM, MIM etc.
+
+        Example ::
+
+            self.mlm_loss = CrossEntropyLoss(ignore_index=-1)
+        """
+        return
+
+    def _init_weights(self, module: Type[nn.Module]):
+        """Initialize the weights for different layers.
+        """
+        if isinstance(module, (nn.Linear, nn.Embedding)):
+            module.weight.data.normal_(
+                mean=self.config.initializer_mean, std=self.config.initializer_range
+            )
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(self.config.layer_norm_weight_fill)
+        if isinstance(module, nn.Linear) and module.bias is not None:
+            module.bias.data.zero_()
+
+    def tie_weights(self):
+        """Tie the weights between the input embeddings and the output embeddings
+        if required.
+        """
+        return
+
+    def init_weights(self):
+        if self.config.random_initialize is False:
+            if self.config.transformer_base is None:
+                # No pretrained model, init weights
+                self.apply(self._init_weights)
+
+        # Tie weights if required
+        self.tie_weights()
+
+    def preprocess_sample(self, sample_list: Dict[str, Any]) -> BaseTransformerInput:
+        """Preprocess the sample_list and returns input ids, position ids, segment or
+        token type ids and masks for different modalities.
+
+        Returns:
+            BaseTransformerInput: BaseTransformerInput containing input_ids,
+                position_ids, segment_ids, masks
+        """
+        return
+
+    def forward(self, sample_list: Dict[str, Any]) -> Dict[str, Tensor]:
+        r"""Forward pass of the model. The input sample_list can be preprocessed using
+        the preprocess_sample method which expects to return a BaseTransformerInput
+        object. BaseTransformerInput contains different properties of the input
+        modalities and the masks. These can be used to generate embeddings for each
+        modality and also create attention mask.
+
+        Flow of how the forward pass can be implemented using various modules in
+        BaseTransformer:
+
+                    preprocess_sample                          ||
+                            |                                  ||
+                   generate embeddings                         ||
+                            |                                  ||
+                 generate attention masks                      ||     MODEL
+                            |                                  ||
+                 transformer encoder pass                      ||     FLOW
+                            |                                  ||
+                   different head pass                         ||   DIRECTION
+                            |                                  ||
+                   postprocess_output                          ||
+                            |                                  ||
+                 Dict[str, Tensor] output                      \/
+
+        Returns:
+            Dict[str, Tensor]: Dict containing scores or losses
+        """
+        return
+
+    def postprocess_output(self, output: List[Tensor]) -> Dict[str, Tensor]:
+        """Postprocessing the output from the transformer head, for pretraining
+        it's the output of the pretrain head and for classification its the output
+        of the classsification head. Calculate lossses on pretraining output or
+        model output scores.
+
+        Returns:
+            Dict[str, Tensor]: Dict containing scores or losses
+        """
+        return output

--- a/mmf/utils/modeling.py
+++ b/mmf/utils/modeling.py
@@ -46,9 +46,8 @@ def get_optimizer_parameters_for_bert(module, config):
     model_config = getattr(config.model_config, config.model, {})
     finetune_lr_multiplier = getattr(model_config, "finetune_lr_multiplier", 1)
     # Finetune the bert pretrained part with finetune_lr_multiplier if it is set
-    parameters = get_bert_configured_parameters(
-        module.bert, lr * finetune_lr_multiplier
-    )
+    encoder = module.transformer if hasattr(module, "transformer") else module.bert
+    parameters = get_bert_configured_parameters(encoder, lr * finetune_lr_multiplier)
     # Classifier will be trained on the normal lr
     parameters += get_bert_configured_parameters(module.classifier, lr)
 


### PR DESCRIPTION
- Adds a base transformer model class with modular components for constructing a transformer based multi modal model. The modularity is divided as : 
```
        self.build_encoders()
        self.build_embeddings()
        self.build_transformer()
        self.build_heads()
        self.build_losses()
```
- Base model automatically loads an encoder specified by `transformer_base` in config. For example it can be `bert-base-uncased`, `roberta-base` etc.
- Ability to preprocess the input sample_list in `preprocess_sample ` according to model's requirement and also postprocess the output from the transformer according to requirement. For pretraining, we can add cls head and calculate loss on the output in the  `postprocess_output ` method. For classification we can calculate scores etc.


Test Plan:
- Tested with creating a new model using the base class and running on Hateful Memes, VQA2