### PR TITLE
[fix] Fix lxmert model bbox processing

### DIFF
--- a/mmf/datasets/builders/vqa2/masked_dataset.py
+++ b/mmf/datasets/builders/vqa2/masked_dataset.py
@@ -22,8 +22,7 @@ class MaskedVQA2Dataset(VQA2Dataset):
 
         if self._use_features:
             features = self.features_db[idx]
-
-            if self.config.get("transformer_bbox_processor", False):
+            if hasattr(self, "transformer_bbox_processor"):
                 features["image_info_0"] = self.transformer_bbox_processor(
                     features["image_info_0"]
                 )

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -1451,7 +1451,7 @@ class TransformerBboxProcessor(BaseProcessor):
         image_w = item[self.image_width_key]
         image_h = item[self.image_height_key]
         image_location = torch.zeros((bbox.shape[0], 5), dtype=torch.float)
-        image_location[:, :4] = torch.from_numpy(bbox)
+        image_location[:, :4] = torch.from_numpy(bbox[:, :4])
         image_location[:, 4] = (
             (image_location[:, 3] - image_location[:, 1])
             * (image_location[:, 2] - image_location[:, 0])

--- a/mmf/models/lxmert.py
+++ b/mmf/models/lxmert.py
@@ -661,35 +661,15 @@ class LXMERT(BaseModel):
         image_info = getattr(sample_list, "image_info_0", {})
         image_dim_variable = getattr(image_info, "max_features", None)
         image_feature_variable = getattr(sample_list, "image_feature_0", None)
-        if image_feature_variable is None:
-            raise Exception("object features must be provided for lxmert")
-        bbox = getattr(image_info, "bbox", None)
-        if bbox is None:
-            raise Exception("bounding boxes must be provided for lxmert")
-        else:
-            bbox = torch.tensor(bbox)
-            max_features = torch.tensor(
-                min(image_feature_variable.shape[1], bbox.shape[1]), dtype=torch.int
-            ).to(device)
-            bbox = bbox[:, : max_features.item(), :4]
-            image_h = getattr(image_info, "image_height", None)
-            image_w = getattr(image_info, "image_width", None)
-            if image_h is not None and image_w is not None:
-                image_h = torch.tensor(image_h, dtype=torch.int)
-                image_w = torch.tensor(image_w, dtype=torch.int)
-                image_location = torch.zeros(tuple(bbox.shape))
-                image_location[:, :, 0] /= image_w[:, None]
-                image_location[:, :, 1] /= image_h[:, None]
-                image_location[:, :, 2] /= image_w[:, None]
-                image_location[:, :, 3] /= image_h[:, None]
-            else:
-                image_location = bbox
-            image_location_variable = image_location.to(device)
+        max_features = torch.tensor(
+            image_feature_variable.shape[1], dtype=torch.int
+        ).to(device)
+        image_location_variable = getattr(image_info, "bbox", None)
+        image_location_variable = image_location_variable[:, : max_features.item(), :4]
 
         # aux data
         image_label_variable = getattr(sample_list, "image_labels", None)
         if image_label_variable is not None:
-            image_label_variable = torch.tensor(image_label_variable, dtype=torch.long)
             image_label_variable = image_label_variable[:, : max_features.item(), None]
             image_label_variable = image_label_variable.unsqueeze(-1).to(device)
         cls_prob = getattr(image_info, "cls_prob", None)

--- a/projects/lxmert/configs/coco/masked.yaml
+++ b/projects/lxmert/configs/coco/masked.yaml
@@ -56,3 +56,9 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.9
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height

--- a/projects/lxmert/configs/gqa/masked.yaml
+++ b/projects/lxmert/configs/gqa/masked.yaml
@@ -47,6 +47,12 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.90
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
       answer_processor:
         type: vqa_answer
         params:

--- a/projects/lxmert/configs/visual_genome/masked.yaml
+++ b/projects/lxmert/configs/visual_genome/masked.yaml
@@ -85,6 +85,12 @@ dataset_config:
             params:
               do_lower_case: true
           max_seq_length: 20
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
       return_scene_graph: false
       return_objects: false
       return_relationships: false

--- a/projects/lxmert/configs/vqa2/defaults.yaml
+++ b/projects/lxmert/configs/vqa2/defaults.yaml
@@ -18,6 +18,12 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0
           max_seq_length: 20
+      transformer_bbox_processor:
+        type: transformer_bbox
+        params:
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
 
 optimizer:
   type: adam_w

--- a/projects/lxmert/configs/vqa2/masked.yaml
+++ b/projects/lxmert/configs/vqa2/masked.yaml
@@ -51,10 +51,12 @@ dataset_config:
         params:
           mask_probability: 0.15
           mask_region_probability: 0.9
-      bbox_processor:
-        type: bbox
+      transformer_bbox_processor:
+        type: transformer_bbox
         params:
-          max_length: 36
+          bbox_key: bbox
+          image_width_key: image_width
+          image_height_key: image_height
       attribute_processor:
         type: vocab
         params:


### PR DESCRIPTION
- Fixes #520 and use `transformer_bbox_processor` processor
- `transformer_bbox_processor` will now work when bbox features already have area norm


Test Plan:

Run lxmert model for pretraining and finetuning on vqa2