### PR TITLE
[fix] Answer processor issues in MaskedVQA2Dataset

### DIFF
--- a/mmf/configs/datasets/vqa2/masked.yaml
+++ b/mmf/configs/datasets/vqa2/masked.yaml
@@ -4,6 +4,7 @@ dataset_config:
     depth_first: false
     fast_read: false
     use_images: false
+    add_answer: false
     use_features: true
     zoo_requirements:
     - coco.defaults
@@ -34,6 +35,14 @@ dataset_config:
               do_lower_case: true
           mask_probability: 0.15
           max_seq_length: 128
+      answer_processor:
+        type: vqa_answer
+        params:
+          num_answers: 10
+          vocab_file: vqa2/defaults/extras/vocabs/answers_vqa.txt
+          preprocessor:
+            type: simple_word
+            params: {}
       masked_region_processor:
         type: masked_region
         params:

--- a/mmf/datasets/builders/vqa2/masked_dataset.py
+++ b/mmf/datasets/builders/vqa2/masked_dataset.py
@@ -14,9 +14,9 @@ class MaskedVQA2Dataset(VQA2Dataset):
             *args,
             **kwargs
         )
-        self._add_answer = config.get("add_answer", True)
+        self._add_answer = config.get("add_answer", False)
 
-    def load_item(self, idx):
+    def __getitem__(self, idx):
         sample_info = self.annotation_db[idx]
         current_sample = Sample()
 


### PR DESCRIPTION
- Adds add_answer option to default config
- Set it to default in the dataset
- Add default answer processor config

Test Plan:

Tested on full masked_vqa2 config under VisualBERT
