### PR TITLE
[feat] Synchronize device for batch based on model

### DIFF
--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -241,13 +241,7 @@ class MultiDatasetLoader:
         self._chosen_dataset.verbose_dump(*args, **kwargs)
 
     def prepare_batch(self, batch):
-        if not hasattr(self._chosen_dataset, "prepare_batch"):
-            warnings.warn(
-                f"{self._chosen_dataset.dataset_name} doesn't define 'prepare_batch' "
-                + "method. You are expected to prepare and move your batch to "
-                + "CUDA device yourself."
-            )
-        else:
+        if hasattr(self._chosen_dataset, "prepare_batch"):
             batch = self._chosen_dataset.prepare_batch(batch)
 
         self.change_dataloader()

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -47,6 +47,7 @@ from copy import deepcopy
 from torch import nn
 
 from mmf.common.registry import registry
+from mmf.common.sample import to_device
 from mmf.modules.losses import Losses
 from mmf.utils.checkpoint import load_pretrained_model
 from mmf.utils.download import download_pretrained_model
@@ -144,6 +145,10 @@ class BaseModel(nn.Module):
         )
 
     def __call__(self, sample_list, *args, **kwargs):
+        # Move to proper device i.e. same as the model before passing
+        model_device = next(self.parameters()).device
+        sample_list = to_device(sample_list, model_device)
+
         model_output = super().__call__(sample_list, *args, **kwargs)
 
         # Don't do anything fancy to output if it is pretrained

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -9,6 +9,7 @@ import tqdm
 
 from mmf.common.meter import Meter
 from mmf.common.report import Report
+from mmf.common.sample import to_device
 from mmf.utils.distributed import is_master
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class TrainerEvaluationLoopMixin(ABC):
 
                 for batch in tqdm.tqdm(dataloader):
                     prepared_batch = reporter.prepare_batch(batch)
+                    prepared_batch = to_device(prepared_batch, torch.device("cuda"))
                     model_output = self.model(prepared_batch)
                     report = Report(prepared_batch, model_output)
                     reporter.add_to_report(report, self.model)

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -12,6 +12,7 @@ from torch import Tensor
 
 from mmf.common.registry import registry
 from mmf.common.report import Report
+from mmf.common.sample import to_device
 from mmf.utils.general import clip_gradients
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,8 @@ class TrainerTrainingLoopMixin(ABC):
 
     def _forward(self, batch: Tensor) -> Dict[str, Any]:
         prepared_batch = self.dataset_loader.prepare_batch(batch)
+        # Move the sample list to device if it isn't as of now.
+        prepared_batch = to_device(prepared_batch, torch.device("cuda"))
         self.profile("Batch prepare time")
         # Arguments should be a dict at this point
         model_output = self.model(prepared_batch)

--- a/tests/common/test_sample.py
+++ b/tests/common/test_sample.py
@@ -1,8 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import torch
+
 import tests.test_utils as test_utils
-from mmf.common.sample import Sample
+from mmf.common.sample import Sample, to_device
 
 
 class TestSample(unittest.TestCase):
@@ -69,3 +71,27 @@ class TestSampleList(unittest.TestCase):
 
         self.assertTrue(all_keys)
         self.assertTrue(isinstance(sample_dict, dict))
+
+
+class TestFunctions(unittest.TestCase):
+    def test_to_device(self):
+        sample_list = test_utils.build_random_sample_list()
+
+        modified = to_device(sample_list, "cpu")
+        self.assertEqual(modified.get_device(), torch.device("cpu"))
+
+        modified = to_device(sample_list, torch.device("cpu"))
+        self.assertEqual(modified.get_device(), torch.device("cpu"))
+
+        modified = to_device(sample_list, "cuda")
+
+        if torch.cuda.is_available():
+            self.assertEqual(modified.get_device(), torch.device("cuda:0"))
+        else:
+            self.assertEqual(modified.get_device(), torch.device("cpu"))
+
+        double_modified = to_device(modified, modified.get_device())
+        self.assertTrue(double_modified is modified)
+
+        custom_batch = [{"a": 1}]
+        self.assertEqual(to_device(custom_batch), custom_batch)

--- a/tests/modules/test_metrics.py
+++ b/tests/modules/test_metrics.py
@@ -143,12 +143,26 @@ class TestModuleMetrics(unittest.TestCase):
         self._test_binary_metric(metric, 0.5)
         self._test_multiclass_metric(metric, 0.34375)
 
+    def test_binary_ap(self):
+        metric = metrics.BinaryAP()
+        self._test_binary_metric(metric, 0.75)
+
+    def test_recall_at_precision_k(self):
+        metric = metrics.RecallAtPrecisionK(50)
+        self._test_binary_metric(metric, 1.0)
+
+        metric = metrics.RecallAtPrecisionK(90)
+        self._test_binary_metric(metric, 0.5)
+
+        metric = metrics.RecallAtPrecisionK(110)
+        self._test_binary_metric(metric, 0)
+
     def test_micro_ap(self):
         metric = metrics.MicroAP()
-        self._test_binary_metric(metric, 0.5)
-        self._test_multiclass_metric(metric, 0.34375)
+        self._test_binary_metric(metric, 0.642857)
+        self._test_multiclass_metric(metric, 0.354166)
 
     def test_macro_ap(self):
         metric = metrics.MacroAP()
-        self._test_binary_metric(metric, 0.5)
-        self._test_multiclass_metric(metric, 0.2222)
+        self._test_binary_metric(metric, 0.6666666)
+        self._test_multiclass_metric(metric, 0.3888888)

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -23,6 +23,9 @@ class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
             self.training_config["max_epochs"] = max_epochs
 
         self.model = SimpleModel(1)
+        if torch.cuda.is_available():
+            self.model = self.model.cuda()
+
         self.dataset_loader = MagicMock()
         self.dataset_loader.seed_sampler = MagicMock(return_value=None)
         self.dataset_loader.prepare_batch = lambda x: SampleList(x)


### PR DESCRIPTION
Summary:
Purpose of this diff is to add `to_device` method which is a helper utility method to move sample list to a proper device. In case the user is using custom dataset and forgot to move it to proper device, this changes will make sure that the batch is automatically moved to proper device at multiple stages of a training loop including making sure the batch model is receiving is on same device as the model's device.

The checks are added at the following stages:
- Before forward in training loop
- Before forward in prediction loop
- Inside BaseModel's forward

This diff also remove the warning about prepare_batch in the multi dataset loader as it is not needed anymore.

Reviewed By: vedanuj

Differential Revision: D22955817

