### PR TITLE
[fix] Unimodal base in case of batch size 2

### DIFF
--- a/mmf/models/unimodal.py
+++ b/mmf/models/unimodal.py
@@ -29,7 +29,7 @@ class UnimodalBase(MultiModalEncoderBase):
     def forward(self, x, *args, **kwargs):
         x = self.encoder(x, *args, **kwargs)
         # Case of bert encoder, we only need pooled output
-        if len(x) == 2:
+        if not torch.is_tensor(x) and len(x) == 2:
             x = x[1]
 
         x = torch.flatten(x, start_dim=1)


### PR DESCRIPTION
Current implementation uses `len` to check whether output was from bert encoder or not. Add extra check for `torch.is_tensor` so that image features case for batch size 2 safely works.

Test Plan:

Tested on batch size 2.