### PR TITLE
[feat] Enable caption generation for all datasets registered to MMF

### DIFF
--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -151,7 +151,14 @@ class TestReporter(Dataset):
         if not is_master():
             return
 
-        results = self.current_dataset.format_for_prediction(report)
+        inference_type = None
+        if self.config.model == "butd":
+            inference_type = self.config.model_config.butd.inference.type
+
+        if inference_type in ["beam_search", "nucleus_sampling"]:
+            results = self.current_dataset.format_for_caption_generation(report)
+        else:
+            results = self.current_dataset.format_for_prediction(report)
 
         if hasattr(model, "format_for_prediction"):
             results = model.format_for_prediction(results, report)

--- a/mmf/configs/datasets/hateful_memes/for_butd_caption_generation.yaml
+++ b/mmf/configs/datasets/hateful_memes/for_butd_caption_generation.yaml
@@ -1,0 +1,42 @@
+dataset_config:
+  hateful_memes:
+    data_dir: ${env.data_dir}/datasets
+    depth_first: false
+    fast_read: false
+    use_images: false
+    use_features: true
+    images:
+      val:
+      - hateful_memes/defaults/images/
+    features:
+      val:
+      - hateful_memes/defaults/features/detectron.lmdb
+    annotations:
+      val:
+      - hateful_memes/defaults/annotations/train.jsonl
+    processors:
+      text_processor:
+        type: vocab
+        params:
+          max_length: 52
+          vocab:
+            type: intersected
+            embedding_name: glove.6B.300d
+            vocab_file: coco/defaults/extras/vocabs/vocabulary_captioning_thresh5.txt
+          preprocessor:
+            type: simple_sentence
+            params: {}
+      caption_processor:
+        type: caption
+        params:
+          vocab:
+            type: intersected
+            embedding_name: glove.6B.300d
+            vocab_file: coco/defaults/extras/vocabs/vocabulary_captioning_thresh5.txt
+
+      context_processor:
+        type: fasttext
+        params:
+          download_initially: false
+          max_length: 50
+          model_file: wiki.en.bin

--- a/mmf/configs/datasets/vqa2/for_butd_caption_generation.yaml
+++ b/mmf/configs/datasets/vqa2/for_butd_caption_generation.yaml
@@ -1,0 +1,36 @@
+dataset_config:
+  vqa2:
+    data_dir: ${env.data_dir}/datasets
+    depth_first: false
+    fast_read: false
+    use_images: false
+    use_features: true
+    images:
+      val:
+      - coco/defaults/images/train2014
+    features:
+      val:
+      - coco/defaults/features/trainval2014.lmdb
+    annotations:
+      val: 
+      - vqa2/defaults/annotations/imdb_train2014.npy
+    processors:
+      text_processor:
+        type: vocab
+        params:
+          max_length: 52
+          vocab:
+            type: intersected
+            embedding_name: glove.6B.300d
+            vocab_file: coco/defaults/extras/vocabs/vocabulary_captioning_thresh5.txt
+          preprocessor:
+            type: simple_sentence
+            params: {}
+      caption_processor:
+        type: caption
+        params:
+          vocab:
+            type: intersected
+            embedding_name: glove.6B.300d
+            vocab_file: coco/defaults/extras/vocabs/vocabulary_captioning_thresh5.txt
+    min_captions_per_img: 5

--- a/projects/butd/configs/hateful_memes/generate_caption.yaml
+++ b/projects/butd/configs/hateful_memes/generate_caption.yaml
@@ -1,0 +1,3 @@
+includes:
+- ../coco/beam_search.yaml
+- ../../../../mmf/configs/datasets/hateful_memes/for_butd_caption_generation.yaml

--- a/projects/butd/configs/vqa2/generate_caption.yaml
+++ b/projects/butd/configs/vqa2/generate_caption.yaml
@@ -1,0 +1,3 @@
+includes:
+- ../coco/beam_search.yaml
+- ../../../../mmf/configs/datasets/vqa2/for_butd_caption_generation.yaml


### PR DESCRIPTION
Summary:
Previously, caption generation could only be done for datasets which had “answers” as a data field and produced “scores”. This PR removes that dependency and should preserve all previous logic.

This PR allows the caption generation model to be applied to any dataset registered in MMF.

* removes the dependency on “answers” being in the text field in `utils/text.py` and `models/butd.py`.

* All datasets which inherit from mmf_dataset.py have a new function `format_for_caption_generation` 

* This function is modified from `mmf/datasets/builders/coco/dataset.py: format_for_caption_generation`, and preserves all keys with string `id`.

*`test_reporter.py` doesn’t require `scores` to be present for caption generation, and directly calls `format_for_caption_generation` if model is butd and in generation mode.

Differential Revision: D23339848

