### PR TITLE
[fix] Isort version same as pre-commit to avoid CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ install_dep: &install_dep
         pip install --upgrade setuptools
         pip install --progress-bar off flake8
         pip install --progress-bar off black
-        pip install --progress-bar off isort
+        pip install --progress-bar off isort==4.3.20
         pip install --progress-bar off pytest
         python setup.py clean --all
         python setup.py install
@@ -50,7 +50,7 @@ install_dep_windows: &install_dep_windows
         pip install -r requirements.txt
         pip install --progress-bar off flake8
         pip install --progress-bar off black
-        pip install --progress-bar off isort
+        pip install --progress-bar off isort==4.3.20
         pip install --progress-bar off pytest
         python setup.py install
         python -c 'import torch; print("Torch version:", torch.__version__)'
@@ -84,6 +84,7 @@ run_flake8: &run_flake8
       name: Run Linter (flake8)
       command: |
         source activate mmf
+        flake8 --version
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
@@ -138,6 +139,7 @@ run_black: &run_black
       name: Run Linter (black)
       command: |
         source activate mmf
+        black --version
         black --check .
 
 run_isort: &run_isort
@@ -145,6 +147,7 @@ run_isort: &run_isort
       name: Run Linter (isort)
       command: |
         source activate mmf
+        isort --version
         isort -c -sp .
 
 # -------------------------------------------------------------------------------------


### PR DESCRIPTION
- With recent update of isort, it is changing alias imports to custom
format, which is breaking our CI builds
- Later, we should look into how we can move to the latest version of
isort

Test Plan:
To be tested on CI