### PR TITLE
[fix] Move anomaly detection to an option

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -116,6 +116,12 @@ training:
     # to enable evaluation every log_interval
     evaluate_metrics: false
 
+    # This will enable anomaly detection mode in PyTorch. Use this for debugging
+    # purposes if you see NaN issues in your experiments.
+    # Warning: As per PyTorch docs, this usually slows down your code and should
+    # only be used for debugging purposes
+    detect_anomaly: false
+
 # Configuration for evaluation
 evaluation:
     # Metrics for evaluation

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -26,7 +26,7 @@ class TrainerTrainingLoopMixin(ABC):
         else:
             self.max_updates = math.inf
 
-        torch.autograd.set_detect_anomaly(True)
+        torch.autograd.set_detect_anomaly(self.training_config.detect_anomaly)
 
         self.writer.write("Starting training...")
         self.model.train()


### PR DESCRIPTION
- As per PyTorch docs anomaly detection should only be turned on for
debugging purposes and can slow down things
- This warning wasn't there when the code was initially added so we
missed this. Setting this to false will drastically improve performance
of all our models.

Thanks @ronghanghu for figuring this out.

Test Plan:
Tested locally on VisualBERT with the setting off