### PR TITLE
[fix] Fix multilabel macro-f1  inheritance

### DIFF
--- a/mmf/modules/metrics.py
+++ b/mmf/modules/metrics.py
@@ -802,7 +802,7 @@ class MultiLabelMicroF1(MultiLabelF1):
 
 
 @registry.register_metric("multilabel_macro_f1")
-class MultiLabelMacroF1(F1):
+class MultiLabelMacroF1(MultiLabelF1):
     """Metric for calculating Multilabel Macro F1.
 
     **Key:** ``multilabel_macro_f1``

--- a/tests/modules/test_metrics.py
+++ b/tests/modules/test_metrics.py
@@ -130,7 +130,7 @@ class TestModuleMetrics(unittest.TestCase):
 
     def test_multilabel_macro_f1(self):
         metric = metrics.MultiLabelMacroF1()
-        self._test_multilabel_metric(metric, 0.13333)
+        self._test_multilabel_metric(metric, 0.355555)
 
     def test_macro_roc_auc(self):
         metric = metrics.MacroROC_AUC()


### PR DESCRIPTION
- Fixes MultiLabel Macro F1 metric. It should inherit from the `MultiLabelF1`.
- Fixes an issue with a recent change in pytorch 1.7+, where earlier argmax would return the index of ANY min or max, but now they will return the index of the FIRST min or max.


Test Plan:
Tests passed