### PR TITLE
[fix] Captioning predictions for bsz 1, remove opinions in testreporter

### DIFF
--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -3,7 +3,6 @@ import csv
 import json
 import os
 
-import torch
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 
@@ -145,23 +144,15 @@ class TestReporter(Dataset):
         return self.current_dataset[idx]
 
     def add_to_report(self, report, model):
-        # TODO: Later gather whole report for no opinions
-        if self.current_dataset.dataset_name == "coco":
-            report.captions = gather_tensor(report.captions)
-            if isinstance(report.image_id, torch.Tensor):
-                report.image_id = gather_tensor(report.image_id).view(-1)
-        else:
-            report.scores = gather_tensor(report.scores).view(
-                -1, report.scores.size(-1)
-            )
-            keys = ["id", "question_id", "image_id", "context_tokens"]
-            for key in keys:
-                report = self.reshape_and_gather(report, key)
+        keys = ["id", "question_id", "image_id", "context_tokens", "captions", "scores"]
+        for key in keys:
+            report = self.reshape_and_gather(report, key)
 
         if not is_master():
             return
 
         results = self.current_dataset.format_for_prediction(report)
+
         if hasattr(model, "format_for_prediction"):
             results = model.format_for_prediction(results, report)
         elif hasattr(model.module, "format_for_prediction"):
@@ -170,16 +161,13 @@ class TestReporter(Dataset):
         self.report = self.report + results
 
     def reshape_and_gather(self, report, key):
-
         if key in report:
             num_dims = report[key].dim()
             if num_dims == 1:
                 report[key] = gather_tensor(report[key]).view(-1)
-
-            elif num_dims == 2:
-                _, enc_size = report[key].size()
+            elif num_dims >= 2:
+                enc_size = report[key].size(-1)
                 report[key] = gather_tensor(report[key]).view(-1, enc_size)
-
             else:
                 raise RuntimeError(
                     "Expect 1 or 2 dimensions for {} in report for 'reshape and gather'"

--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -166,12 +166,8 @@ class TestReporter(Dataset):
             if num_dims == 1:
                 report[key] = gather_tensor(report[key]).view(-1)
             elif num_dims >= 2:
-                enc_size = report[key].size(-1)
-                report[key] = gather_tensor(report[key]).view(-1, enc_size)
-            else:
-                raise RuntimeError(
-                    "Expect 1 or 2 dimensions for {} in report for 'reshape and gather'"
-                    " in 'TestReporter', but got {} instead.".format(key, num_dims)
-                )
+                # Collect dims other than batch
+                other_dims = report[key].size()[1:]
+                report[key] = gather_tensor(report[key]).view(-1, *other_dims)
 
         return report

--- a/mmf/datasets/builders/coco/dataset.py
+++ b/mmf/datasets/builders/coco/dataset.py
@@ -36,12 +36,7 @@ class COCODataset(VQA2Dataset):
                 len(sample_info["caption_tokens"]), dtype=torch.int
             )
 
-        if isinstance(sample_info["image_id"], int):
-            current_sample.image_id = torch.tensor(
-                sample_info["image_id"], dtype=torch.int
-            )
-        else:
-            current_sample.image_id = object_to_byte_tensor(sample_info["image_id"])
+        current_sample.image_id = object_to_byte_tensor(sample_info["image_id"])
 
         if self._use_features is True:
             features = self.features_db[idx]


### PR DESCRIPTION
- Use object_to_byte and reverse for saving image ids
- Remove opinions about shapes and gathering in the test reporter based
on keys. Generalized logic now.