### PR TITLE
[fix, refactor] Tuple output bug in visual_bert model

### DIFF
--- a/mmf/models/visual_bert.py
+++ b/mmf/models/visual_bert.py
@@ -128,21 +128,18 @@ class VisualBERTBase(BertPreTrainedModel):
             pooled_output = self.pooler(final_sequence_output)
             return final_sequence_output, pooled_output
 
-        if self.output_attentions:
-            encoded_layers = self.encoder(
-                embedding_output, extended_attention_mask, self.fixed_head_masks
-            )
-            sequence_output = encoded_layers[0]
-            attn_data_list = encoded_layers[1:]
-            pooled_output = self.pooler(sequence_output)
-            return encoded_layers, pooled_output, attn_data_list
         else:
             encoded_layers = self.encoder(
                 embedding_output, extended_attention_mask, self.fixed_head_masks
             )
             sequence_output = encoded_layers[0]
             pooled_output = self.pooler(sequence_output)
-            return sequence_output, pooled_output, []
+            attn_data_list = []
+
+            if self.output_attentions:
+                attn_data_list = encoded_layers[1:]
+
+            return sequence_output, pooled_output, attn_data_list
 
 
 class VisualBERTForPretraining(nn.Module):


### PR DESCRIPTION
Summary:
[fix]: The first object returned should always be return `encoded_layers[0]` or `sequence_output`, or there will be a `tuple` error.

[refactor]; Remove duplicate lines by better placing of the conditional statement `if self.output_attentions` . No actual logic changed.

Differential Revision: D22970391

