### PR TITLE
[fix] Fix grad accumulation logic for Iterable datasets

### DIFF
--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -40,6 +40,7 @@ class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
         self.train_loader = torch.utils.data.DataLoader(
             dataset=dataset, batch_size=1, shuffle=False, num_workers=1, drop_last=False
         )
+        self.train_loader.current_dataset = dataset
         self.on_batch_start = MagicMock(return_value=None)
         self.on_update_start = MagicMock(return_value=None)
         self.logistics_callback = MagicMock(return_value=None)


### PR DESCRIPTION
PR #367  breaks training with `IterableDataset` as `len(self.train_loader) == 0` since `__len__` is not implemented for every `IterableDataset`. This PR mitigates this regression and :

- Sets `num_remaining_batches` to be equal to  (number of updates remaining x update frequency) for `IterableDataset` case. For non `IterableDataset` the old behavior is maintained (`len(self.train_loader)`)
- Modifies the logic to avoid the need for checking if iterator has finished
- Fixes another instance where we used to check `len(self.train_loader)` for setting number of updates when `max_epochs` is  specified. Now in case of `IterableDataset` it will fall back to using `max_updates`. Added warning.


Test Plan:

- Tested internally on FB datasets
- Tested on Hateful Memes