### PR TITLE
[feat] Install glove only when the processor is called

### DIFF
--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -374,9 +374,17 @@ class GloVeProcessor(VocabProcessor):
 
             vocab_processor_config.vocab.type = "pretrained"
 
-        super().__init__(vocab_processor_config, *args, **kwargs)
+        self._init_extras(vocab_processor_config)
+        self.config = vocab_processor_config
+        self._already_downloaded = False
+        self._args = args
+        self._kwargs = kwargs
 
     def __call__(self, item):
+        if not self._already_downloaded:
+            self.vocab = Vocab(*self._args, **self.config.vocab, **self._kwargs)
+            self._already_downloaded = True
+
         indices = super().__call__(item)["text"]
         embeddings = torch.zeros(
             (len(indices), self.vocab.get_embedding_dim()), dtype=torch.float


### PR DESCRIPTION
Embeddings download happens in Vocab(..), which was previously called in __init__. We put it in __call__ instead to delay the download.