### PR TITLE
[feat] Generalized MM transformer

### DIFF
--- a/mmf/configs/models/mmf_transformer/defaults.yaml
+++ b/mmf/configs/models/mmf_transformer/defaults.yaml
@@ -1,0 +1,31 @@
+model_config:
+  mmf_transformer:
+    transformer_base: bert-base-uncased
+    training_head_type: classification
+    num_labels: 2
+    modalities:
+      - type: text
+        key: text
+        segment_id: 0
+      - type: image
+        key: image
+        embedding_dim: 2048
+        position_dim: 1
+        segment_id: 1
+        layer_norm_eps: 1e-12
+        hidden_dropout_prob: 0.1
+    initializer_range: 0.02
+    initializer_mean: 0.0
+    token_noise_std: 0.01
+    token_noise_mean: 0.0
+    layer_norm_weight_fill: 1.0
+    random_initialize: false
+    freeze_transformer: false
+    freeze_image_encoder: false
+    finetune_lr_multiplier: 1
+    image_encoder:
+      type: resnet152
+      params:
+        pretrained: true
+        pool_type: avg
+        num_output_features: 1

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -1,0 +1,327 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from copy import deepcopy
+from typing import Any, Dict, Type
+
+import torch
+from mmf.common.registry import registry
+from mmf.common.typings import DictConfig
+from mmf.models.transformers.base import (
+    BaseTransformer,
+    BaseTransformerConfigType,
+    BaseTransformerInput,
+)
+from mmf.modules.encoders import MultiModalEncoderBase
+from torch import Tensor, nn
+from transformers.modeling_bert import BertPooler, BertPredictionHeadTransform
+
+
+class ImageEncoder(MultiModalEncoderBase):
+    """Extends the MultiModalEncoderBase class which builds the encoder based on
+    the config parameters. We can set the type of image encoder(resnet50, resnet152,
+    resnext50 etc) and other parameters like num of features, type of pooling etc.
+    """
+
+    def __init__(self, config: DictConfig):
+        super().__init__(config)
+
+    def build(self):
+        self.encoder = self._build_modal_encoder(self.config.image_encoder)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.encoder(x)
+
+
+class MMFTransformerEmbeddings(nn.Module):
+    """Embedding class that can take any number of image or text modalities, each can
+    have their input id, position id and segment id. We generate embeddings of
+    dimension config.hidden_size for each and then first add the three embeddings
+    for each modality to have a modality specific embedding. We then concat the
+    modality specific embeddings to have a joint embedding.
+    """
+
+    def __init__(
+        self,
+        model_config: BaseTransformerConfigType,
+        transformer_config: Dict[str, Any],
+        transformer: Type[nn.Module],
+    ):
+        super().__init__()
+        self.model_config = model_config
+        self.transformer_config = transformer_config
+        self.build_layers()
+        self.init_weights(transformer)
+
+    def build_layers(self):
+
+        for modality in self.model_config.modalities:
+            layer_norm_eps = getattr(
+                modality, "layer_norm_eps", self.transformer_config.layer_norm_eps
+            )
+            if modality.type == "text":
+                setattr(
+                    self,
+                    modality.key + "_embedding",
+                    nn.Embedding(
+                        self.transformer_config.vocab_size,
+                        self.transformer_config.hidden_size,
+                        padding_idx=self.transformer_config.pad_token_id,
+                    ),
+                )
+            elif modality.type == "image":
+                setattr(
+                    self,
+                    modality.key + "_embedding",
+                    nn.Sequential(
+                        nn.Linear(
+                            modality.embedding_dim, self.transformer_config.hidden_size
+                        ),
+                        torch.nn.LayerNorm(
+                            self.transformer_config.hidden_size, eps=layer_norm_eps
+                        ),
+                    ),
+                )
+
+            # Set the position embeddings
+            position_dim = getattr(
+                modality,
+                "position_dim",
+                self.transformer_config.max_position_embeddings,
+            )
+            setattr(
+                self,
+                modality.key + "_pos_embedding",
+                nn.Embedding(position_dim, self.transformer_config.hidden_size),
+            )
+
+            # Layer norm
+            setattr(
+                self,
+                modality.key + "_layer_norm",
+                torch.nn.LayerNorm(
+                    self.transformer_config.hidden_size, eps=layer_norm_eps
+                ),
+            )
+
+            # Dropout
+            hidden_dropout_prob = getattr(
+                modality,
+                "hidden_dropout_prob",
+                self.transformer_config.hidden_dropout_prob,
+            )
+            setattr(self, modality.key + "_dropout", nn.Dropout(hidden_dropout_prob))
+
+        self.token_type_embeddings = nn.Embedding(
+            len(self.model_config.modalities), self.transformer_config.hidden_size
+        )
+
+    def init_weights(self, transformer: Type[nn.Module]):
+        for modality in self.model_config.modalities:
+            if modality.type == "text":
+                setattr(
+                    self,
+                    modality.key + "_embedding",
+                    transformer.embeddings.word_embeddings,
+                )
+                setattr(
+                    self, modality.key + "_layer_norm", transformer.embeddings.LayerNorm
+                )
+
+            pos_embedding_layer = getattr(self, modality.key + "_pos_embedding")
+            pos_embedding_layer.weight = nn.Parameter(
+                deepcopy(transformer.embeddings.position_embeddings.weight.data),
+                requires_grad=True,
+            )
+
+        # Token Type or Segment Embeddings
+        if hasattr(transformer.embeddings, "token_type_embeddings"):
+            token_vocab_size = self.transformer_config.type_vocab_size
+            self.token_type_embeddings.weight.data[:token_vocab_size].copy_(
+                transformer.embeddings.token_type_embeddings.weight
+            )
+            for idx in range(token_vocab_size, len(self.model_config.modalities)):
+                self.token_type_embeddings.weight.data[idx].copy_(
+                    transformer.embeddings.token_type_embeddings.weight.data.mean(dim=0)
+                )
+                # Add random normal noise
+                self.token_type_embeddings.weight.data[idx] += torch.normal(
+                    self.model_config.token_noise_mean,
+                    self.model_config.token_noise_std,
+                    size=self.token_type_embeddings.weight.data[idx].size(),
+                )
+
+    def forward(
+        self,
+        input_ids: Dict[str, Tensor],
+        position_ids: Dict[str, Tensor],
+        segment_ids: Dict[str, Tensor],
+    ) -> Tensor:
+        list_embeddings = []
+        for modality in self.model_config.modalities:
+            total_embedding = getattr(self, modality.key + "_embedding")(
+                input_ids[modality.key]
+            )
+            if modality.key not in position_ids:
+                total_embedding += getattr(self, modality.key + "_pos_embedding")(
+                    position_ids[modality.key]
+                )
+
+            if modality.key in segment_ids:
+                total_embedding += self.token_type_embeddings(segment_ids[modality.key])
+
+            layer_norm_layer = getattr(self, modality.key + "_layer_norm")
+            dropout_layer = getattr(self, modality.key + "_dropout")
+            list_embeddings.append(dropout_layer(layer_norm_layer(total_embedding)))
+
+        return torch.cat(list_embeddings, dim=1)
+
+
+@registry.register_model("mmf_transformer")
+class MMFTransformer(BaseTransformer):
+    def __init__(self, config: BaseTransformerConfigType):
+        super().__init__(config)
+
+    @classmethod
+    def config_path(cls) -> str:
+        return "configs/models/mmf_transformer/defaults.yaml"
+
+    def build_encoders(self):
+        self.image_encoder = ImageEncoder(self.config)
+        if getattr(self.config, "freeze_image_encoder", False):
+            for param in self.image_encoder.parameters():
+                param.requires_grad = False
+
+    def build_embeddings(self):
+        """Initialize the embedding class we will use for multiple
+        modalities (here just text and image). For the text embeeddings we will use the
+        pretrained weights from the trasnformer model rather than training from scratch.
+        """
+        self.embeddings = MMFTransformerEmbeddings(
+            self.config, self.transformer_config, self.transformer
+        )
+
+    def build_heads(self):
+        """Initialize the classifier head. It takes the output of the
+        transformer encoder and passes it through a pooler (we use the pooler from BERT
+        model), then dropout, BertPredictionHeadTransform (which is a liner layer,
+        followed by activation and layer norm) and lastly a linear layer projecting the
+        hidden output to classification labels.
+        """
+        self.classifier = nn.Sequential(
+            BertPooler(self.transformer_config),
+            nn.Dropout(self.transformer_config.hidden_dropout_prob),
+            BertPredictionHeadTransform(self.transformer_config),
+            nn.Linear(self.transformer_config.hidden_size, self.config.num_labels),
+        )
+
+    def preprocess_sample(self, sample_list: Dict[str, Any]) -> BaseTransformerInput:
+        """Preprocess the sample list elements and form a BaseTransformerInput
+        type object. This object standardizes how we represent multiple modalities.
+        Check the definition of this dataclass in BaseTransformer.
+        """
+
+        # Input IDs (or text tokens/image features)
+        input_ids: Dict[str, Tensor] = {}
+        for idx, modality in enumerate(self.config.modalities):
+            if modality.type == "text":
+                if sample_list.input_ids.dim() > 2:
+                    input_ids[modality.key] = sample_list.input_ids[:, idx]
+                else:
+                    input_ids[modality.key] = sample_list.input_ids
+            elif modality.type == "image":
+                if "image" in sample_list:
+                    image_modal = sample_list.image
+                else:
+                    image_modal = sample_list.image_feature_0
+                input_ids[modality.key] = self.image_encoder(image_modal)
+
+        # Position IDs
+        position_ids: Dict[str, Tensor] = {}
+        for modality in self.config.modalities:
+            position_ids[modality.key] = (
+                torch.arange(
+                    0,
+                    input_ids[modality.key].size(1),
+                    dtype=torch.long,
+                    device=input_ids[modality.key].device,
+                )
+                .unsqueeze(0)
+                .expand(input_ids[modality.key].size()[:2])
+            )
+
+        # Segment IDs
+        segment_ids: Dict[str, Tensor] = {}
+        for idx, modality in enumerate(self.config.modalities):
+            if modality.type == "text" and hasattr(sample_list, "segment_ids"):
+                if sample_list.segment_ids.dim() > 2:
+                    segment_ids[modality.key] = sample_list.segment_ids[:, idx]
+                else:
+                    segment_ids[modality.key] = sample_list.segment_ids
+            elif hasattr(modality, "segment_id"):
+                segment_ids[modality.key] = torch.zeros(
+                    input_ids[modality.key].size()[:2],
+                    dtype=torch.long,
+                    device=input_ids[modality.key].device,
+                ).fill_(modality.segment_id)
+
+        # Masks
+        masks: Dict[str, Tensor] = {}
+        for idx, modality in enumerate(self.config.modalities):
+            if modality.type == "text":
+                if sample_list.input_mask.dim() > 2:
+                    masks[modality.key] = sample_list.input_mask[:, idx]
+                else:
+                    masks[modality.key] = sample_list.input_mask
+
+            elif modality.type == "image":
+                if "image_mask" in sample_list:
+                    masks[modality.key] = sample_list.image_mask
+                else:
+                    masks[modality.key] = torch.ones(
+                        input_ids[modality.key].size()[:-1],
+                        dtype=torch.long,
+                        device=input_ids[modality.key].device,
+                    )
+
+        return BaseTransformerInput(input_ids, position_ids, segment_ids, masks)
+
+    def forward(self, sample_list: Dict[str, Any]) -> Dict[str, Tensor]:
+        # Sample preprocess
+        output = self.preprocess_sample(sample_list)
+
+        # Transformer Input Embeddings
+        embedding_output = self.embeddings(
+            input_ids=output.input_ids,
+            position_ids=output.position_ids,
+            segment_ids=output.segment_ids,
+        )
+
+        # Transformer Attention mask
+        # concat the attention masks for all modalities
+        masks = []
+        for modality in self.config.modalities:
+            masks.append(output.masks[modality.key])
+        attention_mask = torch.cat(masks, dim=-1)
+        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+
+        # Transformer Encoder
+        encoded_layers = self.transformer.encoder(
+            embedding_output,  # combined embedding
+            extended_attention_mask,  # combined attention mask
+            [None] * len(self.transformer.encoder.layer),  # head masks
+        )
+
+        # Transformer Heads
+        head_output = self.classifier(encoded_layers[0])
+
+        # Postprocess outputs
+        return self.postprocess_output(head_output)
+
+    def postprocess_output(self, output: Tensor) -> Dict[str, Tensor]:
+        """Postprocess the output from the classifier head and reshape it.
+        This will be used to calculate losses and metrics in mmf.
+        """
+        output_dict = {}
+        output_dict["scores"] = output.contiguous().view(-1, self.config.num_labels)
+        return output_dict

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -45,6 +45,8 @@ class MMFTransformerEmbeddings(nn.Module):
         model_config: BaseTransformerConfigType,
         transformer_config: Dict[str, Any],
         transformer: Type[nn.Module],
+        *args,
+        **kwargs,
     ):
         super().__init__()
         self.model_config = model_config
@@ -178,7 +180,7 @@ class MMFTransformerEmbeddings(nn.Module):
 
 @registry.register_model("mmf_transformer")
 class MMFTransformer(BaseTransformer):
-    def __init__(self, config: BaseTransformerConfigType):
+    def __init__(self, config: BaseTransformerConfigType, *args, **kwargs):
         super().__init__(config)
 
     @classmethod
@@ -203,7 +205,7 @@ class MMFTransformer(BaseTransformer):
     def build_heads(self):
         """Initialize the classifier head. It takes the output of the
         transformer encoder and passes it through a pooler (we use the pooler from BERT
-        model), then dropout, BertPredictionHeadTransform (which is a liner layer,
+        model), then dropout, BertPredictionHeadTransform (which is a linear layer,
         followed by activation and layer norm) and lastly a linear layer projecting the
         hidden output to classification labels.
         """

--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -21,15 +21,31 @@ class BaseTransformerInput:
 
 
 @dataclass
+class BaseModalityConfigType:
+    type: str  # type of modality, text, image, video, audio etc
+    key: str  # name of modality
+    # segment id to be used for modality. Each modality sould have different segment ids
+    segment_id: int
+    embedding_dim: int  # input dimension for modality embedding
+    position_dim: int  # input dimension for position embedding
+    # eps for layer norm, default is base transformer layer_norm_eps
+    layer_norm_eps: float
+    # dropout probability, default is base transformer hidden_dropout_prob
+    hidden_dropout_prob: float
+
+
+@dataclass
 class BaseTransformerConfigType:
     transformer_base: str  # name of transformer base model
     training_head_type: str  # training head type used for initializing head
-    modalities: List[str]  # list of modalities for the model input
+    modalities: List[BaseModalityConfigType]  # list of modalities for the model input
     initializer_range: float  # std dev of the normal distribution to initialize layers
     initializer_mean: float  # mean of the normal distribution to initialize layers
+    token_noise_std: float  # mean of normal noise for token embeddings
+    token_noise_mean: float  # stddev of normal noise for token embeddings
     layer_norm_weight_fill: float  # layer norm weight initialization
     random_initialize: bool  # random initialize whole network
-    freeze_base: bool  # freeze the base transformer
+    freeze_transformer: bool  # freeze the base transformer
     finetune_lr_multiplier: float  # finetune lr multiplier for base transformer
 
 

--- a/projects/mmf_transformer/configs/hateful_memes/defaults.yaml
+++ b/projects/mmf_transformer/configs/hateful_memes/defaults.yaml
@@ -1,0 +1,39 @@
+includes:
+- configs/datasets/hateful_memes/bert.yaml
+
+model_config:
+  mmf_transformer:
+    training_head_type: classification
+    num_labels: 2
+    losses:
+    - cross_entropy
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 1e-5
+    eps: 1e-8
+
+evaluation:
+    metrics:
+    - accuracy
+    - binary_f1
+    - roc_auc
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  max_updates: 22000
+  early_stop:
+    criteria: hateful_memes/roc_auc
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    transformer: transformer

--- a/projects/mmf_transformer/configs/okvqa/defaults.yaml
+++ b/projects/mmf_transformer/configs/okvqa/defaults.yaml
@@ -1,0 +1,47 @@
+model_config:
+  mmf_transformer:
+    training_head_type: classification
+    num_labels: 2253
+    losses:
+    - type: logit_bce
+
+dataset_config:
+  okvqa:
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 128
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+evaluation:
+    metrics:
+    - vqa_accuracy
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  max_updates: 22000
+  early_stop:
+    criteria: okvqa/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    transformer: transformer

--- a/projects/mmf_transformer/configs/vqa2/defaults.yaml
+++ b/projects/mmf_transformer/configs/vqa2/defaults.yaml
@@ -1,0 +1,48 @@
+model_config:
+  mmf_transformer:
+    training_head_type: classification
+    num_labels: 3129
+    losses:
+    - type: logit_bce
+
+dataset_config:
+  vqa2:
+    return_features_info: true
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 64
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 6000
+    num_training_steps: ${training.max_updates}
+
+evaluation:
+  metrics:
+  - vqa_accuracy
+
+training:
+  batch_size: 480
+  lr_scheduler: true
+  max_updates: 11000
+  early_stop:
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    transformer: transformer


### PR DESCRIPTION
Introduces a generalized version of multimodal transformer.

- Extends `BaseTransformer` and builds a modular multimodal transformer model
- Base transformer model can be any model from [transformers](https://github.com/huggingface/transformers)
- Supports n number of modalities
- Adds ability to add separate input, position and segment embeddings for each modality
- text modalities share weight with base transformer model embeddings
- position embeddings use separate embeddings for each modality
- token type/segment embeddings are shared/mean of base transformer token/segment embeddings (if available)


Test:
- Tested with HM, VQA2, OKVQA
