### PR TITLE
[fix] Support for reading raw COCO images for VQA2 and COCO

### DIFF
--- a/mmf/configs/datasets/vqa2/with_raw_images.yaml
+++ b/mmf/configs/datasets/vqa2/with_raw_images.yaml
@@ -1,0 +1,75 @@
+dataset_config:
+  vqa2:
+      data_dir: ${env.data_dir}/datasets
+      depth_first: false
+      fast_read: false
+      use_images: true
+      use_features: false
+      zoo_requirements:
+      - coco.defaults
+      - vqa2.defaults
+      images:
+        train:
+        - coco/defaults/images/train2014
+        val:
+        - coco/defaults/images/val2014
+        test:
+        - coco/defaults/images/test2015
+      features:
+        train:
+        - coco/defaults/features/trainval2014.lmdb
+        val:
+        - coco/defaults/features/trainval2014.lmdb
+        test:
+        - coco/defaults/features/test2015.lmdb
+      annotations:
+        train:
+        - vqa2/defaults/annotations/imdb_train2014.npy
+        val:
+        - vqa2/defaults/annotations/imdb_val2014.npy
+        test:
+        - vqa2/defaults/annotations/imdb_test2015.npy
+      max_features: 100
+      processors:
+        answer_processor:
+          type: vqa_answer
+          params:
+            num_answers: 10
+            vocab_file: vqa2/defaults/extras/vocabs/answers_vqa.txt
+            preprocessor:
+              type: simple_word
+              params: {}
+        context_processor:
+          type: fasttext
+          params:
+            download_initially: false
+            max_length: 50
+            model_file: wiki.en.bin
+        ocr_token_processor:
+          type: simple_word
+          params: {}
+        bbox_processor:
+          type: bbox
+          params:
+            max_length: 50
+        image_processor:
+          type: torchvision_transforms
+          params:
+            transforms:
+            - type: Resize
+              params:
+                  size: [256, 256]
+            - type: CenterCrop
+              params:
+                size: [224, 224]
+            - ToTensor
+            - GrayScaleTo3Channels
+            - type: Normalize
+              params:
+                mean: [0.46777044, 0.44531429, 0.40661017]
+                std: [0.12221994, 0.12145835, 0.14380469]
+      return_features_info: false
+      # Return OCR information
+      use_ocr: false
+      # Return spatial information of OCR tokens if present
+      use_ocr_info: false

--- a/mmf/datasets/builders/coco/dataset.py
+++ b/mmf/datasets/builders/coco/dataset.py
@@ -37,9 +37,12 @@ class COCODataset(VQA2Dataset):
 
         current_sample.image_id = object_to_byte_tensor(sample_info["image_id"])
 
-        if self._use_features is True:
+        if self._use_features:
             features = self.features_db[idx]
             current_sample.update(features)
+        else:
+            image_path = str(sample_info["image_name"]) + ".jpg"
+            current_sample.image = self.image_db.from_path(image_path)["images"][0]
 
         # Add reference captions to sample
         current_sample = self.add_reference_caption(sample_info, current_sample)

--- a/mmf/datasets/builders/coco/masked_dataset.py
+++ b/mmf/datasets/builders/coco/masked_dataset.py
@@ -17,7 +17,7 @@ class MaskedCOCODataset(COCODataset):
         sample_info = self.annotation_db[idx]
         current_sample = Sample()
 
-        if self._use_features is True:
+        if self._use_features:
             features = self.features_db[idx]
             if hasattr(self, "transformer_bbox_processor"):
                 features["image_info_0"] = self.transformer_bbox_processor(
@@ -34,6 +34,9 @@ class MaskedCOCODataset(COCODataset):
                 )
 
             current_sample.update(features)
+        else:
+            image_path = str(sample_info["image_name"]) + ".jpg"
+            current_sample.image = self.image_db.from_path(image_path)["images"][0]
 
         current_sample = self._add_masked_caption(sample_info, current_sample)
         return current_sample

--- a/mmf/datasets/builders/vqa2/masked_dataset.py
+++ b/mmf/datasets/builders/vqa2/masked_dataset.py
@@ -20,7 +20,7 @@ class MaskedVQA2Dataset(VQA2Dataset):
         sample_info = self.annotation_db[idx]
         current_sample = Sample()
 
-        if self._use_features is True:
+        if self._use_features:
             features = self.features_db[idx]
 
             if self.config.get("transformer_bbox_processor", False):
@@ -38,6 +38,9 @@ class MaskedVQA2Dataset(VQA2Dataset):
                 )
 
             current_sample.update(features)
+        else:
+            image_path = str(sample_info["image_name"]) + ".jpg"
+            current_sample.image = self.image_db.from_path(image_path)["images"][0]
 
         current_sample = self._add_masked_question(sample_info, current_sample)
 

--- a/mmf/datasets/databases/annotation_database.py
+++ b/mmf/datasets/databases/annotation_database.py
@@ -43,7 +43,9 @@ class AnnotationDatabase(torch.utils.data.Dataset):
             self.start_idx = 0
 
     def _load_npy(self, path):
-        self.db = np.load(path, allow_pickle=True)
+        with PathManager.open(path, "rb") as f:
+            self.db = np.load(f, allow_pickle=True)
+
         self.start_idx = 0
 
         if type(self.db) == dict:

--- a/projects/mmbt/configs/vqa2/with_raw_images.yaml
+++ b/projects/mmbt/configs/vqa2/with_raw_images.yaml
@@ -1,0 +1,3 @@
+includes:
+- ./defaults.yaml
+- ../../../../mmf/configs/datasets/vqa2/with_raw_images.yaml

--- a/projects/visual_bert/configs/vqa2/with_raw_images.yaml
+++ b/projects/visual_bert/configs/vqa2/with_raw_images.yaml
@@ -1,0 +1,3 @@
+includes:
+- ./defaults.yaml
+- ../../../../mmf/configs/datasets/vqa2/with_raw_images.yaml


### PR DESCRIPTION
Summary:
VQA2 and COCO dataset readers `dataset.py` previously only support reading in from feature file.

After this PR, it should now be compatible with a model which reads in raw images. Should not affect any models which previously relied on `use_images: false`, `use_features: true`

Changes:

* Loads images in `{vqa2,coco}/{masked_,}dataset.py` if `self._use_features` flag is False

* Included image transform in `faim/mmf/mmf/datasets/builders/vqa2/dataset.py:def init_processors(self)`

* Enabled npy loading for internal
`faim/mmf/mmf/datasets/databases/annotation_database.py:def _load_npy()`

* Configs -- The main difference for configs is the inclusion of image_processor in this config file: `mmf/configs/datasets/vqa2/with_raw_images.yaml` and the dataset config `use_images` and `use_features` flags.

```
dataset_config:
  vqa2:
    use_images: true
    use_features: false
  images:
    train:
    - coco/defaults/images/train2014
    val:
    - coco/defaults/images/val2014
    test:
    - coco/defaults/images/test2015

Differential Revision: D22979686

