### PR TITLE
[fix] load lr scheduler state dict during checkpoint loading

### DIFF
--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -55,9 +55,12 @@ class MMFTrainer(
         self.lr_scheduler_callback = LRSchedulerCallback(self.config, self)
 
         # Add callbacks for execution during events
+        self.callbacks.append(self.lr_scheduler_callback)
+        # checkpoint_callback needs to be called after lr_scheduler_callback so that
+        # lr_scheduler_callback._scheduler.step() happens before saving checkpoints
+        # (otherwise the saved last_epoch in scheduler would be wrong)
         self.callbacks.append(self.checkpoint_callback)
         self.callbacks.append(self.logistics_callback)
-        self.callbacks.append(self.lr_scheduler_callback)
 
     def load_datasets(self):
         logger.info("Loading datasets")


### PR DESCRIPTION
Summary: the current implementation does not load lr_scheduler's states from checkpoints, which is a bug (causing last_epoch to be reset when loading from checkpoints). This commit fixes it by saving and loading lr_scheduler's states. It fall backs to setting lr_scheduler's last_epoch when lr_scheduler's states don't exist in checkpoint.

Test Plan: tested with M4C checkpoint saving and loading.

(CPU tests failed due to black formatting error in mmf/datasets/processors/bert_processors.py, unrelated to this PR.)