### PR TITLE
[fix] More informative logging for loading checkpoints.

### DIFF
--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -208,15 +208,18 @@ class Checkpoint:
                 self._load_optimizer(ckpt)
 
             self.trainer.early_stop_callback.early_stopping.init_from_checkpoint(ckpt)
-
-            logger.info("Checkpoint loaded")
-
             reset_counts = ckpt_config.reset.all or ckpt_config.reset.counts
 
             if not reset_counts:
                 self._load_counts(ckpt)
         else:
             self._load_pretrained(new_dict)
+
+        logger.info(
+            f"Checkpoint loaded.. num updates:{self.trainer.num_updates} "
+            + f"current iteration:{self.trainer.current_iteration} "
+            + f"current epoch:{self.trainer.current_epoch}"
+        )
 
     def _load_optimizer(self, ckpt):
         if "optimizer" in ckpt:


### PR DESCRIPTION
Summary:
Previously unclear at what stage the loaded checkpoint file resumes training and this may have some unintended consequences.

Adding `num_updates`, `current_iteration`, and `current_epoch` to the logger.

Differential Revision: D23199211

