### PR TITLE
[feat] Support epoch based training

### DIFF
--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -148,7 +148,8 @@ class TrainerTrainingLoopMixin(ABC):
     def _calculate_max_updates(self):
         max_updates = self.training_config.max_updates
         max_epochs = self.training_config.max_epochs
-        assert max_updates is not None or max_epochs is not None
+        if max_updates is None and max_epochs is None:
+            raise Exception("Neither max_updates nor max_epochs is specified.")
 
         if max_updates is not None and max_epochs is not None:
             warnings.warn(

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -3,6 +3,7 @@
 import gc
 import logging
 import math
+import warnings
 from abc import ABC
 from typing import Any, Dict
 
@@ -22,13 +23,7 @@ class TrainerTrainingLoopMixin(ABC):
     num_updates: int = 0
 
     def training_loop(self) -> None:
-        self.max_updates = self.training_config.max_updates
-        self.max_epochs = self.training_config.max_epochs
-        if self.max_epochs is None:
-            self.max_epochs = math.inf
-        else:
-            self.max_updates = math.inf
-
+        self.max_updates = self._calculate_max_updates()
         torch.autograd.set_detect_anomaly(self.training_config.detect_anomaly)
 
         logger.info("Starting training...")
@@ -60,9 +55,6 @@ class TrainerTrainingLoopMixin(ABC):
 
             # Seed the sampler in case if it is distributed
             self.dataset_loader.seed_sampler("train", self.current_epoch)
-
-            if self.current_epoch > self.max_epochs:
-                break
 
             for batch in self.train_loader:
                 self.profile("Batch load time")
@@ -97,7 +89,7 @@ class TrainerTrainingLoopMixin(ABC):
                     if stop is True:
                         logger.info("Early stopping activated")
                         should_break = True
-                if self.num_updates > self.max_updates:
+                if self.num_updates >= self.max_updates:
                     should_break = True
 
                 if should_break:
@@ -152,3 +144,18 @@ class TrainerTrainingLoopMixin(ABC):
         loss_dict = report.losses
         loss = sum([loss.mean() for loss in loss_dict.values()])
         return loss
+
+    def _calculate_max_updates(self):
+        max_updates = self.training_config.max_updates
+        max_epochs = self.training_config.max_epochs
+        assert max_updates is not None or max_epochs is not None
+
+        if max_updates is not None and max_epochs is not None:
+            warnings.warn(
+                f"Both max_updates and max_epochs are specified. Favoring max_epochs: {max_epochs}"
+            )
+
+        if max_epochs is not None:
+            max_updates = len(self.train_loader) * max_epochs
+
+        return max_updates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,3 +90,27 @@ def build_random_sample_list():
     second.z.y = torch.rand((6, 4))
 
     return SampleList([first, second])
+
+
+DATA_ITEM_KEY = "test"
+class NumbersDataset(torch.utils.data.Dataset):
+    def __init__(self, num_examples):
+        self.num_examples = num_examples
+
+    def __getitem__(self, idx):
+        return {DATA_ITEM_KEY: torch.tensor(idx, dtype=torch.float32)}
+
+    def __len__(self):
+        return self.num_examples
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self, size):
+        super().__init__()
+        self.linear = torch.nn.Linear(size, 4)
+
+    def forward(self, prepared_batch):
+        batch = prepared_batch[DATA_ITEM_KEY]
+        model_output = {"losses": {"loss": torch.sum(self.linear(batch))}}
+        return model_output
+

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -1,0 +1,112 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+from omegaconf import OmegaConf
+
+from mmf.common.sample import SampleList
+from mmf.trainers.core.profiling import TrainerProfilingMixin
+from mmf.trainers.core.training_loop import TrainerTrainingLoopMixin
+
+DATA_ITEM_KEY = "test"
+
+
+class NumbersDataset(torch.utils.data.Dataset):
+    def __init__(self, num_examples):
+        self.num_examples = num_examples
+
+    def __getitem__(self, idx):
+        return {DATA_ITEM_KEY: torch.tensor(idx, dtype=torch.float32)}
+
+    def __len__(self):
+        return self.num_examples
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self, size):
+        super().__init__()
+        self.linear = torch.nn.Linear(size, 4)
+
+    def forward(self, prepared_batch):
+        batch = prepared_batch[DATA_ITEM_KEY]
+        model_output = {"losses": {"loss": torch.sum(self.linear(batch))}}
+        return model_output
+
+
+class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
+    def __init__(self, num_train_data, max_updates, max_epochs):
+        self.training_config = OmegaConf.create(
+            {"detect_anomaly": False, "evaluation_interval": 10000}
+        )
+        if max_updates is not None:
+            self.training_config["max_updates"] = max_updates
+        if max_epochs is not None:
+            self.training_config["max_epochs"] = max_epochs
+
+        self.model = SimpleModel(1)
+        self.dataset_loader = MagicMock()
+        self.dataset_loader.seed_sampler = MagicMock(return_value=None)
+        self.dataset_loader.prepare_batch = lambda x: SampleList(x)
+        self.optimizer = MagicMock()
+        self.optimizer.step = MagicMock(return_value=None)
+        self.optimizer.zero_grad = MagicMock(return_value=None)
+        dataset = NumbersDataset(num_train_data)
+        self.train_loader = torch.utils.data.DataLoader(
+            dataset=dataset,
+            batch_size=1,
+            shuffle=False,
+            num_workers=1,
+            drop_last=False,
+        )
+        self.on_batch_start = MagicMock(return_value=None)
+        self.logistics_callback = MagicMock(return_value=None)
+        self.logistics_callback.log_interval = MagicMock(return_value=None)
+        self.on_batch_end = MagicMock(return_value=None)
+        self.meter = MagicMock(return_value=None)
+        self.after_training_loop = MagicMock(return_value=None)
+
+
+class TestTrainingLoop(unittest.TestCase):
+    def test_epoch_over_updates(self):
+        trainer = TrainerTrainingLoopMock(100, 2, 0.04)
+        max_updates = trainer._calculate_max_updates()
+        self.assertEqual(max_updates, 4)
+
+        self.assertEqual(trainer.current_iteration, 0)
+        self.assertEqual(trainer.current_epoch, 0)
+        self.assertEqual(trainer.num_updates, 0)
+
+        trainer.training_loop()
+        self.assertEqual(trainer.current_iteration, 4)
+        self.assertEqual(trainer.current_epoch, 1)
+        self.assertEqual(trainer.num_updates, 4)
+
+    def test_fractional_epoch(self):
+        trainer = TrainerTrainingLoopMock(100, None, 0.04)
+        max_updates = trainer._calculate_max_updates()
+        self.assertEqual(max_updates, 4)
+
+        self.assertEqual(trainer.current_iteration, 0)
+        self.assertEqual(trainer.current_epoch, 0)
+        self.assertEqual(trainer.num_updates, 0)
+
+        trainer.training_loop()
+        self.assertEqual(trainer.current_iteration, 4)
+        self.assertEqual(trainer.current_epoch, 1)
+        self.assertEqual(trainer.num_updates, 4)
+
+    def test_updates(self):
+        trainer = TrainerTrainingLoopMock(100, 2, None)
+        max_updates = trainer._calculate_max_updates()
+        self.assertEqual(max_updates, 2)
+
+        self.assertEqual(trainer.current_iteration, 0)
+        self.assertEqual(trainer.current_epoch, 0)
+        self.assertEqual(trainer.num_updates, 0)
+
+        trainer.training_loop()
+        self.assertEqual(trainer.current_iteration, 2)
+        self.assertEqual(trainer.current_epoch, 1)
+        self.assertEqual(trainer.num_updates, 2)


### PR DESCRIPTION
Hi y'all, this is my first PR, so let me know how you feel about my approach. :) Some logging was only added for this test plan and therefore does not exist in this PR. Let me know if you find those logging helpful. I can always add them back. 

A couple contributions:
* This adds support for max_epochs. Using num_updates to control training loop; 
* If you have both num_epochs and num_updates specified, we warn you, and favor num_epochs.
* This supports fractional epoch. 
* I think I found an issue where we are training max_updates + 1 iterations, this PR also fixes it.

When cmd is:
```
mmf_run config=projects/m4c/configs/textvqa/defaults.yaml\
     datasets=textvqa\
     model=m4c\
     run_type=train_val\
     training.max_updates=None\
     training.max_epochs=None
```
![Screen Shot 2020-08-04 at 11 53 39 AM](https://user-images.githubusercontent.com/1545487/89333073-4feb5180-d649-11ea-9d38-8f480bec0bb2.png)



When cmd is:
```
mmf_run config=projects/m4c/configs/textvqa/defaults.yaml\
     datasets=textvqa\
     model=m4c\
     run_type=train_val\
     training.max_updates=10\
     training.max_epochs=1
```
we favor max_epochs over max_updates, added a warning message.
![Screen Shot 2020-08-04 at 11 58 25 AM](https://user-images.githubusercontent.com/1545487/89333543-f3d4fd00-d649-11ea-8711-59e8d678cef1.png)





When cmd is: 
```
mmf_run config=projects/m4c/configs/textvqa/defaults.yaml\
     datasets=textvqa\
     model=m4c\
     run_type=train_val\
     training.max_updates=None\
     training.max_epochs=1
```
![Screen Shot 2020-08-04 at 1 52 54 AM](https://user-images.githubusercontent.com/1545487/89274076-4637fe80-d5f5-11ea-89cc-131f167beb38.png)


When cmd is:
```
mmf_run config=projects/m4c/configs/textvqa/defaults.yaml \
    datasets=textvqa\
     model=m4c\
     run_type=train_val\
     training.max_updates=10\
     training.max_epochs=None
```
![Screen Shot 2020-08-04 at 1 13 11 AM](https://user-images.githubusercontent.com/1545487/89270083-b04da500-d5ef-11ea-9c0e-26cbba18f3ca.png)


To test fractional epochs:
```
mmf_run config=projects/m4c/configs/textvqa/defaults.yaml\
     datasets=textvqa\
     model=m4c\
     run_type=train_val\
     training.max_updates=40\
     training.max_epochs=0.04
```

<img width="1073" alt="Screen Shot 2020-08-04 at 9 59 22 AM" src="https://user-images.githubusercontent.com/1545487/89323554-bb79f280-d63a-11ea-96d4-1cdafc47b7e2.png">


To test:
pytest tests/trainers/test_training_loop.py

![Screen Shot 2020-08-04 at 4 58 05 PM](https://user-images.githubusercontent.com/1545487/89356885-c8ff9e80-d673-11ea-9f5c-43e9a520e508.png)
