### PR TITLE
[fix] modify mmf_convert_hm to create a copy of a file

### DIFF
--- a/mmf/utils/download.py
+++ b/mmf/utils/download.py
@@ -423,6 +423,13 @@ def move(path1, path2):
     shutil.move(path1, path2)
 
 
+def copy(path1, path2):
+    """
+    Copy the given file from path1 to path2.
+    """
+    shutil.copy(path1, path2)
+
+
 def remove_dir(path):
     """
     Remove the given directory, if it exists.

--- a/mmf_cli/hm_convert.py
+++ b/mmf_cli/hm_convert.py
@@ -57,6 +57,9 @@ class HMConverter:
             "--password", required=True, type=str, help="Password for the zip file"
         )
         parser.add_argument(
+            "--move", required=None, type=int, help="Move data dir to mmf cache dir"
+        )
+        parser.add_argument(
             "--mmf_data_folder", required=None, type=str, help="MMF Data folder"
         )
         parser.add_argument(
@@ -86,13 +89,21 @@ class HMConverter:
         images_path = os.path.join(base_path, "images")
         PathManager.mkdirs(images_path)
 
+        move_dir = False
+        if self.args.move:
+            move_dir = bool(self.args.move)
+
         if not bypass_checksum:
             self.checksum(self.args.zip_file, self.POSSIBLE_CHECKSUMS)
 
         src = self.args.zip_file
-        print(f"Copying {src}")
         dest = images_path
-        copy(src, dest)
+        if move_dir:
+            print(f"Moving {src}")
+            move(src, dest)
+        else:
+            print(f"Copying {src}")
+            copy(src, dest)
 
         print(f"Unzipping {src}")
         self.decompress_zip(

--- a/mmf_cli/hm_convert.py
+++ b/mmf_cli/hm_convert.py
@@ -7,7 +7,7 @@ import subprocess
 import zipfile
 
 from mmf.utils.configuration import Configuration
-from mmf.utils.download import decompress, move
+from mmf.utils.download import copy, decompress, move
 from mmf.utils.file_io import PathManager
 
 
@@ -90,9 +90,9 @@ class HMConverter:
             self.checksum(self.args.zip_file, self.POSSIBLE_CHECKSUMS)
 
         src = self.args.zip_file
-        print(f"Moving {src}")
+        print(f"Copying {src}")
         dest = images_path
-        move(src, dest)
+        copy(src, dest)
 
         print(f"Unzipping {src}")
         self.decompress_zip(


### PR DESCRIPTION
This PR resolves #528 to ensure `mmf_convert_hm` preserves the original file

Test plan:
- tested it on the hateful memes dataset on colab and the original file is preserved.