### PR TITLE
[feat] OKVQA dataset implementation

### DIFF
--- a/mmf/common/typings.py
+++ b/mmf/common/typings.py
@@ -1,13 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-
-from typing import Any, Dict, Optional, Tuple, Type
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import omegaconf
 import torch
 
 from mmf.datasets.base_dataset import BaseDataset
 from mmf.datasets.base_dataset_builder import BaseDatasetBuilder
-from mmf.datasets.processors.processors import Processor
 from mmf.utils.download import DownloadableFile
 
 DownloadableFileType = Type[DownloadableFile]
@@ -18,5 +17,28 @@ DataLoaderAndSampler = Tuple[
     Type[torch.utils.data.DataLoader], Optional[torch.utils.data.Sampler]
 ]
 DataLoaderArgsType = Optional[Dict[str, Any]]
-ProcessorType = Type[Processor]
-ProcessorDict = Dict[str, ProcessorType]
+
+
+@dataclass
+class PerSetAttributeType:
+    train: List[str]
+    val: List[str]
+    test: List[str]
+
+
+@dataclass
+class ProcessorConfigType:
+    type: str
+    params: Dict[str, Any]
+
+
+@dataclass
+class MMFDatasetConfigType:
+    data_dir: str
+    use_images: bool
+    use_features: bool
+    zoo_requirements: List[str]
+    images: PerSetAttributeType
+    features: PerSetAttributeType
+    annotations: PerSetAttributeType
+    processors: Dict[str, ProcessorConfigType]

--- a/mmf/configs/datasets/okvqa/defaults.yaml
+++ b/mmf/configs/datasets/okvqa/defaults.yaml
@@ -9,9 +9,9 @@ dataset_config:
       train:
       - okvqa/defaults/images/
       val:
-      - okvqa/defaults/images/val2014
+      - okvqa/defaults/images/
       test:
-      - okvqa/defaults/images/test2015
+      - okvqa/defaults/images/
     annotations:
       train:
       - okvqa/defaults/annotations/mscoco_train2014_annotations.json,okvqa/defaults/annotations/OpenEnded_mscoco_train2014_questions.json
@@ -35,7 +35,7 @@ dataset_config:
         type: vqa_answer
         params:
           num_answers: 10
-          vocab_file: okvqa/defaults/extras/vocabs/answers_vqa.txt
+          vocab_file: okvqa/defaults/extras/vocabs/answers_okvqa.txt
           preprocessor:
             type: simple_word
             params: {}

--- a/mmf/configs/datasets/okvqa/defaults.yaml
+++ b/mmf/configs/datasets/okvqa/defaults.yaml
@@ -1,0 +1,57 @@
+dataset_config:
+  okvqa:
+    data_dir: ${env.data_dir}/datasets
+    use_images: true
+    use_features: false
+    zoo_requirements:
+    - okvqa.defaults
+    images:
+      train:
+      - okvqa/defaults/images/
+      val:
+      - okvqa/defaults/images/val2014
+      test:
+      - okvqa/defaults/images/test2015
+    annotations:
+      train:
+      - okvqa/defaults/annotations/mscoco_train2014_annotations.json,okvqa/defaults/annotations/OpenEnded_mscoco_train2014_questions.json
+      val:
+      - okvqa/defaults/annotations/mscoco_val2014_annotations.json,okvqa/defaults/annotations/OpenEnded_mscoco_val2014_questions.json
+      test:
+      - okvqa/defaults/annotations/mscoco_val2014_annotations.json,okvqa/defaults/annotations/OpenEnded_mscoco_val2014_questions.json
+    processors:
+      text_processor:
+        type: vocab
+        params:
+          max_length: 14
+          vocab:
+            type: intersected
+            embedding_name: glove.6B.300d
+            vocab_file: okvqa/defaults/extras/vocabs/vocabulary_100k.txt
+          preprocessor:
+            type: simple_sentence
+            params: {}
+      answer_processor:
+        type: vqa_answer
+        params:
+          num_answers: 10
+          vocab_file: okvqa/defaults/extras/vocabs/answers_vqa.txt
+          preprocessor:
+            type: simple_word
+            params: {}
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: Resize
+              params:
+                size: [256, 256]
+            - type: CenterCrop
+              params:
+                size: [224, 224]
+            - ToTensor
+            - GrayScaleTo3Channels
+            - type: Normalize
+              params:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.12221994, 0.12145835, 0.14380469]

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -351,3 +351,26 @@ gqa:
       - url: mmf://datasets/gqa/defaults/features/features.tar.gz
         file_name: features.tar.gz
         hashcode: 530e62e398faa5c9f2d4f7edc2223cce4a679b2837fa4252976f0eff4127f9ce
+
+
+okvqa:
+  defaults:
+    version: 1.0_2020_07_16
+    resources:
+      images:
+      - url: mmf://datasets/okvqa/defaults/images/images.tar.gz
+        file_name: images.tar.gz
+        hashcode: 674380cee4285a495c398fe9265224052b04454e4599d56b844f0453140ea82f
+      extras:
+      - url: mmf://datasets/vqa2/defaults/extras.tar.gz
+        file_name: extras.tar.gz
+        hashcode: e45c3dbef61e5cc550b08ed7299c88cf7937efa219d071342b8ed7a6a5642a55
+      annotations:
+      - url: https://okvqa.allenai.org/static/data/mscoco_train2014_annotations.json.zip
+        file_name: mscoco_train2014_annotations.json.zip
+      - url: https://okvqa.allenai.org/static/data/mscoco_val2014_annotations.json.zip
+        file_name: mscoco_val2014_annotations.json.zip
+      - url: https://okvqa.allenai.org/static/data/OpenEnded_mscoco_train2014_questions.json.zip
+        file_name: OpenEnded_mscoco_train2014_questions.json.zip
+      - url: https://okvqa.allenai.org/static/data/OpenEnded_mscoco_val2014_questions.json.zip
+        file_name: OpenEnded_mscoco_val2014_questions.json.zip

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -362,9 +362,9 @@ okvqa:
         file_name: images.tar.gz
         hashcode: 674380cee4285a495c398fe9265224052b04454e4599d56b844f0453140ea82f
       extras:
-      - url: mmf://datasets/vqa2/defaults/extras.tar.gz
+      - url: mmf://datasets/okvqa/defaults/extras.tar.gz
         file_name: extras.tar.gz
-        hashcode: e45c3dbef61e5cc550b08ed7299c88cf7937efa219d071342b8ed7a6a5642a55
+        hashcode: 9a1cc2f2abedcee494917fae853069d8e465dad050307221b7969c9d65ed1b45
       annotations:
       - url: https://okvqa.allenai.org/static/data/mscoco_train2014_annotations.json.zip
         file_name: mscoco_train2014_annotations.json.zip

--- a/mmf/datasets/builders/okvqa/builder.py
+++ b/mmf/datasets/builders/okvqa/builder.py
@@ -1,19 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
 from mmf.common.registry import registry
-from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
 from mmf.datasets.builders.okvqa.dataset import OKVQADataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
 
 
 @registry.register_builder("okvqa")
 class OKVQABuilder(MMFDatasetBuilder):
-  def __init__(
-      self,
-      dataset_name="okvqa",
-      dataset_class=OKVQADataset,
-      *args,
-      **kwargs,
-  ):
-    super().__init__(dataset_name, dataset_class, *args, **kwargs)
+    def __init__(
+        self, dataset_name="okvqa", dataset_class=OKVQADataset, *args, **kwargs
+    ):
+        super().__init__(dataset_name, dataset_class, *args, **kwargs)
 
-  @classmethod
-  def config_path(cls):
-    return "configs/datasets/okvqa/defaults.yaml"
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/okvqa/defaults.yaml"

--- a/mmf/datasets/builders/okvqa/builder.py
+++ b/mmf/datasets/builders/okvqa/builder.py
@@ -1,0 +1,19 @@
+from mmf.common.registry import registry
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+from mmf.datasets.builders.okvqa.dataset import OKVQADataset
+
+
+@registry.register_builder("okvqa")
+class OKVQABuilder(MMFDatasetBuilder):
+  def __init__(
+      self,
+      dataset_name="okvqa",
+      dataset_class=OKVQADataset,
+      *args,
+      **kwargs,
+  ):
+    super().__init__(dataset_name, dataset_class, *args, **kwargs)
+
+  @classmethod
+  def config_path(cls):
+    return "configs/datasets/okvqa/defaults.yaml"

--- a/mmf/datasets/builders/okvqa/database.py
+++ b/mmf/datasets/builders/okvqa/database.py
@@ -1,0 +1,45 @@
+import json
+
+from mmf.datasets.databases.annotation_database import AnnotationDatabase
+from mmf.utils.general import get_absolute_path
+
+
+class OKVQAAnnotationDatabase(AnnotationDatabase):
+    def __init__(self, config, path, *args, **kwargs):
+        path = path.split(",")
+        super().__init__(config, path, *args, **kwargs)
+
+    def load_annotation_db(self, path):
+        # Expect two paths, one to questions and one to annotations
+        assert len(path) == 2, (
+            "OKVQA requires 2 paths; one to questions and one to annotations"
+        )
+
+        with open(path[0]) as f:
+            path_0 = json.load(f)
+        with open(path[1]) as f:
+            path_1 = json.load(f)
+
+        if "annotations" in path_0:
+            annotations = path_0
+            questions = path_1
+        else:
+            annotations = path_1
+            questions = path_0
+
+        # Convert to linear format
+        data = []
+        question_dict = {}
+        for question in questions["questions"]:
+            question_dict[question["question_id"]] = question["question"]
+
+        for annotation in annotations["annotations"]:
+            annotation["question"] = question_dict[annotation["question_id"]]
+
+        answers = []
+        for answer in annotation["answers"]:
+            answers.append(answer["answer"])
+        annotation["answers"] = answers
+        data.append(annotation)
+
+        self.data = data

--- a/mmf/datasets/builders/okvqa/database.py
+++ b/mmf/datasets/builders/okvqa/database.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import copy
 import json
 
 from mmf.datasets.databases.annotation_database import AnnotationDatabase
@@ -11,9 +13,9 @@ class OKVQAAnnotationDatabase(AnnotationDatabase):
 
     def load_annotation_db(self, path):
         # Expect two paths, one to questions and one to annotations
-        assert len(path) == 2, (
-            "OKVQA requires 2 paths; one to questions and one to annotations"
-        )
+        assert (
+            len(path) == 2
+        ), "OKVQA requires 2 paths; one to questions and one to annotations"
 
         with open(path[0]) as f:
             path_0 = json.load(f)
@@ -35,11 +37,10 @@ class OKVQAAnnotationDatabase(AnnotationDatabase):
 
         for annotation in annotations["annotations"]:
             annotation["question"] = question_dict[annotation["question_id"]]
-
-        answers = []
-        for answer in annotation["answers"]:
-            answers.append(answer["answer"])
-        annotation["answers"] = answers
-        data.append(annotation)
+            answers = []
+            for answer in annotation["answers"]:
+                answers.append(answer["answer"])
+            annotation["answers"] = answers
+            data.append(copy.deepcopy(annotation))
 
         self.data = data

--- a/mmf/datasets/builders/okvqa/dataset.py
+++ b/mmf/datasets/builders/okvqa/dataset.py
@@ -38,7 +38,7 @@ class OKVQADataset(MMFDataset):
 
     # Get the first image from the set of images returned from the image_db
     image_path = self.get_image_path(sample_info["image_id"])
-    current_sample.image = self.image_db.from_path(image_path)
+    current_sample.image = self.image_db.from_path(image_path)["images"][0]
 
     if "answers" in sample_info:
       answers = self.answer_processor({"answers": sample_info["answers"]})

--- a/mmf/datasets/builders/okvqa/dataset.py
+++ b/mmf/datasets/builders/okvqa/dataset.py
@@ -1,47 +1,57 @@
-from typing import Union, Type
+# Copyright (c) Facebook, Inc. and its affiliates.
+from typing import Type, Union
 
 import torch
 
 from mmf.common.sample import Sample
 from mmf.common.typings import MMFDatasetConfigType
-from mmf.datasets.mmf_dataset import MMFDataset
 from mmf.datasets.builders.okvqa.database import OKVQAAnnotationDatabase
+from mmf.datasets.mmf_dataset import MMFDataset
 
 
 class OKVQADataset(MMFDataset):
-  def __init__(self, config: MMFDatasetConfigType, dataset_type: str, index: int, *args, **kwargs):
-    super().__init__("okvqa", config, dataset_type, index, *args, **kwargs)
+    def __init__(
+        self,
+        config: MMFDatasetConfigType,
+        dataset_type: str,
+        index: int,
+        *args,
+        **kwargs,
+    ):
+        super().__init__("okvqa", config, dataset_type, index, *args, **kwargs)
 
-  def build_annotation_db(self) -> Type[OKVQAAnnotationDatabase]:
-    annotation_path = self._get_path_based_on_index(
-        self.config, "annotations", self._index
-    )
-    return OKVQAAnnotationDatabase(self.config, annotation_path)
+    def build_annotation_db(self) -> Type[OKVQAAnnotationDatabase]:
+        annotation_path = self._get_path_based_on_index(
+            self.config, "annotations", self._index
+        )
+        return OKVQAAnnotationDatabase(self.config, annotation_path)
 
-  def get_image_path(self, image_id: Union[str, int]) -> str:
-    if self.dataset_type == "train":
-      image_path = f"COCO_train2014_{str(image_id).zfill(12)}"
-    else:
-      image_path = f"COCO_val2014_{str(image_id).zfill(12)}"
-    return image_path
+    def get_image_path(self, image_id: Union[str, int]) -> str:
+        if self.dataset_type == "train":
+            image_path = f"COCO_train2014_{str(image_id).zfill(12)}.jpg"
+        else:
+            image_path = f"COCO_val2014_{str(image_id).zfill(12)}.jpg"
+        return image_path
 
-  def init_processors(self):
-    super().init_processors()
-    self.image_db.transform = self.image_processor
+    def init_processors(self):
+        super().init_processors()
+        self.image_db.transform = self.image_processor
 
-  def __getitem__(self, idx: int) -> Type[Sample]:
-    sample_info = self.annotation_db[idx]
-    current_sample = Sample()
-    processed_question = self.text_processor({"text": sample_info["question"]})
-    current_sample.update(processed_question)
-    current_sample.id = torch.tensor(int(sample_info["question_id"]), dtype=torch.int)
+    def __getitem__(self, idx: int) -> Type[Sample]:
+        sample_info = self.annotation_db[idx]
+        current_sample = Sample()
+        processed_question = self.text_processor({"text": sample_info["question"]})
+        current_sample.update(processed_question)
+        current_sample.id = torch.tensor(
+            int(sample_info["question_id"]), dtype=torch.int
+        )
 
-    # Get the first image from the set of images returned from the image_db
-    image_path = self.get_image_path(sample_info["image_id"])
-    current_sample.image = self.image_db.from_path(image_path)["images"][0]
+        # Get the first image from the set of images returned from the image_db
+        image_path = self.get_image_path(sample_info["image_id"])
+        current_sample.image = self.image_db.from_path(image_path)["images"][0]
 
-    if "answers" in sample_info:
-      answers = self.answer_processor({"answers": sample_info["answers"]})
-      current_sample.targets = answers["answers_scores"]
+        if "answers" in sample_info:
+            answers = self.answer_processor({"answers": sample_info["answers"]})
+            current_sample.targets = answers["answers_scores"]
 
-    return current_sample
+        return current_sample

--- a/mmf/datasets/builders/okvqa/dataset.py
+++ b/mmf/datasets/builders/okvqa/dataset.py
@@ -1,0 +1,47 @@
+from typing import Union, Type
+
+import torch
+
+from mmf.common.sample import Sample
+from mmf.common.typings import MMFDatasetConfigType
+from mmf.datasets.mmf_dataset import MMFDataset
+from mmf.datasets.builders.okvqa.database import OKVQAAnnotationDatabase
+
+
+class OKVQADataset(MMFDataset):
+  def __init__(self, config: MMFDatasetConfigType, dataset_type: str, index: int, *args, **kwargs):
+    super().__init__("okvqa", config, dataset_type, index, *args, **kwargs)
+
+  def build_annotation_db(self) -> Type[OKVQAAnnotationDatabase]:
+    annotation_path = self._get_path_based_on_index(
+        self.config, "annotations", self._index
+    )
+    return OKVQAAnnotationDatabase(self.config, annotation_path)
+
+  def get_image_path(self, image_id: Union[str, int]) -> str:
+    if self.dataset_type == "train":
+      image_path = f"COCO_train2014_{str(image_id).zfill(12)}"
+    else:
+      image_path = f"COCO_val2014_{str(image_id).zfill(12)}"
+    return image_path
+
+  def init_processors(self):
+    super().init_processors()
+    self.image_db.transform = self.image_processor
+
+  def __getitem__(self, idx: int) -> Type[Sample]:
+    sample_info = self.annotation_db[idx]
+    current_sample = Sample()
+    processed_question = self.text_processor({"text": sample_info["question"]})
+    current_sample.update(processed_question)
+    current_sample.id = torch.tensor(int(sample_info["question_id"]), dtype=torch.int)
+
+    # Get the first image from the set of images returned from the image_db
+    image_path = self.get_image_path(sample_info["image_id"])
+    current_sample.image = self.image_db.from_path(image_path)
+
+    if "answers" in sample_info:
+      answers = self.answer_processor({"answers": sample_info["answers"]})
+      current_sample.targets = answers["answers_scores"]
+
+    return current_sample

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -80,17 +80,12 @@ import numpy as np
 import torch
 
 from mmf.common.registry import registry
+from mmf.common.typings import ProcessorConfigType
 from mmf.utils.configuration import get_mmf_cache_dir, get_mmf_env
 from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
 from mmf.utils.text import VocabDict
 from mmf.utils.vocab import Vocab, WordToVectorDict
-
-
-@dataclass
-class ProcessorConfigType:
-    type: str
-    params: Dict[str, Any]
 
 
 @dataclass

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -2,7 +2,7 @@
 
 import os
 import warnings
-from typing import Any, Type, Dict
+from typing import Any, Dict, Type
 
 import torch
 from omegaconf import OmegaConf
@@ -13,7 +13,6 @@ from mmf.datasets.processors.processors import Processor
 from mmf.utils.configuration import Configuration
 from mmf.utils.distributed import is_dist_initialized
 from mmf.utils.general import get_optimizer_parameters
-
 
 ProcessorType = Type[Processor]
 ProcessorDict = Dict[str, ProcessorType]

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -2,16 +2,21 @@
 
 import os
 import warnings
-from typing import Any, Type
+from typing import Any, Type, Dict
 
 import torch
 from omegaconf import OmegaConf
 
 from mmf.common import typings as mmf_typings
 from mmf.common.registry import registry
+from mmf.datasets.processors.processors import Processor
 from mmf.utils.configuration import Configuration
 from mmf.utils.distributed import is_dist_initialized
 from mmf.utils.general import get_optimizer_parameters
+
+
+ProcessorType = Type[Processor]
+ProcessorDict = Dict[str, ProcessorType]
 
 
 def build_config(
@@ -262,7 +267,7 @@ def build_image_encoder(config, direct_features=False, **kwargs):
 
 def build_processors(
     processors_config: mmf_typings.DictConfig, registry_key: str = None, *args, **kwargs
-) -> mmf_typings.ProcessorDict:
+) -> ProcessorDict:
     """Given a processor config, builds the processors present and returns back
     a dict containing processors mapped to keys as per the config
 
@@ -275,7 +280,7 @@ def build_processors(
             be called on this string. Defaults to None.
 
     Returns:
-        mmf_typings.ProcessorDict: Dictionary containing key to
+        ProcessorDict: Dictionary containing key to
             processor mapping
     """
     from mmf.datasets.processors.processors import Processor

--- a/projects/mmbt/configs/okvqa/with_images.yaml
+++ b/projects/mmbt/configs/okvqa/with_images.yaml
@@ -19,6 +19,13 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 128
+
+model_config:
+  mmbt:
+    losses:
+    - logit_bce
+    num_labels: 3129
+
 optimizer:
   type: adam_w
   params:

--- a/projects/mmbt/configs/okvqa/with_images.yaml
+++ b/projects/mmbt/configs/okvqa/with_images.yaml
@@ -24,7 +24,7 @@ model_config:
   mmbt:
     losses:
     - logit_bce
-    num_labels: 3129
+    num_labels: 2253
 
 optimizer:
   type: adam_w

--- a/projects/mmbt/configs/okvqa/with_images.yaml
+++ b/projects/mmbt/configs/okvqa/with_images.yaml
@@ -1,0 +1,42 @@
+includes:
+- configs/models/mmbt/classification.yaml
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+dataset_config:
+  okvqa:
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 128
+optimizer:
+  type: adam_w
+  params:
+    lr: 1e-5
+    eps: 1e-8
+
+evaluation:
+    metrics:
+    - vqa_accuracy
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  max_updates: 22000
+  early_stop:
+    criteria: okvqa/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    bert: bert


### PR DESCRIPTION
Adds support for OKVQA dataset in MMF. Automatic downloads are only supported at image level, feature support maybe added later.

Test Plan:
A config has been added to test on MMBT with Images.

```
mmf_run config=projects/mmbt/configs/okvqa/with_images.yaml run_type=train_val dataset=okvqa model=mmbt  training.batch_size=64 training.stdout_capture=False training.seed=1
```