### PR TITLE
[fix] Checkpoint resume dir and value in sweeps scripts

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -219,7 +219,7 @@ distributed:
 
 # Configuration for checkpointing including resuming and loading pretrained models
 checkpoint:
-    # If checkpoint.resume is true, MMF will try to load automatically load
+    # If checkpoint.resume is true or 1, MMF will try to load automatically load
     # checkpoint and state from "current.ckpt" from env.save_dir
     resume: false
     # `checkpoint.resume_file` can be used to load a specific checkpoint from a file

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -152,10 +152,11 @@ class Checkpoint:
                     load_zoo=True,
                     load_pretrained=ckpt_config.resume_pretrained,
                 )
+                return
             else:
                 raise RuntimeError(f"{ckpt_config.resume_file} doesn't exist")
 
-        if ckpt_config.resume is True:
+        if ckpt_config.resume:
             if PathManager.exists(ckpt_filepath):
                 self._load(ckpt_filepath)
             else:

--- a/tools/sweeps/lib/slurm.py
+++ b/tools/sweeps/lib/slurm.py
@@ -146,7 +146,7 @@ def launch_train(args, config):
 
     if args.config is not None:
         train_cmd.extend(["config", args.config])
-    train_cmd.extend(["checkpoint.resume", "1"])
+    train_cmd.extend(["checkpoint.resume", "True"])
     train_cmd.extend(["env.save_dir", save_dir])
     if args.tensorboard:
         train_cmd.extend(["training.tensorboard", "1"])


### PR DESCRIPTION
Summary:
- Checkpoint resume wasn't enabled in fblearner script.
- Checkpoint.resume should directly checked truthy. This will allow users to pass `checkpoint.resume=1` and avoid confusion.

Differential Revision: D22566067

