### PR TITLE
[fix] Typo in fusions for image feature

### DIFF
--- a/mmf/models/fusions.py
+++ b/mmf/models/fusions.py
@@ -100,7 +100,7 @@ class ConcatBERT(BaseModel):
         segment = sample_list.segment_ids
 
         if self._is_direct_features_input:
-            modal = sample_list.image_features_0
+            modal = sample_list.image_feature_0
         else:
             modal = sample_list.image
 


### PR DESCRIPTION
Summary: Change image_features_0 to image_feature_0. All other image tokens are named as image_feature_0.

Differential Revision: D23178741

