### PR TITLE
[feat] added split dataset feature

### DIFF
--- a/mmf/datasets/mmf_dataset_builder.py
+++ b/mmf/datasets/mmf_dataset_builder.py
@@ -3,7 +3,6 @@ import copy
 import os
 import typing
 import warnings
-import numpy as np
 
 import numpy as np
 
@@ -13,6 +12,7 @@ from mmf.datasets.concat_dataset import MMFConcatDataset
 from mmf.datasets.subset_dataset import MMFSubset
 from mmf.utils.configuration import get_global_config, get_mmf_env, get_zoo_config
 from mmf.utils.general import get_absolute_path
+
 
 class MMFDatasetBuilder(BaseDatasetBuilder):
     ZOO_CONFIG_PATH = None

--- a/mmf/datasets/mmf_dataset_builder.py
+++ b/mmf/datasets/mmf_dataset_builder.py
@@ -1,17 +1,17 @@
 import collections
-import copy
 import os
 import typing
 import warnings
-
-import numpy as np
+from copy import deepcopy
 
 import mmf.utils.download as download
+import torch
 from mmf.datasets.base_dataset_builder import BaseDatasetBuilder
 from mmf.datasets.concat_dataset import MMFConcatDataset
 from mmf.datasets.subset_dataset import MMFSubset
 from mmf.utils.configuration import get_global_config, get_mmf_env, get_zoo_config
 from mmf.utils.general import get_absolute_path
+from omegaconf import open_dict
 
 
 class MMFDatasetBuilder(BaseDatasetBuilder):
@@ -24,7 +24,7 @@ class MMFDatasetBuilder(BaseDatasetBuilder):
         dataset_class=None,
         zoo_variation="defaults",
         *args,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(dataset_name)
         self.dataset_class = dataset_class
@@ -124,46 +124,59 @@ class MMFDatasetBuilder(BaseDatasetBuilder):
     def load(self, config, dataset_type, *args, **kwargs):
         self.config = config
 
-        new_config = config
-        split_dataset_from_train = self.config.split_train
+        split_dataset_from_train = self.config.get("split_train", False)
         if split_dataset_from_train:
-            split_range = self._calculate_split_for_dataset_type(dataset_type)
-            new_config = self._modify_dataset_config(config)
+            config = self._modify_dataset_config_for_split(config)
 
-        annotations = self._read_annotations(new_config, dataset_type)
+        annotations = self._read_annotations(config, dataset_type)
         if annotations is None:
             return None
 
         datasets = []
         for imdb_idx in range(len(annotations)):
             dataset_class = self.dataset_class
-            dataset = dataset_class(new_config, dataset_type, imdb_idx)
+            dataset = dataset_class(config, dataset_type, imdb_idx)
             datasets.append(dataset)
 
         dataset = MMFConcatDataset(datasets)
         if split_dataset_from_train:
-            start, end = split_range
-            dataset_length = len(dataset)
-            start, end = round(start * dataset_length), round(end * dataset_length)
-            seed = new_config.split_train.seed
-            indices = np.random.RandomState(seed).permutation(dataset_length)[start:end]
-            dataset = MMFSubset(dataset, indices)
+            dataset = self._split_dataset_from_train(dataset, dataset_type)
 
         self.dataset = dataset
         return self.dataset
 
-    def _modify_dataset_config(self, config):
-        modified_config = copy.deepcopy(config)
-        for data_type in config.split_train:
-            if data_type == "seed":
-                continue
-            if config.use_images:
-                modified_config.images[data_type] = config.images.train
-            if config.use_features:
-                modified_config.features[data_type] = config.features.train
-            modified_config.annotations[data_type] = modified_config.annotations.train
+    def _split_dataset_from_train(self, dataset, dataset_type):
+        if dataset_type in self.config.split_train.keys() or dataset_type == "train":
+            start, end = self._calculate_split_for_dataset_type(dataset_type)
+            dataset_length = len(dataset)
+            start, end = round(start * dataset_length), round(end * dataset_length)
+            if start > end:
+                raise ValueError(
+                    f"Train split ratio for {dataset_type} must be positive."
+                )
+            indices = self._generate_permuted_indexes(dataset_length)[start:end]
+            dataset = MMFSubset(dataset, indices)
+            print(
+                f"Dataset type: {dataset_type} length: {len(dataset)} total: {dataset_length}"
+            )
+        return dataset
 
-        return modified_config
+    def _generate_permuted_indexes(self, dataset_length):
+        generator = torch.Generator()
+        generator.manual_seed(self.config.get("split_train.seed", 123456))
+        return torch.randperm(dataset_length, generator=generator)
+
+    def _modify_dataset_config_for_split(self, config):
+        with open_dict(config):
+            for data_type in config.split_train:
+                if data_type == "seed":
+                    continue
+                if config.use_images:
+                    config.images[data_type] = deepcopy(config.images.train)
+                if config.use_features:
+                    config.features[data_type] = deepcopy(config.features.train)
+                config.annotations[data_type] = deepcopy(config.annotations.train)
+        return config
 
     def _read_annotations(self, config, dataset_type):
         annotations = config.get("annotations", {}).get(dataset_type, [])
@@ -191,11 +204,13 @@ class MMFDatasetBuilder(BaseDatasetBuilder):
                 return (start, start + self.config.split_train[data_type])
             start += self.config.split_train[data_type]
 
-        if start >= 1.0:
+        if start > 1.0:
             raise ValueError(
-                "Ratios of val and test should not exceed 100%."
-                + "Need to leave some percentage for training."
+                "Ratios of val plus test should not exceed 100%."
+                + " Need to leave some percentage for training."
             )
+        elif start == 1.0:
+            warnings.warn("All data in training set is used for val and/or test.")
 
         if dataset_type == "train":
             return (start, 1.0)

--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -132,8 +132,10 @@ class MultiDatasetLoader:
             self.datasets.append(dataset_instance)
 
             if hasattr(dataset_instance, "__len__"):
-                self._per_dataset_lengths.append(len(dataset_instance))
-                self._total_length += len(dataset_instance)
+                dataset_instance_length = len(dataset_instance)
+                assert dataset_instance_length, f"dataset: {self.dataset_type} is empty"
+                self._per_dataset_lengths.append(dataset_instance_length)
+                self._total_length += dataset_instance_length
 
         self._num_datasets = len(self.datasets)
         self.current_index = 0

--- a/mmf/datasets/subset_dataset.py
+++ b/mmf/datasets/subset_dataset.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
 from torch.utils.data.dataset import Subset
 
 

--- a/mmf/datasets/subset_dataset.py
+++ b/mmf/datasets/subset_dataset.py
@@ -1,0 +1,15 @@
+from torch.utils.data.dataset import Subset
+
+
+class MMFSubset(Subset):
+    def __init__(self, dataset, indices):
+        super().__init__(dataset, indices)
+        self._dir_representation = dir(self)
+
+    def __getattr__(self, name):
+        if "_dir_representation" in self.__dict__ and name in self._dir_representation:
+            return getattr(self, name)
+        elif "dataset" in self.__dict__ and hasattr(self.dataset, name):
+            return getattr(self.dataset, name)
+        else:
+            raise AttributeError(name)

--- a/tests/datasets/test_mmf_dataset_builder.py
+++ b/tests/datasets/test_mmf_dataset_builder.py
@@ -4,10 +4,9 @@ import os
 import unittest
 from unittest.mock import MagicMock
 
-from omegaconf import OmegaConf
-
 from mmf.datasets.base_dataset import BaseDataset
 from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+from omegaconf import OmegaConf
 
 
 class SimpleMMFDataset(BaseDataset):

--- a/tests/datasets/test_mmf_dataset_builder.py
+++ b/tests/datasets/test_mmf_dataset_builder.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import functools
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from omegaconf import OmegaConf
+
+from mmf.datasets.base_dataset import BaseDataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+class SimpleMMFDataset(BaseDataset):
+    def __init__(
+        self, dataset_name, config, dataset_type, *args, num_examples, **kwargs
+    ):
+        self.num_examples = num_examples
+        self.features = [x for x in range(self.num_examples)]
+        self.annotations = [x for x in range(self.num_examples)]
+
+    def __getitem__(self, idx):
+        return self.features[idx], self.annotations[idx]
+
+    def __len__(self):
+        return self.num_examples
+
+
+class TestMMFDatasetBuilder(unittest.TestCase):
+    def setUp(self):
+        self.config = OmegaConf.create(
+            {
+                "use_features": True,
+                "split_train": {"val": 0.2, "test": 0.1, "seed": 42},
+                "annotations": {"train": "not_a_real_annotations_dataset"},
+                "features": {"train": "not_a_real_features_dataset"},
+            }
+        )
+        self.train = self._create_dataset("train")
+        self.val = self._create_dataset("val")
+        self.test = self._create_dataset("test")
+
+    def test_train_split_len(self):
+        self.assertEqual(len(self.train), 70)
+        self.assertEqual(len(self.val), 20)
+        self.assertEqual(len(self.test), 10)
+
+    def test_train_split_non_overlap(self):
+        total = (
+            self._samples_set(self.train)
+            | self._samples_set(self.val)
+            | self._samples_set(self.test)
+        )
+        self.assertSetEqual(total, {x for x in range(100)})
+
+    def test_train_split_alignment(self):
+        self._test_alignment_in_dataset(self.train)
+        self._test_alignment_in_dataset(self.val)
+        self._test_alignment_in_dataset(self.test)
+
+    def _create_dataset(self, dataset_type):
+        dataset_builder = MMFDatasetBuilder(
+            "vqa", functools.partial(SimpleMMFDataset, num_examples=100)
+        )
+        return dataset_builder.load(self.config, dataset_type)
+
+    def _samples_set(self, dataset):
+        return set(x for x, _ in dataset)
+
+    def _test_alignment_in_dataset(self, dataset):
+        for feature, annotation in dataset:
+            self.assertEqual(feature, annotation)


### PR DESCRIPTION
* allow user to specify x% of dataset to split from train, example yaml shown below:
```
  textvqa:
    zoo_requirements:
    - textvqa.defaults
    - textvqa.ocr_en
    split_train:
      val: 0.2
      test: 0.1
      seed: 42
    features:
      train:
      - textvqa/defaults/features/open_images/detectron.lmdb,textvqa/ocr_en/features/ocr_en_frcn_features.lmdb
   processors:
```
* To test: `pytests test`
* See logs, 24221 is 0.7 of 34602 which is the total size of the train after calculation, etc.
![Screen Shot 2020-08-10 at 11 47 12 PM](https://user-images.githubusercontent.com/1545487/89866133-e052f600-db63-11ea-80e0-4f2c6b1a7acc.png)
