### PR TITLE
[fix] raise value error rather than exception; fixed formating with black

### DIFF
--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -149,7 +149,7 @@ class TrainerTrainingLoopMixin(ABC):
         max_updates = self.training_config.max_updates
         max_epochs = self.training_config.max_epochs
         if max_updates is None and max_epochs is None:
-            raise Exception("Neither max_updates nor max_epochs is specified.")
+            raise ValueError("Neither max_updates nor max_epochs is specified.")
 
         if max_updates is not None and max_epochs is not None:
             warnings.warn(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,8 @@ def build_random_sample_list():
 
 
 DATA_ITEM_KEY = "test"
+
+
 class NumbersDataset(torch.utils.data.Dataset):
     def __init__(self, num_examples):
         self.num_examples = num_examples
@@ -113,4 +115,3 @@ class SimpleModel(torch.nn.Module):
         batch = prepared_batch[DATA_ITEM_KEY]
         model_output = {"losses": {"loss": torch.sum(self.linear(batch))}}
         return model_output
-


### PR DESCRIPTION
[fix] raise value error rather than exception; fixed formating with black

- I apologize with the premature land, I kicked off transfering code before I saw the comments. 
- Test with ``pytest tests``
- This passes tests

Question, would you be open to using git precommit hooks to run isort, black automatically?
