### PR TITLE
[feat] Added VQACPv2 Dataset Implementation

### DIFF
--- a/mmf/configs/datasets/vqacp_v2/defaults.yaml
+++ b/mmf/configs/datasets/vqacp_v2/defaults.yaml
@@ -1,0 +1,60 @@
+dataset_config:
+  vqacp_v2:
+    data_dir: ${env.data_dir}/datasets
+    use_images: true
+    use_features: false
+    zoo_requirements:
+    - coco.defaults
+    - vqa2.defaults
+    - vqacp_v2.defaults
+    images:
+      train:
+      - coco/defaults/images/train2014,coco/defaults/images/val2014
+      val:
+      - coco/defaults/images/train2014,coco/defaults/images/val2014
+      test:
+      - coco/defaults/images/train2014,coco/defaults/images/val2014
+    annotations:
+      train:
+      - vqacp_v2/defaults/annotations/vqacp_v2_train_annotations.json,vqacp_v2/defaults/annotations/vqacp_v2_train_questions.json
+      val:
+      - vqacp_v2/defaults/annotations/vqacp_v2_test_annotations.json,vqacp_v2/defaults/annotations/vqacp_v2_test_questions.json
+      test:
+      - vqacp_v2/defaults/annotations/vqacp_v2_test_annotations.json,vqacp_v2/defaults/annotations/vqacp_v2_test_questions.json
+    processors:
+      text_processor:
+        type: vocab
+        params:
+          max_length: 14
+          vocab:
+            type: intersected
+            embedding_name: glove.6B.300d
+            vocab_file: vqa2/defaults/extras/vocabs/vocabulary_100k.txt
+          preprocessor:
+            type: simple_sentence
+            params: {}
+      answer_processor:
+        type: vqa_answer
+        params:
+          num_answers: 10
+          vocab_file: vqa2/defaults/extras/vocabs/answers_vqa.txt
+          preprocessor:
+            type: simple_word
+            params: {}
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: Resize
+              params:
+                size: [256, 256]
+            - type: CenterCrop
+              params:
+                size: [224, 224]
+            - ToTensor
+            - GrayScaleTo3Channels
+            - type: Normalize
+              params:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.12221994, 0.12145835, 0.14380469]
+

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -378,3 +378,23 @@ okvqa:
         file_name: OpenEnded_mscoco_train2014_questions.json.zip
       - url: https://okvqa.allenai.org/static/data/OpenEnded_mscoco_val2014_questions.json.zip
         file_name: OpenEnded_mscoco_val2014_questions.json.zip
+
+
+vqacp_v2:
+  defaults:
+    version: 1.0_2020_08_02
+    # Images should be used from coco.defaults, extras should be used from vqa2 as zoo_requirements
+    resources:
+      annotations:
+        - url: https://computing.ece.vt.edu/~aish/vqacp/vqacp_v2_train_annotations.json
+          file_name: vqacp_v2_train_annotations.json
+          compressed: false
+        - url: https://computing.ece.vt.edu/~aish/vqacp/vqacp_v2_train_questions.json
+          file_name: vqacp_v2_train_questions.json
+          compressed: false
+        - url: https://computing.ece.vt.edu/~aish/vqacp/vqacp_v2_test_annotations.json
+          file_name: vqacp_v2_test_annotations.json
+          compressed: false
+        - url: https://computing.ece.vt.edu/~aish/vqacp/vqacp_v2_test_questions.json
+          file_name: vqacp_v2_test_questions.json
+          compressed: false

--- a/mmf/datasets/builders/vqacp_v2/builder.py
+++ b/mmf/datasets/builders/vqacp_v2/builder.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.builders.vqacp_v2.dataset import VQACPv2Dataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("vqacp_v2")
+class VQACPv2Builder(MMFDatasetBuilder):
+    def __init__(
+        self, dataset_name="vqacp_v2", dataset_class=VQACPv2Dataset, *args, **kwargs
+    ):
+        super().__init__(dataset_name, dataset_class, *args, **kwargs)
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/vqacp_v2/defaults.yaml"

--- a/mmf/datasets/builders/vqacp_v2/database.py
+++ b/mmf/datasets/builders/vqacp_v2/database.py
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import copy
+import json
+
+from mmf.datasets.builders.okvqa.database import OKVQAAnnotationDatabase
+from mmf.utils.file_io import PathManager
+
+
+class VQACPv2AnnotationDatabase(OKVQAAnnotationDatabase):
+    def __init__(self, config, path, *args, **kwargs):
+        super().__init__(config, path, *args, **kwargs)
+
+    def load_annotation_db(self, path):
+        # Expect two paths, one to questions and one to annotations
+        assert (
+            len(path) == 2
+        ), "VQACPv2 requires 2 paths; one to questions and one to annotations"
+
+        with PathManager.open(path[0]) as f:
+            path_0 = json.load(f)
+        with PathManager.open(path[1]) as f:
+            path_1 = json.load(f)
+
+        if "annotations" in path[0]:
+            annotations = path_0
+            questions = path_1
+        else:
+            annotations = path_1
+            questions = path_0
+
+        # Convert to linear format
+        data = []
+        question_dict = {}
+        for question in questions:
+            question_dict[question["question_id"]] = question["question"]
+
+        for annotation in annotations:
+            annotation["question"] = question_dict[annotation["question_id"]]
+            answers = []
+            for answer in annotation["answers"]:
+                answers.append(answer["answer"])
+            annotation["answers"] = answers
+            data.append(copy.deepcopy(annotation))
+
+        self.data = data

--- a/mmf/datasets/builders/vqacp_v2/dataset.py
+++ b/mmf/datasets/builders/vqacp_v2/dataset.py
@@ -1,0 +1,67 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import os
+from typing import Type, Union
+
+import torch
+
+from mmf.common.sample import Sample
+from mmf.common.typings import MMFDatasetConfigType
+from mmf.datasets.builders.okvqa.dataset import OKVQADataset
+from mmf.datasets.builders.vqacp_v2.database import VQACPv2AnnotationDatabase
+
+
+class VQACPv2Dataset(OKVQADataset):
+    def __init__(
+        self,
+        config: MMFDatasetConfigType,
+        dataset_type: str,
+        index: int,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(config, dataset_type, index, *args, **kwargs)
+
+    def build_annotation_db(self) -> Type[VQACPv2AnnotationDatabase]:
+        annotation_path = self._get_path_based_on_index(
+            self.config, "annotations", self._index
+        )
+        return VQACPv2AnnotationDatabase(self.config, annotation_path)
+
+    def get_image_path(self, image_id: Union[str, int], coco_split: str) -> str:
+        base_paths = self._get_path_based_on_index(self.config, "images", self._index)
+        base_paths = base_paths.split(",")
+        if "train" in base_paths[0]:
+            train_path = base_paths[0]
+            val_path = base_paths[1]
+        else:
+            train_path = base_paths[1]
+            val_path = base_paths[0]
+
+        # coco_split indicates whether the image is from the train or val split of COCO
+        if "train" in coco_split:
+            image_path = f"COCO_train2014_{str(image_id).zfill(12)}.jpg"
+            image_path = os.path.join(train_path, image_path)
+        else:
+            image_path = f"COCO_val2014_{str(image_id).zfill(12)}.jpg"
+            image_path = os.path.join(val_path, image_path)
+        return image_path
+
+    def __getitem__(self, idx: int) -> Type[Sample]:
+        sample_info = self.annotation_db[idx]
+        current_sample = Sample()
+        processed_question = self.text_processor({"text": sample_info["question"]})
+        current_sample.update(processed_question)
+        current_sample.id = torch.tensor(
+            int(sample_info["question_id"]), dtype=torch.int
+        )
+
+        image_path = self.get_image_path(
+            sample_info["image_id"], sample_info["coco_split"]
+        )
+        current_sample.image = self.image_db.from_path(image_path)["images"][0]
+
+        if "answers" in sample_info:
+            answers = self.answer_processor({"answers": sample_info["answers"]})
+            current_sample.targets = answers["answers_scores"]
+
+        return current_sample


### PR DESCRIPTION
Adds support for VQACPv2 dataset in MMF. Automatic downloads are only supported at image level.

Test Plan:
A config has been added to test on MMBT with Images.

`mmf_run config=projects/mmbt/configs/vqacp_v2/with_images.yaml run_type=train_val dataset=vqacp_v2 model=mmbt  training.batch_size=64 training.seed=1`