### PR TITLE
[refactor] Release some restrictions on supported dataset types

### DIFF
--- a/mmf/common/batch_collator.py
+++ b/mmf/common/batch_collator.py
@@ -8,8 +8,21 @@ class BatchCollator:
         self._dataset_type = dataset_type
 
     def __call__(self, batch):
-        # Create and return sample list with proper name and type set
-        sample_list = SampleList(batch)
+        # Create and return sample list with proper name
+        # and type set if it is already not a sample list
+        # (case of batched iterators)
+        sample_list = batch
+        if (
+            # Check if batch is a list before checking batch[0]
+            # or len as sometimes batch is already SampleList
+            isinstance(batch, list)
+            and len(batch) == 1
+            and isinstance(batch[0], SampleList)
+        ):
+            sample_list = batch[0]
+        elif not isinstance(batch, SampleList):
+            sample_list = SampleList(batch)
+
         sample_list.dataset_name = self._dataset_name
         sample_list.dataset_type = self._dataset_type
         return sample_list

--- a/mmf/datasets/base_dataset.py
+++ b/mmf/datasets/base_dataset.py
@@ -64,9 +64,6 @@ class BaseDataset(Dataset):
             full_key = reg_key.format(processor_key)
             registry.register(full_key, processor_instance)
 
-    def try_fast_read(self):
-        return
-
     def prepare_batch(self, batch):
         """
         Can be possibly overridden in your child class

--- a/mmf/datasets/base_dataset_builder.py
+++ b/mmf/datasets/base_dataset_builder.py
@@ -94,9 +94,10 @@ class BaseDatasetBuilder:
             DO NOT OVERRIDE in child class. Instead override ``load``.
         """
         dataset = self.load(config, dataset_type, *args, **kwargs)
-        if dataset is not None:
+        if dataset is not None and hasattr(dataset, "init_processors"):
+            # Checking for init_processors allows us to load some datasets
+            # which don't have processors and don't inherit from BaseDataset
             dataset.init_processors()
-            dataset.try_fast_read()
         return dataset
 
     def load(self, config, dataset_type="train", *args, **kwargs):

--- a/mmf/datasets/builders/vqa2/builder.py
+++ b/mmf/datasets/builders/vqa2/builder.py
@@ -19,6 +19,13 @@ class VQA2Builder(MMFDatasetBuilder):
     def config_path(cls):
         return "configs/datasets/vqa2/defaults.yaml"
 
+    def load(self, *args, **kwargs):
+        dataset = super().load(*args, **kwargs)
+        if dataset is not None and hasattr(dataset, "try_fast_read"):
+            dataset.try_fast_read()
+
+        return dataset
+
     # TODO: Deprecate this method and move configuration updates directly to processors
     def update_registry_for_model(self, config):
         if hasattr(self.dataset, "text_processor"):

--- a/tests/common/test_batch_collator.py
+++ b/tests/common/test_batch_collator.py
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+
+import torch
+
+import tests.test_utils as test_utils
+from mmf.common.batch_collator import BatchCollator
+from mmf.common.sample import Sample
+
+
+class TestBatchCollator(unittest.TestCase):
+    def test_call(self):
+        batch_collator = BatchCollator("vqa2", "train")
+        sample_list = test_utils.build_random_sample_list()
+        sample_list = batch_collator(sample_list)
+
+        # Test already build sample list
+        self.assertEqual(sample_list.dataset_name, "vqa2")
+        self.assertEqual(sample_list.dataset_type, "train")
+
+        sample = Sample()
+        sample.a = torch.tensor([1, 2], dtype=torch.int)
+
+        # Test list of samples
+        sample_list = batch_collator([sample, sample])
+        self.assertTrue(
+            test_utils.compare_tensors(
+                sample_list.a, torch.tensor([[1, 2], [1, 2]], dtype=torch.int)
+            )
+        )
+
+        # Test IterableDataset case
+        sample_list = test_utils.build_random_sample_list()
+        new_sample_list = batch_collator([sample_list])
+        self.assertEqual(new_sample_list, sample_list)

--- a/tests/common/test_sample.py
+++ b/tests/common/test_sample.py
@@ -1,11 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import random
 import unittest
 
-import torch
-
 import tests.test_utils as test_utils
-from mmf.common.sample import Sample, SampleList
+from mmf.common.sample import Sample
 
 
 class TestSample(unittest.TestCase):
@@ -31,7 +28,7 @@ class TestSample(unittest.TestCase):
 class TestSampleList(unittest.TestCase):
     @test_utils.skip_if_no_cuda
     def test_pin_memory(self):
-        sample_list = self._build_random_sample_list()
+        sample_list = test_utils.build_random_sample_list()
         sample_list.pin_memory()
 
         pin_list = [sample_list.y, sample_list.z.y]
@@ -52,7 +49,7 @@ class TestSampleList(unittest.TestCase):
         self.assertFalse(any_pinned)
 
     def test_to_dict(self):
-        sample_list = self._build_random_sample_list()
+        sample_list = test_utils.build_random_sample_list()
         sample_dict = sample_list.to_dict()
         self.assertTrue(isinstance(sample_dict, dict))
         # hasattr won't work anymore
@@ -72,20 +69,3 @@ class TestSampleList(unittest.TestCase):
 
         self.assertTrue(all_keys)
         self.assertTrue(isinstance(sample_dict, dict))
-
-    def _build_random_sample_list(self):
-        first = Sample()
-        first.x = random.randint(0, 100)
-        first.y = torch.rand((5, 4))
-        first.z = Sample()
-        first.z.x = random.randint(0, 100)
-        first.z.y = torch.rand((6, 4))
-
-        second = Sample()
-        second.x = random.randint(0, 100)
-        second.y = torch.rand((5, 4))
-        second.z = Sample()
-        second.z.x = random.randint(0, 100)
-        second.z.y = torch.rand((6, 4))
-
-        return SampleList([first, second])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import argparse
 import platform
+import random
 import socket
 import unittest
 
@@ -69,3 +70,23 @@ def compare_state_dicts(a, b):
             return same
 
     return same
+
+
+def build_random_sample_list():
+    from mmf.common.sample import Sample, SampleList
+
+    first = Sample()
+    first.x = random.randint(0, 100)
+    first.y = torch.rand((5, 4))
+    first.z = Sample()
+    first.z.x = random.randint(0, 100)
+    first.z.y = torch.rand((6, 4))
+
+    second = Sample()
+    second.x = random.randint(0, 100)
+    second.y = torch.rand((5, 4))
+    second.z = Sample()
+    second.z.x = random.randint(0, 100)
+    second.z.y = torch.rand((6, 4))
+
+    return SampleList([first, second])


### PR DESCRIPTION
Summary:
- Allows datasets which are not inherited from BaseDataset to be returned from the DatasetBuilder
- This will allow us to use IterableDataset which is required for some internal dataset
- Batches can be directly returned now
- Sampler doesn't need to have set_epoch method
- Move fast read to VQABuilder as that's the only builder using it currently.
- If prepare_batch is not implemented, throw a warning instead of error. User needs to implement it themselves now
- `update_registry_for_model` is optional as well.

Differential Revision: D22563932

