### PR TITLE
[feat,fix] Logger overhaul, shift to Python logger

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -384,7 +384,7 @@ class Registry:
             and value == default
             and no_warning is False
         ):
-            cls.mapping["state"]["writer"].write(
+            cls.mapping["state"]["writer"].warning(
                 "Key {} is not present in registry, returning default value "
                 "of {}".format(original_name, default)
             )

--- a/mmf/common/report.py
+++ b/mmf/common/report.py
@@ -5,8 +5,6 @@ from collections import OrderedDict
 
 import torch
 
-from mmf.common.registry import registry
-
 
 class Report(OrderedDict):
     def __init__(self, batch, model_output=None, *args):
@@ -24,7 +22,6 @@ class Report(OrderedDict):
                     "collections.abc.Mapping".format(idx, arg)
                 )
 
-        self.writer = registry.get("writer")
         self.batch_size = batch.get_batch_size()
         self.warning_string = (
             "Updating forward report with key {}"

--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import csv
 import json
+import logging
 import os
 
 import torch
@@ -19,13 +20,14 @@ from mmf.utils.general import (
 )
 from mmf.utils.timer import Timer
 
+logger = logging.getLogger(__name__)
+
 
 class TestReporter(Dataset):
     def __init__(self, multi_task_instance):
         self.test_task = multi_task_instance
         self.task_type = multi_task_instance.dataset_type
         self.config = registry.get("config")
-        self.writer = registry.get("writer")
         self.report = []
         self.timer = Timer()
         self.training_config = self.config.training
@@ -64,7 +66,7 @@ class TestReporter(Dataset):
             return False
         else:
             self.current_dataset = self.datasets[self.current_dataset_idx]
-            self.writer.write("Predicting for " + self.current_dataset.dataset_name)
+            logger.info(f"Predicting for {self.current_dataset.dataset_name}")
             return True
 
     def flush_report(self):
@@ -90,10 +92,8 @@ class TestReporter(Dataset):
             filepath = os.path.join(self.report_folder, filename + ".json")
             self.json_dump(filepath)
 
-        self.writer.write(
-            "Wrote evalai predictions for {} to {}".format(
-                name, os.path.abspath(filepath)
-            )
+        logger.info(
+            f"Wrote evalai predictions for {name} to {os.path.abspath(filepath)}"
         )
         self.report = []
 
@@ -117,7 +117,7 @@ class TestReporter(Dataset):
             ),
             num_workers=self.num_workers,
             pin_memory=self.config.training.pin_memory,
-            **other_args
+            **other_args,
         )
 
     def _add_extra_args_for_dataloader(self, other_args=None):

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -33,8 +33,8 @@ training:
     # Whether MMF should log or not, Default: False, which means
     # mmf will log by default
     should_not_log: false
-    # Whether to capture stdout logs by the logger. Default: True
-    stdout_capture: true
+    # Whether the colored logs should be used
+    colored_logs: true
 
     # Tensorboard control, by default tensorboard is disabled
     tensorboard: false

--- a/mmf/datasets/base_dataset.py
+++ b/mmf/datasets/base_dataset.py
@@ -24,7 +24,6 @@ class BaseDataset(Dataset):
         self.config = config
         self._dataset_name = dataset_name
         self._dataset_type = dataset_type
-        self.writer = registry.get("writer")
         self._global_config = registry.get("config")
         self._device = registry.get("current_device")
         self.use_cuda = "cuda" in str(self._device)

--- a/mmf/datasets/builders/clevr/builder.py
+++ b/mmf/datasets/builders/clevr/builder.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 import os
 import zipfile
@@ -11,12 +12,13 @@ from mmf.datasets.builders.clevr.dataset import CLEVRDataset
 from mmf.utils.download import download
 from mmf.utils.general import get_mmf_root
 
+logger = logging.getLogger(__name__)
+
 
 @registry.register_builder("clevr")
 class CLEVRBuilder(BaseDatasetBuilder):
     def __init__(self):
         super().__init__("clevr")
-        self.writer = registry.get("writer")
         self.dataset_class = CLEVRDataset
 
     @classmethod
@@ -39,7 +41,7 @@ class CLEVRBuilder(BaseDatasetBuilder):
         # Either if the zip file is already present or if there are some
         # files inside the folder we don't continue download process
         if os.path.exists(local_filename):
-            self.writer.write("CLEVR dataset is already present. Skipping download.")
+            logger.info("CLEVR dataset is already present. Skipping download.")
             return
 
         if (
@@ -48,10 +50,10 @@ class CLEVRBuilder(BaseDatasetBuilder):
         ):
             return
 
-        self.writer.write("Downloading the CLEVR dataset now")
+        logger.info("Downloading the CLEVR dataset now")
         download(CLEVR_DOWNLOAD_URL, download_folder, CLEVR_DOWNLOAD_URL.split("/")[-1])
 
-        self.writer.write("Downloaded. Extracting now. This can take time.")
+        logger.info("Downloaded. Extracting now. This can take time.")
         with zipfile.ZipFile(local_filename, "r") as zip_ref:
             zip_ref.extractall(download_folder)
 

--- a/mmf/datasets/builders/coco/builder.py
+++ b/mmf/datasets/builders/coco/builder.py
@@ -32,7 +32,7 @@ class COCOBuilder(VQA2Builder):
             )
 
             registry.register(
-                self.dataset_name + "_answer_processor", self.dataset.answer_processor,
+                self.dataset_name + "_answer_processor", self.dataset.answer_processor
             )
 
     @classmethod

--- a/mmf/datasets/builders/hateful_memes/builder.py
+++ b/mmf/datasets/builders/hateful_memes/builder.py
@@ -68,6 +68,4 @@ class HatefulMemesBuilder(MMFDatasetBuilder):
                 self.dataset_name + "_text_vocab_size",
                 self.dataset.text_processor.get_vocab_size(),
             )
-        registry.register(
-            self.dataset_name + "_num_final_outputs", 2,
-        )
+        registry.register(self.dataset_name + "_num_final_outputs", 2)

--- a/mmf/datasets/builders/visual_dialog/builder.py
+++ b/mmf/datasets/builders/visual_dialog/builder.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import logging
 import os
 import shutil
 
@@ -9,6 +10,8 @@ from mmf.datasets.builders.visual_genome.builder import VisualGenomeBuilder
 from mmf.utils.download import decompress, download
 from mmf.utils.general import get_mmf_root
 
+logger = logging.getLogger(__name__)
+
 
 @registry.register_builder("visual_dialog")
 class VisualDialogBuilder(VisualGenomeBuilder):
@@ -16,7 +19,6 @@ class VisualDialogBuilder(VisualGenomeBuilder):
         super().__init__()
         self.dataset_name = "visual_dialog"
         self.dataset_class = VisualDialogDataset
-        self.writer = registry.get("writer")
 
     @classmethod
     def config_path(cls):

--- a/mmf/datasets/builders/visual_genome/builder.py
+++ b/mmf/datasets/builders/visual_genome/builder.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import logging
 import os
 import shutil
 
@@ -9,6 +10,8 @@ from mmf.datasets.builders.vqa2.builder import VQA2Builder
 from mmf.utils.download import decompress, download
 from mmf.utils.general import get_mmf_root
 
+logger = logging.getLogger(__name__)
+
 
 @registry.register_builder("visual_genome")
 class VisualGenomeBuilder(VQA2Builder):
@@ -17,7 +20,6 @@ class VisualGenomeBuilder(VQA2Builder):
         self.dataset_name = "visual_genome"
         self.dataset_proper_name = "Visual Genome"
         self.dataset_class = VisualGenomeDataset
-        self.writer = registry.get("writer")
 
     @classmethod
     def config_path(cls):
@@ -74,22 +76,18 @@ class VisualGenomeBuilder(VQA2Builder):
             )
             != 0
         ):
-            self.writer.write(
-                "{} {} already present. Skipping download.".format(
-                    self.dataset_proper_name, file_type
-                )
+            logger.info(
+                f"{self.dataset_proper_name} {file_type} already present. "
+                + "Skipping download."
             )
             return extraction_folder
 
-        self.writer.write(
-            "Downloading the {} {} now.".format(self.dataset_proper_name, file_type)
-        )
+        logger.info(f"Downloading the {self.dataset_proper_name} {file_type} now.")
         download(url, download_folder, url.split("/")[-1])
 
-        self.writer.write(
-            "Extracting the {} {} now. This may take time".format(
-                self.dataset_proper_name, file_type
-            )
+        logger.info(
+            f"Extracting the {self.dataset_proper_name} {file_type} now. "
+            + "This may take time"
         )
         decompress(download_folder, url.split("/")[-1])
 

--- a/mmf/datasets/builders/vqa2/dataset.py
+++ b/mmf/datasets/builders/vqa2/dataset.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import logging
 import os
 
 import torch
@@ -7,6 +8,8 @@ import tqdm
 from mmf.common.sample import Sample
 from mmf.datasets.mmf_dataset import MMFDataset
 from mmf.utils.distributed import is_master
+
+logger = logging.getLogger(__name__)
 
 
 class VQA2Dataset(MMFDataset):
@@ -29,10 +32,9 @@ class VQA2Dataset(MMFDataset):
             return
 
         if hasattr(self, "_should_fast_read") and self._should_fast_read is True:
-            self.writer.write(
-                "Starting to fast read {} {} dataset".format(
-                    self.dataset_name, self.dataset_type
-                )
+            logger.info(
+                f"Starting to fast read {self.dataset_name} {self.dataset_type} "
+                + "dataset"
             )
             self.cache = {}
             for idx in tqdm.tqdm(

--- a/mmf/datasets/databases/features_database.py
+++ b/mmf/datasets/databases/features_database.py
@@ -1,13 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import logging
 from multiprocessing.pool import ThreadPool
 
 import tqdm
 
-from mmf.common.registry import registry
 from mmf.datasets.databases.image_database import ImageDatabase
 from mmf.datasets.databases.readers.feature_readers import FeatureReader
 from mmf.utils.distributed import is_master
 from mmf.utils.general import get_absolute_path
+
+logger = logging.getLogger(__name__)
 
 
 class FeaturesDatabase(ImageDatabase):
@@ -20,7 +22,6 @@ class FeaturesDatabase(ImageDatabase):
         self.feature_key = config.get("feature_key", "feature_path")
         self.feature_key = feature_key if feature_key else self.feature_key
         self._fast_read = config.get("fast_read", False)
-        self.writer = registry.get("writer")
 
         path = path.split(",")
 
@@ -37,8 +38,9 @@ class FeaturesDatabase(ImageDatabase):
         self._should_return_info = config.get("return_features_info", True)
 
         if self._fast_read:
-            self.writer.write("Fast reading features from {}".format(", ".join(path)))
-            self.writer.write("Hold tight, this may take a while...")
+            path = ", ".join(path)
+            logger.info(f"Fast reading features from {path}")
+            logger.info("Hold tight, this may take a while...")
             self._threaded_read()
 
     def _threaded_read(self):

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -67,10 +67,10 @@ Example::
 """
 
 import copy
+import logging
 import os
 import random
 import re
-import sys
 import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -86,6 +86,8 @@ from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
 from mmf.utils.text import VocabDict
 from mmf.utils.vocab import Vocab, WordToVectorDict
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -129,13 +131,11 @@ class Processor:
 
     Args:
         config (DictConfig): DictConfig containing ``type`` of the processor to
-                             be initialized and ``params`` of that procesor.
+                             be initialized and ``params`` of that processor.
 
     """
 
     def __init__(self, config: ProcessorConfigType, *args, **kwargs):
-        self.writer = registry.get("writer")
-
         if not hasattr(config, "type"):
             raise AttributeError(
                 "Config must have 'type' attribute to specify type of processor"
@@ -145,10 +145,10 @@ class Processor:
 
         params = {}
         if not hasattr(config, "params"):
-            warnings.warn(
+            logger.warning(
                 "Config doesn't have 'params' attribute to "
                 "specify parameters of the processor "
-                "of type {}. Setting to default {{}}".format(config.type)
+                f"of type {config.type}. Setting to default {{}}"
             )
         else:
             params = config.params
@@ -246,8 +246,6 @@ class VocabProcessor(BaseProcessor):
         self._init_extras(config)
 
     def _init_extras(self, config, *args, **kwargs):
-        writer = registry.get("writer")
-        self.writer = writer if writer is not None else sys.stdout
         self.preprocessor = None
 
         if hasattr(config, "max_length"):
@@ -436,7 +434,7 @@ class FastTextProcessor(VocabProcessor):
             needs_download = True
 
         if needs_download:
-            self.writer.write("Downloading FastText bin")
+            logger.info("Downloading FastText bin")
             model_file = self._download_model()
 
         self.model_file = model_file
@@ -452,7 +450,7 @@ class FastTextProcessor(VocabProcessor):
             return model_file_path
 
         if PathManager.exists(model_file_path):
-            self.writer.write(f"Vectors already present at {model_file_path}.")
+            logger.info(f"Vectors already present at {model_file_path}.")
             return model_file_path
 
         import requests
@@ -479,7 +477,7 @@ class FastTextProcessor(VocabProcessor):
 
             pbar.close()
 
-        self.writer.write(f"fastText bin downloaded at {model_file_path}.")
+        logger.info(f"fastText bin downloaded at {model_file_path}.")
 
         return model_file_path
 
@@ -489,12 +487,12 @@ class FastTextProcessor(VocabProcessor):
 
         from fasttext import load_model
 
-        self.writer.write("Loading fasttext model now from %s" % model_file)
+        logger.info(f"Loading fasttext model now from {model_file}")
 
         self.model = load_model(model_file)
         # String to Vector
         self.stov = WordToVectorDict(self.model)
-        self.writer.write("Finished loading fasttext model")
+        logger.info("Finished loading fasttext model")
 
         self._already_loaded = True
 
@@ -537,7 +535,6 @@ class VQAAnswerProcessor(BaseProcessor):
     DEFAULT_NUM_ANSWERS = 10
 
     def __init__(self, config, *args, **kwargs):
-        self.writer = registry.get("writer")
         if not hasattr(config, "vocab_file"):
             raise AttributeError(
                 "'vocab_file' argument required, but not "

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -67,7 +67,6 @@ class BaseModel(nn.Module):
         super().__init__()
         self.config = config
         self._logged_warning = {"losses_present": False}
-        self.writer = registry.get("writer")
         self._is_pretrained = False
 
     @property

--- a/mmf/models/m4c.py
+++ b/mmf/models/m4c.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import functools
+import logging
 import math
 
 import torch
@@ -17,6 +18,8 @@ from mmf.common.registry import registry
 from mmf.models.base_model import BaseModel
 from mmf.modules.encoders import ImageFeatureEncoder
 from mmf.modules.layers import ClassifierLayer
+
+logger = logging.getLogger(__name__)
 
 
 @registry.register_model("m4c")
@@ -55,18 +58,17 @@ class M4C(BaseModel):
                 {"module": self.text_bert, "lr_scale": self.config.lr_scale_text_bert}
             )
         else:
-            self.writer.write("NOT initializing text_bert from BERT_BASE")
+            logger.info("NOT initializing text_bert from BERT_BASE")
             self.text_bert = TextBert(self.text_bert_config)
 
         # if the text bert output dimension doesn't match the
         # multimodal transformer (mmt) hidden dimension,
         # add a linear projection layer between the two
         if self.mmt_config.hidden_size != TEXT_BERT_HIDDEN_SIZE:
-            self.writer.write(
-                "Projecting text_bert output to {} dim".format(
-                    self.mmt_config.hidden_size
-                )
+            logger.info(
+                f"Projecting text_bert output to {self.mmt_config.hidden_size} dim"
             )
+
             self.text_bert_out_linear = nn.Linear(
                 TEXT_BERT_HIDDEN_SIZE, self.mmt_config.hidden_size
             )

--- a/mmf/models/movie_mcan.py
+++ b/mmf/models/movie_mcan.py
@@ -95,9 +95,7 @@ class MoVieMcan(BaseModel):
         feature_embedding = TwoBranchEmbedding(
             getattr(self, attr + "_feature_dim"), **embedding_kwargs
         )
-        setattr(
-            self, attr + "_feature_embeddings_list", feature_embedding,
-        )
+        setattr(self, attr + "_feature_embeddings_list", feature_embedding)
 
     def _get_embeddings_attr(self, attr: str):
         embedding_attr1 = attr

--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -129,7 +129,6 @@ class MMFLoss(nn.Module):
         super().__init__()
         if params is None:
             params = {}
-        self.writer = registry.get("writer")
 
         is_mapping = isinstance(params, collections.abc.MutableMapping)
 
@@ -376,7 +375,6 @@ class MultiLoss(nn.Module):
         super().__init__()
         self.losses = []
         self.losses_weights = []
-        self.writer = registry.get("writer")
 
         self.loss_names = []
 

--- a/mmf/modules/metrics.py
+++ b/mmf/modules/metrics.py
@@ -71,7 +71,6 @@ class Metrics:
         if not isinstance(metric_list, collections.abc.Sequence):
             metric_list = [metric_list]
 
-        self.writer = registry.get("writer")
         self.metrics = self._init_metrics(metric_list)
 
     def _init_metrics(self, metric_list):

--- a/mmf/trainers/base_trainer.py
+++ b/mmf/trainers/base_trainer.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 
 from mmf.common import typings as mmf_typings
 from mmf.common.registry import registry
-from mmf.utils.logger import Logger
 
 
 @registry.register_trainer("base")
@@ -16,14 +15,6 @@ class BaseTrainer(ABC):
     def load(self):
         # Set run type
         self.run_type = self.config.get("run_type", "train")
-
-        # Check if logger is already defined, else init it
-        writer = registry.get("writer", no_warning=True)
-        if writer:
-            self.writer = writer
-        else:
-            self.writer = Logger(self.config)
-            registry.register("writer", self.writer)
 
         # Print configuration
         configuration = registry.get("configuration", no_warning=True)

--- a/mmf/trainers/callbacks/checkpoint.py
+++ b/mmf/trainers/callbacks/checkpoint.py
@@ -1,8 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import logging
 
-from mmf.common.registry import registry
 from mmf.trainers.callbacks.base import Callback
 from mmf.utils.checkpoint import Checkpoint
+
+logger = logging.getLogger(__name__)
 
 
 class CheckpointCallback(Callback):
@@ -19,7 +21,6 @@ class CheckpointCallback(Callback):
 
         self._checkpoint = Checkpoint(trainer)
         self.checkpoint_interval = self.config.training.checkpoint_interval
-        self.writer = registry.get("writer")
 
     @property
     def checkpoint(self):
@@ -30,7 +31,7 @@ class CheckpointCallback(Callback):
 
     def on_batch_end(self, **kwargs):
         if self.trainer.num_updates % self.checkpoint_interval == 0:
-            self.writer.write("Checkpoint time. Saving a checkpoint.")
+            logger.info("Checkpoint time. Saving a checkpoint.")
             self._checkpoint.save(
                 self.trainer.num_updates,
                 self.trainer.current_iteration,

--- a/mmf/trainers/core/device.py
+++ b/mmf/trainers/core/device.py
@@ -1,10 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import logging
 from abc import ABC
 
 import torch
 
 from mmf.common.registry import registry
+
+logger = logging.getLogger(__name__)
 
 
 class TrainerDeviceMixin(ABC):
@@ -33,14 +36,7 @@ class TrainerDeviceMixin(ABC):
             self.device = torch.device("cpu")
 
         registry.register("current_device", self.device)
-
-        if "cuda" in str(self.device):
-            device_info = "CUDA Device {} is: {}".format(
-                self.config.distributed.rank,
-                torch.cuda.get_device_name(self.local_rank),
-            )
-            registry.register("global_device", self.config.distributed.rank)
-            self.writer.write(device_info, log_all=True)
+        registry.register("global_device", self.config.distributed.rank)
 
     def parallelize_model(self) -> None:
         registry.register("data_parallel", False)

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import logging
 from abc import ABC
 from typing import Any, Dict, Tuple, Type
 
@@ -9,6 +10,8 @@ import tqdm
 from mmf.common.meter import Meter
 from mmf.common.report import Report
 from mmf.utils.distributed import is_master
+
+logger = logging.getLogger(__name__)
 
 
 class TrainerEvaluationLoopMixin(ABC):
@@ -50,8 +53,7 @@ class TrainerEvaluationLoopMixin(ABC):
         reporter = self.dataset_loader.get_test_reporter(dataset_type)
         with torch.no_grad():
             self.model.eval()
-            message = f"Starting {dataset_type} inference predictions"
-            self.writer.write(message)
+            logger.info(f"Starting {dataset_type} inference predictions")
 
             while reporter.next_dataset():
                 dataloader = reporter.get_dataloader()
@@ -62,5 +64,5 @@ class TrainerEvaluationLoopMixin(ABC):
                     report = Report(prepared_batch, model_output)
                     reporter.add_to_report(report, self.model)
 
-            self.writer.write("Finished predicting")
+            logger.info("Finished predicting")
             self.model.train()

--- a/mmf/trainers/core/profiling.py
+++ b/mmf/trainers/core/profiling.py
@@ -1,9 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import logging
 from abc import ABC
 from typing import Type
 
 from mmf.utils.timer import Timer
+
+logger = logging.getLogger(__name__)
 
 
 class TrainerProfilingMixin(ABC):
@@ -12,5 +15,5 @@ class TrainerProfilingMixin(ABC):
     def profile(self, text: str) -> None:
         if self.training_config.logger_level != "debug":
             return
-        self.writer.write(text + ": " + self.profiler.get_time_since_start(), "debug")
+        logging.debug(f"{text}: {self.profiler.get_time_since_start()}")
         self.profiler.reset()

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -63,7 +63,7 @@ def build_model(config):
     model_class = registry.get_model_class(model_name)
 
     if model_class is None:
-        registry.get("writer").write("No model registered for name: %s" % model_name)
+        raise RuntimeError(f"No model registered for name: {model_name}")
     model = model_class(config)
 
     if hasattr(model, "build"):

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -2,6 +2,7 @@
 
 import glob
 import importlib
+import logging
 import os
 import sys
 import warnings
@@ -20,6 +21,8 @@ try:
     import git
 except ImportError:
     git = None
+
+logger = logging.getLogger(__name__)
 
 
 def _hack_imports():
@@ -172,7 +175,7 @@ class Checkpoint:
 
     def _load(self, file, force=False, load_zoo=False, load_pretrained=False):
         ckpt_config = self.config.checkpoint
-        self.trainer.writer.write("Loading checkpoint")
+        logger.info("Loading checkpoint")
         if load_zoo:
             ckpt, should_continue = self._load_from_zoo(file)
             if not should_continue:
@@ -206,7 +209,7 @@ class Checkpoint:
 
             self.trainer.early_stop_callback.early_stopping.init_from_checkpoint(ckpt)
 
-            self.trainer.writer.write("Checkpoint loaded")
+            logger.info("Checkpoint loaded")
 
             reset_counts = ckpt_config.reset.all or ckpt_config.reset.counts
 
@@ -220,7 +223,7 @@ class Checkpoint:
             try:
                 self.trainer.optimizer.load_state_dict(ckpt["optimizer"])
             except ValueError:
-                self.trainer.writer.write(
+                logger.info(
                     "Optimizer failed to load. Try with "
                     + "checkpoint.reset.optimizer=True"
                 )
@@ -289,11 +292,9 @@ class Checkpoint:
                         and own_attr.replace(key, "")
                         == formatted_attr.replace(value, "")
                     ):
-                        self.trainer.writer.write(
-                            "Copying " + own_attr + " from " + attr
-                        )
+                        logger.info("Copying " + own_attr + " from " + attr)
                         own_state[own_attr].copy_(ckpt[attr])
-        self.trainer.writer.write("Pretrained model loaded")
+        logger.info("Pretrained model loaded")
 
     def upgrade_state_dict(self, state_dict):
         data_parallel = registry.get("data_parallel") or registry.get("distributed")
@@ -432,7 +433,7 @@ class Checkpoint:
 
     def restore(self):
         synchronize()
-        self.trainer.writer.write("Restoring checkpoint")
+        logger.info("Restoring checkpoint")
         best_path = os.path.join(self.ckpt_foldername, self.ckpt_prefix + "best.ckpt")
 
         if PathManager.exists(best_path):

--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # Inspired from maskrcnn_benchmark, fairseq
+import logging
 import os
 import pickle
 import socket
@@ -11,6 +12,7 @@ from torch import distributed as dist
 
 MAX_SIZE_LIMIT = 65533
 BYTE_SIZE = 256
+logger = logging.getLogger(__name__)
 
 
 def synchronize():
@@ -222,11 +224,9 @@ def distributed_init(config):
     if dist.is_initialized():
         warnings.warn("Distributed is already initialized, cannot initialize twice!")
     else:
-        print(
-            "Distributed Init (Rank {}): {}".format(
-                config.distributed.rank, config.distributed.init_method
-            ),
-            flush=True,
+        logger.info(
+            f"Distributed Init (Rank {config.distributed.rank}): "
+            f"{config.distributed.init_method}"
         )
         dist.init_process_group(
             backend=config.distributed.backend,
@@ -234,11 +234,9 @@ def distributed_init(config):
             world_size=config.distributed.world_size,
             rank=config.distributed.rank,
         )
-        print(
-            "Initialized Host {} as Rank {}".format(
-                socket.gethostname(), config.distributed.rank
-            ),
-            flush=True,
+        logger.info(
+            f"Initialized Host {socket.gethostname()} as Rank "
+            f"{config.distributed.rank}"
         )
 
         # perform a dummy all-reduce to initialize the NCCL communicator
@@ -275,11 +273,3 @@ def suppress_output(is_master):
     # Log warnings only once
     warnings.warn = warn
     warnings.simplefilter("once", UserWarning)
-
-
-# def is_master(config=None):
-#     if config is None:
-#         from mmf.common.registry import registry
-#         config = registry.get("configuration").args
-
-#     return config.distributed.rank == 0

--- a/mmf/utils/env.py
+++ b/mmf/utils/env.py
@@ -101,12 +101,13 @@ def setup_imports():
         root_folder = os.path.dirname(os.path.abspath(__file__))
         root_folder = os.path.join(root_folder, "..")
 
-        environment_pythia_path = os.environ.get("PYTHIA_PATH")
+        environment_mmf_path = os.environ.get("MMF_PATH", os.environ.get("PYTHIA_PATH"))
 
-        if environment_pythia_path is not None:
-            root_folder = environment_pythia_path
+        if environment_mmf_path is not None:
+            root_folder = environment_mmf_path
 
         registry.register("pythia_path", root_folder)
+        registry.register("mmf_path", root_folder)
 
     trainer_folder = os.path.join(root_folder, "trainers")
     trainer_pattern = os.path.join(trainer_folder, "**", "*.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.isort]
-known_third_party = ["PIL", "cv2", "demjson", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme", "recommonmark", "requests", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "tqdm", "transformers"]
+known_third_party = ["PIL", "cv2", "demjson", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme", "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "torch", "torchtext", "torchvision", "tqdm", "transformers"]
 skip_glob = "**/build/**,website/**"
 multi_line_output = 3
 line_length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ transformers==2.3.0
 sklearn==0.0
 omegaconf==2.0.1rc4
 lmdb==0.98
+termcolor==1.1.0

--- a/tests/trainers/callbacks/test_lr_scheduler.py
+++ b/tests/trainers/callbacks/test_lr_scheduler.py
@@ -64,7 +64,7 @@ class TestLogisticsCallback(unittest.TestCase):
         self.trainer.val_dataset = NumbersDataset()
 
         self.trainer.optimizer = torch.optim.Adam(
-            self.trainer.model.parameters(), lr=1e-01,
+            self.trainer.model.parameters(), lr=1e-01
         )
         self.trainer.lr_scheduler_callback = LRSchedulerCallback(
             self.config, self.trainer

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -18,7 +18,6 @@ from mmf.trainers.callbacks.early_stopping import EarlyStoppingCallback
 from mmf.utils.checkpoint import Checkpoint
 from mmf.utils.configuration import load_yaml
 from mmf.utils.file_io import PathManager
-from mmf.utils.logger import Logger
 from tests.test_utils import compare_state_dicts
 
 
@@ -87,7 +86,6 @@ class TestUtilsCheckpoint(unittest.TestCase):
         )
         # Keep original copy for testing purposes
         self.trainer.config = deepcopy(self.config)
-        self.trainer.writer = Mock(spec=Logger)
 
         self.trainer.model = SimpleModule()
 

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import argparse
+import glob
 import os
 import shutil
 import tempfile
@@ -10,7 +11,7 @@ from typing import Optional
 from mmf.common.registry import registry
 from mmf.utils.configuration import Configuration
 from mmf.utils.file_io import PathManager
-from mmf.utils.logger import Logger
+from mmf.utils.logger import setup_logger, setup_output_folder
 
 
 class TestLogger(unittest.TestCase):
@@ -28,23 +29,34 @@ class TestLogger(unittest.TestCase):
         configuration.freeze()
         cls.config = configuration.get_config()
         registry.register("config", cls.config)
-        cls.writer = Logger(cls.config)
+        setup_output_folder.cache_clear()
+        setup_logger.cache_clear()
+        cls.writer = setup_logger()
 
     @classmethod
     def tearDownClass(cls) -> None:
         # Cleanup temp working dir.
-        for handler in cls.writer._logger.handlers:
+        for handler in cls.writer.handlers:
             handler.close()
         if cls._tmpdir is not None:
             # set ignore_errors as Windows throw error due to Permission
             shutil.rmtree(cls._tmpdir, ignore_errors=True)
 
     def test_logger_files(self) -> None:
+        self.assertTrue(
+            PathManager.exists(
+                glob.glob(os.path.join(self._tmpdir, "logs", "train*"))[0]
+            )
+        )
         self.assertTrue(PathManager.exists(os.path.join(self._tmpdir, "train.log")))
         self.assertTrue(PathManager.exists(os.path.join(self._tmpdir, "logs")))
 
     def test_log_writer(self) -> None:
-        self.writer.write(self._tmpfile_write_contents)
+        self.writer.info(self._tmpfile_write_contents)
+        f = PathManager.open(glob.glob(os.path.join(self._tmpdir, "logs", "train*"))[0])
+        self.assertTrue(
+            any(self._tmpfile_write_contents in line for line in f.readlines())
+        )
         f = PathManager.open(os.path.join(self._tmpdir, "train.log"))
         self.assertTrue(
             any(self._tmpfile_write_contents in line for line in f.readlines())

--- a/website/docs/tutorials/dataset.md
+++ b/website/docs/tutorials/dataset.md
@@ -44,6 +44,7 @@ Let's write down this using example of _CLEVR_ dataset.
 .. code-block:: python
 
     import json
+    import logging
     import math
     import os
     import zipfile
@@ -56,6 +57,10 @@ Let's write down this using example of _CLEVR_ dataset.
     from mmf.datasets.builders.clevr.dataset import CLEVRDataset
     from mmf.utils.general import download_file, get_mmf_root
 
+
+    logger = logging.getLogger(__name__)
+
+
     @registry.register_builder("clevr")
     class CLEVRBuilder(BaseDatasetBuilder):
         DOWNLOAD_URL = "https://s3-us-west-1.amazonaws.com/clevr/CLEVR_v1.0.zip"
@@ -63,7 +68,6 @@ Let's write down this using example of _CLEVR_ dataset.
         def __init__(self):
             # Init should call super().__init__ with the key for the dataset
             super().__init__("clevr")
-            self.writer = registry.get("writer")
 
             # Assign the dataset class
             self.dataset_class = CLEVRDataset
@@ -88,10 +92,10 @@ Let's write down this using example of _CLEVR_ dataset.
                 len(os.listdir(extraction_folder)) != 0:
                 return
 
-            self.writer.write("Downloading the CLEVR dataset now")
+            logger.info("Downloading the CLEVR dataset now")
             download_file(self.DOWNLOAD_URL, output_dir=download_folder)
 
-            self.writer.write("Downloaded. Extracting now. This can take time.")
+            logger.info("Downloaded. Extracting now. This can take time.")
             with zipfile.ZipFile(local_filename, "r") as zip_ref:
                 zip_ref.extractall(download_folder)
 


### PR DESCRIPTION
- All logging uses python based logging after this
- Colored logging support inspired from d2
- Wherever touched moved to format strings
- Adds options for colored logging
- Moves torch version and cuda devices to top
- Moves all print and writer statements to logger
- Also, fixes the long failing windows tests for logger

What are the benefits of doing this?
- All libraries which use python logging will receives our logs now and
we receive theirs
- Proper division between stderr and stdout

Test Plan:

Tested locally

Reviewer suggestions:
This PR needs to be reviewed somewhat carefully to make sure I don't miss anything and as it touches all of the MMF.