### PR TITLE
[feat] Support for more than 2 segments in MMBT

### DIFF
--- a/mmf/configs/models/mmbt/defaults.yaml
+++ b/mmf/configs/models/mmbt/defaults.yaml
@@ -26,6 +26,7 @@ model_config:
     text_encoder:
       type: transformer
       params:
+        num_segments: 2
         bert_model_name: ${model_config.mmbt.bert_model_name}
         # Options below can be overridden to update the bert configuration used
         # to initialize the bert encoder. If some option is missing or

--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -386,17 +386,19 @@ vilbert:
 mmbt:
   hateful_memes:
     images:
+      # bs64.s1.adam_w.lr5e-05.mu22000
       version: 1.0_2020_05_10
       resources:
-      - url: mmf://models/mmbt/mmbt.finetuned.hateful_memes_images.tar.gz
+      - url: mmf://models/mmbt/mmbt.finetuned.hateful_memes_images_2020_08_20.tar.gz
         file_name: mmbt.finetuned.hateful_memes_images.tar.gz
-        hashcode: 8955e70019acbd79348b8fd480949aea181d0586e97faa3771f7a3ae2057ee90
+        hashcode: 0df7a4ab4da9f2f05c2f5fcf6f7c0ce775e80279039a2e6069e958e0f1a2786a
     features:
+      # bs128.s1.adam_w.lr5e-05.mu22000
       version: 1.0_2020_05_10
       resources:
-      - url: mmf://models/mmbt/mmbt.finetuned.hateful_memes_features.tar.gz
-        file_name: mmbt.finetuned.hateful_memes_features.tar.gz
-        hashcode: 3b206003f8e7c79791baaf61edf540f0135e81d822859abd1ad70ff1c14da4bf
+      - url: mmf://models/mmbt/mmbt.finetuned.hateful_memes_features_2020_08_20.tar.gz
+        file_name: mmbt.finetuned.hateful_memes_features_2020_08_20.tar.gz
+        hashcode: e110262220636d89f0434a417e07acb7f9713035ea1083184d896978c5124aa7
     defaults: ${mmbt.hateful_memes.features}
 
 unimodal_image:

--- a/tests/models/interfaces/test_interfaces.py
+++ b/tests/models/interfaces/test_interfaces.py
@@ -19,14 +19,12 @@ class TestModelInterfaces(unittest.TestCase):
         )
 
         self.assertEqual(result["label"], 0)
-        np.testing.assert_almost_equal(result["confidence"], 0.9999, decimal=4)
+        np.testing.assert_almost_equal(result["confidence"], 0.9993, decimal=4)
         result = model.classify(
             "https://i.imgur.com/tEcsk5q.jpg", "they have the privilege"
         )
         self.assertEqual(result["label"], 0)
-        np.testing.assert_almost_equal(result["confidence"], 0.9869, decimal=4)
-        result = model.classify(
-            "https://i.imgur.com/tEcsk5q.jpg", "a black man doing nothing"
-        )
+        np.testing.assert_almost_equal(result["confidence"], 0.9777, decimal=4)
+        result = model.classify("https://i.imgur.com/tEcsk5q.jpg", "hitler and jews")
         self.assertEqual(result["label"], 1)
-        np.testing.assert_almost_equal(result["confidence"], 0.6941, decimal=4)
+        np.testing.assert_almost_equal(result["confidence"], 0.6342, decimal=4)


### PR DESCRIPTION
Summary:
Segment embedding other than first 2 dim are initialized from the average of first 2 embeddings

This is required for the case where there are 3 segments such as post, ocr, and features.

Differential Revision: D22970794

