### PR TITLE
[fix] Rename transformer_bbox_processor as bbox_processor already exists

### DIFF
--- a/mmf/configs/datasets/coco/masked.yaml
+++ b/mmf/configs/datasets/coco/masked.yaml
@@ -40,7 +40,7 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.90
-      bbox_processor:
+      transformer_bbox_processor:
         type: transformer_bbox
         params:
           bbox_key: bbox

--- a/mmf/configs/datasets/conceptual_captions/masked.yaml
+++ b/mmf/configs/datasets/conceptual_captions/masked.yaml
@@ -40,7 +40,7 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.90
-      bbox_processor:
+      transformer_bbox_processor:
           type: transformer_bbox
           params:
             bbox_key: bbox

--- a/mmf/configs/datasets/gqa/masked.yaml
+++ b/mmf/configs/datasets/gqa/masked.yaml
@@ -38,7 +38,7 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.90
-      bbox_processor:
+      transformer_bbox_processor:
           type: transformer_bbox
           params:
             bbox_key: bbox

--- a/mmf/configs/datasets/mmimdb/masked.yaml
+++ b/mmf/configs/datasets/mmimdb/masked.yaml
@@ -36,7 +36,7 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.90
-      bbox_processor:
+      transformer_bbox_processor:
           type: transformer_bbox
           params:
             bbox_key: bbox

--- a/mmf/configs/datasets/vqa2/masked.yaml
+++ b/mmf/configs/datasets/vqa2/masked.yaml
@@ -39,7 +39,7 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.90
-      bbox_processor:
+      transformer_bbox_processor:
           type: transformer_bbox
           params:
             bbox_key: bbox

--- a/mmf/datasets/builders/coco/masked_dataset.py
+++ b/mmf/datasets/builders/coco/masked_dataset.py
@@ -19,8 +19,10 @@ class MaskedCOCODataset(COCODataset):
 
         if self._use_features is True:
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
 
             if self.config.get("use_image_feature_masks", False):
                 current_sample.update(

--- a/mmf/datasets/builders/gqa/dataset.py
+++ b/mmf/datasets/builders/gqa/dataset.py
@@ -33,8 +33,10 @@ class GQADataset(MMFDataset):
 
         if self._use_features is True:
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
             current_sample.update(features)
 
         # Depending on whether we are using soft copy this can add
@@ -68,8 +70,6 @@ class GQADataset(MMFDataset):
             else:
                 answer = self.answer_processor.idx2word(answer_id)
 
-            predictions.append(
-                {"questionId": question_id.item(), "prediction": answer,}
-            )
+            predictions.append({"questionId": question_id.item(), "prediction": answer})
 
         return predictions

--- a/mmf/datasets/builders/gqa/masked_dataset.py
+++ b/mmf/datasets/builders/gqa/masked_dataset.py
@@ -20,8 +20,10 @@ class MaskedGQADataset(MMFDataset):
         if self._use_features is True:
             features = self.features_db[idx]
 
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
 
             if self.config.get("use_image_feature_masks", False):
                 current_sample.update(

--- a/mmf/datasets/builders/hateful_memes/dataset.py
+++ b/mmf/datasets/builders/hateful_memes/dataset.py
@@ -45,8 +45,10 @@ class HatefulMemesFeaturesDataset(MMFDataset):
         # Instead of using idx directly here, use sample_info to fetch
         # the features as feature_path has been dynamically added
         features = self.features_db.get(sample_info)
-        if hasattr(self, "bbox_processor"):
-            features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+        if hasattr(self, "transformer_bbox_processor"):
+            features["image_info_0"] = self.transformer_bbox_processor(
+                features["image_info_0"]
+            )
         current_sample.update(features)
 
         if "label" in sample_info:
@@ -118,7 +120,5 @@ def generate_prediction(report):
     for idx, image_id in enumerate(report.id):
         proba = probabilities[idx].item()
         label = labels[idx].item()
-        predictions.append(
-            {"id": image_id.item(), "proba": proba, "label": label,}
-        )
+        predictions.append({"id": image_id.item(), "proba": proba, "label": label})
     return predictions

--- a/mmf/datasets/builders/mmimdb/dataset.py
+++ b/mmf/datasets/builders/mmimdb/dataset.py
@@ -30,8 +30,10 @@ class MMIMDbFeaturesDataset(MMFDataset):
 
         if self._use_features is True:
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
             current_sample.update(features)
 
         processed = self.answer_processor({"answers": sample_info["genres"]})

--- a/mmf/datasets/builders/mmimdb/masked_dataset.py
+++ b/mmf/datasets/builders/mmimdb/masked_dataset.py
@@ -23,8 +23,10 @@ class MaskedMMImdbDataset(VQA2Dataset):
         if self._use_features is True:
             features = self.features_db[idx]
 
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
 
             if self.config.get("use_image_feature_masks", False):
                 current_sample.update(

--- a/mmf/datasets/builders/nlvr2/dataset.py
+++ b/mmf/datasets/builders/nlvr2/dataset.py
@@ -29,15 +29,19 @@ class NLVR2Dataset(VQA2Dataset):
             # Load img0 and img1 features
             sample_info["feature_path"] = "{}-img0.npy".format(identifier)
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
             current_sample.img0 = Sample()
             current_sample.img0.update(features)
 
             sample_info["feature_path"] = "{}-img1.npy".format(identifier)
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
             current_sample.img1 = Sample()
             current_sample.img1.update(features)
 

--- a/mmf/datasets/builders/visual_entailment/dataset.py
+++ b/mmf/datasets/builders/visual_entailment/dataset.py
@@ -36,8 +36,10 @@ class VisualEntailmentDataset(VQA2Dataset):
             # Load img0 and img1 features
             sample_info["feature_path"] = "{}.npy".format(identifier)
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
             current_sample.update(features)
 
         label = LABEL_TO_INT_MAPPING[sample_info["gold_label"]]

--- a/mmf/datasets/builders/vqa2/dataset.py
+++ b/mmf/datasets/builders/vqa2/dataset.py
@@ -81,8 +81,10 @@ class VQA2Dataset(MMFDataset):
 
         if self._use_features is True:
             features = self.features_db[idx]
-            if hasattr(self, "bbox_processor"):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if hasattr(self, "transformer_bbox_processor"):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
             current_sample.update(features)
 
         # Add details for OCR like OCR bbox, vectors, tokens here

--- a/mmf/datasets/builders/vqa2/masked_dataset.py
+++ b/mmf/datasets/builders/vqa2/masked_dataset.py
@@ -23,8 +23,10 @@ class MaskedVQA2Dataset(VQA2Dataset):
         if self._use_features is True:
             features = self.features_db[idx]
 
-            if self.config.get("bbox_processor", False):
-                features["image_info_0"] = self.bbox_processor(features["image_info_0"])
+            if self.config.get("transformer_bbox_processor", False):
+                features["image_info_0"] = self.transformer_bbox_processor(
+                    features["image_info_0"]
+                )
 
             if self.config.get("use_image_feature_masks", False):
                 current_sample.update(

--- a/projects/vilbert/configs/hateful_memes/defaults.yaml
+++ b/projects/vilbert/configs/hateful_memes/defaults.yaml
@@ -21,12 +21,12 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 128
-      bbox_processor:
-          type: transformer_bbox
-          params:
-            bbox_key: bbox
-            image_width_key: image_width
-            image_height_key: image_height
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
 
 optimizer:
   type: adam_w

--- a/projects/vilbert/configs/mmimdb/defaults.yaml
+++ b/projects/vilbert/configs/mmimdb/defaults.yaml
@@ -21,7 +21,7 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 256
-      bbox_processor:
+      transformer_bbox_processor:
         type: transformer_bbox
         params:
           bbox_key: bbox

--- a/projects/vilbert/configs/nlvr2/defaults.yaml
+++ b/projects/vilbert/configs/nlvr2/defaults.yaml
@@ -18,12 +18,12 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 128
-      bbox_processor:
-          type: transformer_bbox
-          params:
-            bbox_key: bbox
-            image_width_key: image_width
-            image_height_key: image_height
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
 
 optimizer:
   type: adam_w

--- a/projects/vilbert/configs/visual_entailment/defaults.yaml
+++ b/projects/vilbert/configs/visual_entailment/defaults.yaml
@@ -18,12 +18,12 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 128
-      bbox_processor:
-          type: transformer_bbox
-          params:
-            bbox_key: bbox
-            image_width_key: image_width
-            image_height_key: image_height
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
 
 optimizer:
   type: adam_w

--- a/projects/vilbert/configs/vizwiz/defaults.yaml
+++ b/projects/vilbert/configs/vizwiz/defaults.yaml
@@ -22,12 +22,12 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 128
-      bbox_processor:
-          type: transformer_bbox
-          params:
-            bbox_key: bbox
-            image_width_key: image_width
-            image_height_key: image_height
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
 
 optimizer:
   type: adam_w

--- a/projects/vilbert/configs/vqa2/defaults.yaml
+++ b/projects/vilbert/configs/vqa2/defaults.yaml
@@ -18,12 +18,12 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 128
-      bbox_processor:
-          type: transformer_bbox
-          params:
-            bbox_key: bbox
-            image_width_key: image_width
-            image_height_key: image_height
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
 
 optimizer:
   type: adam_w


### PR DESCRIPTION
Summary: Fix `bbox_processor` bug due to duplicate name of processors. Rename to `transformer_bbox_processor` for transformer specific bbox processor

Differential Revision: D22655123

