### PR TITLE
[feat] Add support for BS, NS metric calculation, update butd model etc.

### DIFF
--- a/mmf/common/report.py
+++ b/mmf/common/report.py
@@ -77,6 +77,10 @@ class Report(OrderedDict):
     def accumulate_tensor_fields(self, report, field_list):
         for key in field_list:
             if key not in self.keys():
-                raise AttributeError(key)
+                warnings.warn(
+                    f"{key} not found in report. Metrics calculation "
+                    + "might not work as expected."
+                )
+                continue
             if isinstance(self[key], torch.Tensor):
                 self[key] = torch.cat((self[key], report[key]), dim=0)

--- a/mmf/configs/datasets/coco/defaults.yaml
+++ b/mmf/configs/datasets/coco/defaults.yaml
@@ -5,6 +5,8 @@ dataset_config:
     fast_read: false
     use_images: false
     use_features: true
+    zoo_requirements:
+    - coco.defaults
     # annotation_style can be coco or textcaps which allows us to override
     # the dataset class
     annotation_style: coco

--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -451,3 +451,13 @@ movie_mcan:
         file_name: movie_mcan.grid.vqa2_vg.tar.gz
         hashcode: eb155846799d12c0b989490595ce57aa934cd7c71fc9956235e4d9e06cbe8985
     defaults: ${movie_mcan.grid.vqa2_vg}
+
+butd:
+  defaults: ${butd.coco}
+  coco:
+    # Model from project : projects/butd, Karpathy Val: BLEU4 0.36
+    version: 1.0_2020_08_19
+    resources:
+    - url: mmf://models/butd/butd.coco.tar.gz
+      file_name: butd.coco.tar.gz
+      hashcode: 55e57d791e6e5c785b96d8254ef48f3d9b5b107ff1152560b09d868f88c3598f

--- a/mmf/models/butd.py
+++ b/mmf/models/butd.py
@@ -155,8 +155,25 @@ class BUTD(Pythia):
             else:
                 scores[:batch_size_t, t] = output
 
-        model_output = {"scores": scores}
+        model_output = {}
         if self.config.inference.type in ["beam_search", "nucleus_sampling"]:
-            model_output["captions"] = decoder.get_result()
+            results = decoder.get_result()
+            results = torch.nn.functional.pad(
+                results,
+                (0, self.text_processor.max_length - results.size()[-1]),
+                "constant",
+                0,
+            )
+            model_output["captions"] = results
+            model_output["losses"] = {}
+            loss_key = "{}/{}".format(
+                sample_list.dataset_name, sample_list.dataset_type
+            )
+            # Add a dummy loss so that loss calculation is not required
+            model_output["losses"][loss_key + "/dummy_loss"] = torch.zeros(
+                batch_size, device=sample_list.answers.device
+            )
+        else:
+            model_output["scores"] = scores
 
         return model_output

--- a/mmf/modules/metrics.py
+++ b/mmf/modules/metrics.py
@@ -268,7 +268,7 @@ class CaptionBleu4Metric(BaseMetric):
         self._bleu_score = bleu_score
         super().__init__("caption_bleu4")
         self.caption_processor = registry.get("coco_caption_processor")
-        self.required_params = ["scores", "answers"]
+        self.required_params = ["scores", "answers", "captions"]
 
     def calculate(self, sample_list, model_output, *args, **kwargs):
         """Calculate accuracy and return it back.
@@ -295,7 +295,10 @@ class CaptionBleu4Metric(BaseMetric):
             references.append(img_captions)
 
         # Hypotheses
-        scores = torch.max(model_output["scores"], dim=-1)[1]
+        if "captions" in model_output:
+            scores = model_output["captions"]
+        else:
+            scores = torch.max(model_output["scores"], dim=-1)[1]
         scores = scores.tolist()
         predictions = []
         for j, _ in enumerate(scores):


### PR DESCRIPTION
Fixes #482 #489 

Previously caption bleu4 metric in mmf could not be directly used with Beam Search(BS), Nucleus Sampling(NS). The process to follow was extract the predictions and then compare separately. 

- Adds support for calculating metrics when using BS, NS
- Uploaded new model to zoo trained with latest features. Old model when used with new features with mmf doesn't work. Issue #489 
- Modified `accumulate_tensor_fields` to throw a warning instead of KeyError when some metric field is not available. This is done to support use cases where different model output needs to be accumulated depending on train/val/test stages.
- Fix zoo requirement for coco captioning
- Fixes the issue of CUDA OOM when running inference with BS, NS on a GPU with less memory. Now only the captions(bsxcap_len) are used instead of scores (bs x cap_len x vocab_sz).  