### PR TITLE
[fix] PathManager in sweep script as part of Manifold Migration

### DIFF
--- a/tools/sweeps/lib/__init__.py
+++ b/tools/sweeps/lib/__init__.py
@@ -75,7 +75,7 @@ def get_args():
     else:
         default_backend = "fblearner"
         parser.add_argument(
-            "--checkpoints-dir",
+            "--checkpoints_dir",
             default=os.path.join(
                 "/mnt/vol/gfsai-east/ai-group/users",
                 os.environ["USER"],


### PR DESCRIPTION
Summary:
Adopting `PathManager` for various file io utilities as part of Manifold migration.

The default checkpoint_dir is still gluster, because I'm assuming not everyone has a manifold directory.  To use a manifold_dir, we would sent it as an argument `--checkpoints_dir <manifold_save_dir>` via cli.

Reasons for all the if-else statements within `fblearner.py` for manifold vs gluster,
*  this diff actually slows down submitting jobs to flow (because of the PathManager dependency).
* It also requires a custom built kernel with torch instead of a regular bento kernel to run the flow script.

Other changes

* simplified the logic of `has_started`
* better logging of run in progress and what to do
* check for `config.yaml` instead of `train.log` to determine if run exists

Differential Revision: D23236008

