### PR TITLE
[fix] Allow user to define 'text_b' for bert_tokenizer text processor.

### DIFF
--- a/mmf/datasets/processors/bert_processors.py
+++ b/mmf/datasets/processors/bert_processors.py
@@ -145,6 +145,7 @@ class BertTokenizer(MaskedTokenProcessor):
         self._probability = 0
 
     def __call__(self, item):
+
         if "text" in item:
             text_a = item["text"]
         else:
@@ -155,8 +156,17 @@ class BertTokenizer(MaskedTokenProcessor):
 
         tokens_a = self._tokenizer.tokenize(text_a)
 
-        self._truncate_seq_pair(tokens_a, None, self._max_seq_length - 2)
-        output = self._convert_to_indices(tokens_a, None, probability=self._probability)
+        # 'text_b' can be defined in the dataset preparation
+        tokens_b = None
+        if "text_b" in item:
+            text_b = item["text_b"]
+            if text_b:
+                tokens_b = self._tokenizer.tokenize(text_b)
+
+        self._truncate_seq_pair(tokens_a, tokens_b, self._max_seq_length - 2)
+        output = self._convert_to_indices(
+            tokens_a, tokens_b, probability=self._probability
+        )
         output["text"] = output["tokens"]
         return output
 
@@ -168,6 +178,7 @@ class MultiSentenceBertTokenizer(BertTokenizer):
     bert tokenizer separately and indices will be reshaped as single
     tensor. Segment ids will also be increasing in number.
     """
+
     def __call__(self, item):
         texts = item["text"]
         if not isinstance(texts, list):


### PR DESCRIPTION
Summary:
Previously `bert_tokenizer` text processor assumed there are no `text_b` tokens.

We still preserve this default logic (tokens_b defaults to None), but additionally allow the user to specify `text_b` if desired.

Differential Revision: D22988310

