### PR TITLE
train retriever; model interface, retrieval training loop, and tuple dataset

### DIFF
--- a/mmf/configs/datasets/vqa2/train_retriever.yaml
+++ b/mmf/configs/datasets/vqa2/train_retriever.yaml
@@ -1,0 +1,83 @@
+dataset_config:
+  coco_tuple:
+      data_dir: ${env.data_dir}/datasets
+      depth_first: false
+      fast_read: false
+      use_images: true
+      use_features: false
+      images:
+        train:
+        - coco/defaults/images/train2014
+        val:
+        - coco/defaults/images/val2014
+        test:
+        - coco/defaults/images/val2014
+      features:
+        train:
+        - coco/defaults/features/trainval2014.lmdb
+        val:
+        - coco/defaults/features/trainval2014.lmdb
+        test:
+        - coco/defaults/features/test2015.lmdb
+      annotations:
+        train:
+        - coco/defaults/annotations/imdb_karpathy_train_by_image_retrieve.jsonl
+        val:
+        - coco/defaults/annotations/imdb_karpathy_val_by_image_retrieve.jsonl
+        test:
+        - coco/defaults/annotations/imdb_karpathy_val_by_image_retrieve.jsonl
+        ref:
+        - coco_train_dev_retrieverset.jsonl
+      max_features: 100
+      processors:
+        text_processor:
+          type: bert_tokenizer
+          params:
+            tokenizer_config:
+              type: bert-base-uncased
+              params:
+                do_lower_case: true
+            mask_probability: 0
+            max_seq_length: 128
+        answer_processor:
+          type: vqa_answer
+          params:
+            num_answers: 10
+            vocab_file: vqa2/defaults/extras/vocabs/answers_vqa.txt
+            preprocessor:
+              type: simple_word
+              params: {}
+        context_processor:
+          type: fasttext
+          params:
+            download_initially: false
+            max_length: 50
+            model_file: wiki.en.bin
+        ocr_token_processor:
+          type: simple_word
+          params: {}
+        bbox_processor:
+          type: bbox
+          params:
+            max_length: 50
+        image_processor:
+          type: torchvision_transforms
+          params:
+            transforms:
+              - type: Resize
+                params:
+                  size: [256, 256]
+              - type: CenterCrop
+                params:
+                  size: [224, 224]
+              - ToTensor
+              - GrayScaleTo3Channels
+              - type: Normalize
+                params:
+                  mean: [0.46777044, 0.44531429, 0.40661017]
+                  std: [0.12221994, 0.12145835, 0.14380469]
+      return_features_info: false
+      # Return OCR information
+      use_ocr: false
+      # Return spatial information of OCR tokens if present
+      use_ocr_info: false

--- a/mmf/configs/models/mmbt_rag/defaults.yaml
+++ b/mmf/configs/models/mmbt_rag/defaults.yaml
@@ -1,0 +1,33 @@
+model_config:
+  mmbt_rag:    
+    training_head_type: pretraining
+    bert_model_name: bert-base-uncased
+    direct_features_input: false
+    freeze_text: false
+    freeze_modal: false
+    freeze_complete_base: false
+    finetune_lr_multiplier: 1
+    # Dimension of the embedding finally returned by the modal encoder
+    modal_hidden_size: 2048
+    # Dimension of the embedding finally returned by the text encoder
+    text_hidden_size: 768
+    # Used when classification head is activated
+    num_labels: 2
+    modal_encoder:
+      type: resnet152
+      params:
+        pretrained: true
+        pool_type: avg
+        num_output_features: 1
+    use_modal_start_token: true
+    use_modal_end_token: true
+    text_encoder:
+      type: transformer
+      params:
+        num_segments: 2
+        bert_model_name: ${model_config.mmbt_rag.bert_model_name}
+        hidden_size: 768
+        num_hidden_layers: 12
+        num_attention_heads: 12
+        output_attentions: false
+        output_hidden_states: false

--- a/mmf/configs/models/mmbt_rag/pretrain.yaml
+++ b/mmf/configs/models/mmbt_rag/pretrain.yaml
@@ -1,0 +1,2 @@
+includes:
+- ./defaults.yaml

--- a/mmf/configs/models/mmbt_rag/retriever_vqa2.yaml
+++ b/mmf/configs/models/mmbt_rag/retriever_vqa2.yaml
@@ -1,0 +1,9 @@
+includes:
+- ./defaults.yaml
+
+model_config:
+  mmbt_rag:
+    training_head_type: classification
+    num_labels: 3129
+    losses:
+      - type: ${ret_trainer_config.loss}

--- a/mmf/configs/models/mmbt_rag/with_features.yaml
+++ b/mmf/configs/models/mmbt_rag/with_features.yaml
@@ -1,0 +1,11 @@
+model_config:
+  mmbt:
+    model_data_dir: ${env.data_dir}
+    direct_features_input: true
+    modal_encoder:
+      type: finetune_faster_rcnn_fpn_fc7
+      params:
+        in_dim: 2048
+        bias_file: models/detectron.defaults/fc7_b.pkl
+        weights_file: models/detectron.defaults/fc7_w.pkl
+        model_data_dir: ${model_config.mmbt.model_data_dir}

--- a/mmf/datasets/builders/coco/builder.py
+++ b/mmf/datasets/builders/coco/builder.py
@@ -6,7 +6,7 @@
 #
 
 from mmf.common.registry import registry
-from mmf.datasets.builders.coco.dataset import COCODataset
+from mmf.datasets.builders.coco.dataset import COCODataset, COCOTupleDataset
 from mmf.datasets.builders.textcaps.dataset import TextCapsDataset
 from mmf.datasets.builders.vqa2 import VQA2Builder
 
@@ -47,3 +47,10 @@ class COCOBuilder(VQA2Builder):
         dataset = super().load(config, *args, **kwargs)
         dataset.dataset_name = self.dataset_name
         return dataset
+
+@registry.register_builder("coco_tuple")
+class COCOTupleBuilder(COCOBuilder):
+    def __init__(self):
+        super().__init__()
+        self.dataset_name = "coco_tuple"
+        self.set_dataset_class(COCOTupleDataset)

--- a/mmf/models/interfaces/retriever.py
+++ b/mmf/models/interfaces/retriever.py
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Type, Union
+
+import torch
+from torch.nn import functional as F
+from PIL import Image
+from torch import nn
+
+ImageType = Union[Type[Image.Image], str]
+
+
+class RetrieverInterface(nn.Module):
+    """Interface for MMBT Grid for Hateful Memes.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def ref_encode_image(self, image: ImageType):
+        raise NotImplementedError
+
+    def ref_encode_text(self, input_ids, segment_ids):
+        raise NotImplementedError
+
+    def calc_batch_sim(self, rawQ_embeds, rawA_embeds):
+        rawA_embeds = F.normalize(rawA_embeds)
+        rawQ_embeds = F.normalize(rawQ_embeds)
+        sim_scores = torch.matmul(rawQ_embeds, rawA_embeds.T)
+        return sim_scores
+
+    def convert_dims(self, embeds):
+        if len(embeds.shape) != 2:
+            if len(embeds.shape) == 1:
+                embeds = embeds.unsqueeze(0)
+            if len(embeds.shape) == 3:
+                embeds = embeds.squeeze(1)
+
+        assert len(embeds.shape) == 2
+        return embeds

--- a/mmf/models/mmbt_rag.py
+++ b/mmf/models/mmbt_rag.py
@@ -1,0 +1,147 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# MMBTModel, ModalEmbeddings is copied from [1]
+# as we have internal dependency on transformers v2.3.
+# These will be removed when we upgrade to package v2.5+.
+# [1]: https://github.com/huggingface/transformers/blob/master/src/transformers/modeling_mmbt.py # noqa
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.mmbt import MMBT, MMBTBase, MMBTConfig, MMBTModel, MMBTForClassification
+from mmf.models.interfaces.retriever import RetrieverInterface
+
+
+# TODO: Remove after transformers package upgrade to 2.5
+class MMBTModelRAG(MMBTModel, RetrieverInterface):
+
+    def __init__(self, config, transformer, encoder):
+        super().__init__(config, transformer, encoder)
+        self.config = config
+
+    def proj_modal_embeddings(self, input_modal):
+        modal_embeds = self.modal_encoder.encoder(input_modal)
+        proj_embeds = self.modal_encoder.proj_embeddings(modal_embeds)
+        return proj_embeds
+
+    def ref_encode_image(self, input_modal):
+        proj_embeds = self.proj_modal_embeddings(input_modal)
+        return proj_embeds
+
+    def ref_encode_text(
+        self,
+        input_ids=None,
+        inputs_embeds=None,
+        position_ids=None,
+        token_type_ids=None,
+        encoder_hidden_states=None,
+    ):
+
+        if input_ids is not None:
+            input_txt_shape = input_ids.size()
+        elif inputs_embeds is not None:
+            input_txt_shape = inputs_embeds.size()[:-1]
+        else:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        if token_type_ids is None:
+            token_type_ids = torch.ones(
+                input_txt_shape, dtype=torch.long, device=input_ids.device
+            )
+
+        txt_embeddings = self.transformer.embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+            inputs_embeds=inputs_embeds,
+        )
+
+        masks = self.construct_masks(
+            txt_embeddings,
+            input_modal_shape=None,
+            attention_mask=None,
+            encoder_attention_mask=None,
+            head_mask=None
+        )
+
+        attention_mask, encoder_attention_mask, head_mask = masks
+
+        encoder_outputs = self.transformer.encoder(
+            txt_embeddings,
+            attention_mask=attention_mask,
+            head_mask=head_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+        )
+
+        # [bs,131,768]
+        sequence_output = encoder_outputs[0]
+        # [bs,768]
+        pooled_output = self.transformer.pooler(sequence_output)
+
+        outputs = (sequence_output, pooled_output) + encoder_outputs[
+            1:
+        ]
+
+        return outputs[1]
+
+
+class MMBTBaseRAG(MMBTBase, RetrieverInterface):
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+
+    def build(self):
+        super().build()
+        encoders = self._build_encoders(self.config)
+        text_encoder, modal_encoder = encoders[0], encoders[1]
+        self._encoder_config = text_encoder.config
+
+        self._mmbt_config = MMBTConfig(
+            self._encoder_config,
+            num_labels=self.config.num_labels,
+            modal_hidden_size=self.config.modal_hidden_size,
+        )
+
+        self.mmbt = MMBTModelRAG(self._mmbt_config, text_encoder, modal_encoder)
+
+    def ref_encode_image(self, input_modal):
+        return self.mmbt.ref_encode_image(input_modal)
+
+    def ref_encode_text(self, input_ids, segment_ids):
+        return self.mmbt.ref_encode_text(
+            input_ids=input_ids,
+            token_type_ids=segment_ids,
+            position_ids=None,
+            inputs_embeds=None,
+        )
+
+
+class MMBTForClassificationRAG(MMBTForClassification, RetrieverInterface):
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        self.config = config
+        self.bert = MMBTBaseRAG(config, *args, **kwargs)
+
+    def ref_encode_image(self, input_modal):
+        return self.bert.ref_encode_image(input_modal)
+
+    def ref_encode_text(self, input_ids, segment_ids):
+        return self.bert.ref_encode_text(input_ids, segment_ids)
+
+    def ref_encode_image_text(self, batch):
+        # same as line pooled_output = module_output[1] in foward
+        return self.bert(batch)[1]
+
+
+@registry.register_model("mmbt_rag")
+class MMBTRAG(MMBT, RetrieverInterface):
+    def __init__(self, config):
+        super().__init__(config)
+
+    def build(self):
+        self.model = MMBTForClassificationRAG(self.config)
+
+    def ref_encode_image(self, input_modal):
+        return self.model.ref_encode_image(input_modal)
+
+    def ref_encode_text(self, input_ids, segment_ids):
+        return self.model.ref_encode_text(input_ids, segment_ids)

--- a/mmf/trainers/mmf_retriever_trainer.py
+++ b/mmf/trainers/mmf_retriever_trainer.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.common import typings as mmf_typings
+from mmf.common.registry import registry
+from mmf.trainers.mmf_trainer import MMFTrainer
+from mmf.trainers.core.training_loop import TrainerRetrieverTrainingLoopMixin
+
+
+@registry.register_trainer("mmf_ret")
+class MMFRetTrainer(
+    MMFTrainer,
+    TrainerRetrieverTrainingLoopMixin,
+):
+    def __init__(self, config: mmf_typings.DictConfig):
+        super().__init__(config)
+        TrainerRetrieverTrainingLoopMixin.__init__(config)

--- a/projects/mm_rag/configs/mmbt/default_optimizer_retriever.yaml
+++ b/projects/mm_rag/configs/mmbt/default_optimizer_retriever.yaml
@@ -1,0 +1,27 @@
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+evaluation:
+    metrics:
+    - accuracy
+
+training:
+  batch_size: 64
+  lr_scheduler: true
+  max_updates: 22000
+  early_stop:
+    criteria: total_loss
+    minimize: true
+
+checkpoint:
+  pretrained_state_mapping:
+    bert: bert

--- a/projects/mm_rag/configs/mmbt/rag_defaults.yaml
+++ b/projects/mm_rag/configs/mmbt/rag_defaults.yaml
@@ -1,0 +1,13 @@
+env:
+  ref_index_dir: null
+  ref_rawimage_dir: null
+rag_config:
+  knn: 1
+  retrieve_mode: image
+  ref_set: coco
+  faiss_index_type: L2
+  augment_types: all_caption_str
+  exp: ptdefaults
+
+ret_trainer_config:
+  loss: batch_cross_entropy

--- a/projects/mm_rag/configs/mmbt/train_retriever.yaml
+++ b/projects/mm_rag/configs/mmbt/train_retriever.yaml
@@ -1,0 +1,9 @@
+training:
+  trainer: mmf_ret
+  task: vqa2
+
+includes:
+- ../../../../mmf/configs/models/mmbt_rag/retriever_${training.task}.yaml
+- ../../../../mmf/configs/datasets/${training.task}/train_retriever.yaml
+- ./default_optimizer_retriever.yaml
+- ./rag_defaults.yaml


### PR DESCRIPTION
Summary:
Extending MMBT for training a unimodal (I to I, T to T) and bimodal (I, T to I, T) retriever. I is Image and T is Text.

To train a retriever, we need to first construct a tuple dataset, which has anchor item and a reference to its positive item. The anchor item is loaded as per usual from dataloader, but the reference item can come from anywhere.

* New Dataset and Datasetbuilder, where we use `COCOTupleDataset` to demonstrate.

  * XTupleDataset, inherits from X Dataset but has an additional field `pos_image_ids` which needs to be prepared beforehand. These are its positive/similar image_ids (ref_ids).

  * A reference file which provides the mapping to the datapoint via the image_ids (ref_ids). The reference file does not need to be loaded by data loader and can come from anywhere.
`self.ref_data = self.construct_refdata()`

* Retriever Interface for any model in MMF to inherit, should implement `ref_encode_image` and `ref_encode_text`, which is used in unimodal and bimodal retrieval training.
  * `faim/mmf/mmf/models/interfaces/retriever.py`

  * `mmbt_rag` which inherits from `mmbt` and `RetrieverInterface` is used as an example here.

* New config files for `mm_rag`:
  * faim/mmf/projects/mm_rag/configs/mmbt
    * default_optimizer_retriever.yaml
    * rag_defaults.yaml
    * train_retriever.yaml

Limitations:

* While we have a way to train, we currently don't have a way to evaluate retrieval performance outside of batch training. Currently metrics like accuracy are tied to inbatch accuracy. Early stop is also tied to inbatch loss.
* For actual retrieval evaluation, we need to encode all items in the reference set into something like a faiss index and then calculate Precision Recall.
* The way the reference set is loaded in `faim/mmf/mmf/datasets/coco/dataset.py: COCOTupleDataset` is kind of ugly but we wanted a way to sample similar images randomly during training (not fix the anchor and positive item pair).

Differential Revision: D23304586

