### PR TITLE
[feat] Add torchscript support for VisualBERT

### DIFF
--- a/mmf/modules/embeddings.py
+++ b/mmf/modules/embeddings.py
@@ -395,10 +395,8 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
 
             # We want to averge along the alignment_number dimension.
             image_text_alignment_mask = image_text_alignment_mask.sum(2)
-            image_text_alignment_mask[
-                image_text_alignment_mask == 0
-            ] = torch.tensor(
-                [1]
+            image_text_alignment_mask[image_text_alignment_mask == 0] = torch.tensor(
+                [1], dtype=torch.long
             )  # Avoid devide by zero error
             position_embeddings_visual = (
                 position_embeddings_visual / image_text_alignment_mask.unsqueeze(-1)
@@ -423,7 +421,7 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
             position_embeddings_visual = self.position_embeddings_visual(
                 position_ids_visual
             )
-        
+
         return position_embeddings_visual
 
     def forward(

--- a/mmf/modules/embeddings.py
+++ b/mmf/modules/embeddings.py
@@ -14,7 +14,7 @@ from mmf.modules.bottleneck import MovieBottleneck
 from mmf.modules.layers import AttnPool1d, Identity
 from mmf.utils.file_io import PathManager
 from mmf.utils.vocab import Vocab
-from torch import nn
+from torch import Tensor, nn
 from transformers.modeling_bert import BertEmbeddings
 
 
@@ -322,7 +322,9 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
             deepcopy(self.position_embeddings.weight.data), requires_grad=True
         )
 
-    def encode_text(self, input_ids, token_type_ids=None, *args, **kwargs):
+    def encode_text(
+        self, input_ids: Tensor, token_type_ids: Optional[Tensor] = None
+    ) -> Tensor:
         seq_length = input_ids.size(1)
         position_ids = torch.arange(
             seq_length, dtype=torch.long, device=input_ids.device
@@ -340,13 +342,11 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
 
     def encode_image(
         self,
-        visual_embeddings,
-        visual_embeddings_type=None,
-        position_embeddings_visual=None,
-        image_text_alignment=None,
-        *args,
-        **kwargs,
-    ):
+        visual_embeddings: Tensor,
+        visual_embeddings_type: Tensor,
+        position_embeddings_visual: Optional[Tensor] = None,
+        image_text_alignment: Optional[Tensor] = None,
+    ) -> Tensor:
 
         visual_embeddings = self.projection(visual_embeddings)
         token_type_embeddings_visual = self.token_type_embeddings_visual(
@@ -371,18 +371,18 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
 
     def get_position_embeddings_visual(
         self,
-        visual_embeddings,
-        image_text_alignment=None,
-        position_embeddings_visual=None,
-        *args,
-        **kwargs,
-    ):
+        visual_embeddings: Tensor,
+        image_text_alignment: Optional[Tensor] = None,
+        position_embeddings_visual: Optional[Tensor] = None,
+    ) -> Tensor:
 
         if image_text_alignment is not None:
             # image_text_alignment = Batch x image_length x alignment_number.
             # Each element denotes the position of the word corresponding to the
             # image feature. -1 is the padding value.
-            image_text_alignment_mask = (image_text_alignment != -1).long()
+            image_text_alignment_mask = (
+                (image_text_alignment != -1).long().to(image_text_alignment.device)
+            )
             # Get rid of the -1.
             image_text_alignment = image_text_alignment_mask * image_text_alignment
 
@@ -390,37 +390,25 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
             # = Batch x image_length x alignment length x dim
             position_embeddings_visual = self.position_embeddings(
                 image_text_alignment
-            ) * image_text_alignment_mask.to(
-                dtype=next(self.parameters()).dtype
-            ).unsqueeze(
-                -1
-            )
+            ) * image_text_alignment_mask.unsqueeze(-1)
             position_embeddings_visual = position_embeddings_visual.sum(2)
 
             # We want to averge along the alignment_number dimension.
-            image_text_alignment_mask = image_text_alignment_mask.to(
-                dtype=next(self.parameters()).dtype
-            ).sum(2)
+            image_text_alignment_mask = image_text_alignment_mask.sum(2)
             image_text_alignment_mask[
                 image_text_alignment_mask == 0
-            ] = 1  # Avoid devide by zero error
+            ] = torch.tensor(
+                [1]
+            )  # Avoid devide by zero error
             position_embeddings_visual = (
                 position_embeddings_visual / image_text_alignment_mask.unsqueeze(-1)
             )
 
             position_ids_visual = torch.zeros(
-                *visual_embeddings.size()[:-1],
+                visual_embeddings.size()[:-1],
                 dtype=torch.long,
                 device=visual_embeddings.device,
             )
-
-            # When fine-tuning the detector , the image_text_alignment is
-            # sometimes padded too long.
-            if position_embeddings_visual.size(1) != visual_embeddings.size(1):
-                assert position_embeddings_visual.size(1) >= visual_embeddings.size(1)
-                position_embeddings_visual = position_embeddings_visual[
-                    :, : visual_embeddings.size(1), :
-                ]
 
             position_embeddings_visual = (
                 position_embeddings_visual
@@ -428,27 +416,25 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
             )
         else:
             position_ids_visual = torch.zeros(
-                *visual_embeddings.size()[:-1],
+                visual_embeddings.size()[:-1],
                 dtype=torch.long,
                 device=visual_embeddings.device,
             )
             position_embeddings_visual = self.position_embeddings_visual(
                 position_ids_visual
             )
-
+        
         return position_embeddings_visual
 
     def forward(
         self,
-        input_ids,
-        token_type_ids=None,
-        visual_embeddings=None,
-        visual_embeddings_type=None,
-        position_embeddings_visual=None,
-        image_text_alignment=None,
-        *args,
-        **kwargs,
-    ):
+        input_ids: Tensor,
+        token_type_ids: Optional[Tensor] = None,
+        visual_embeddings: Optional[Tensor] = None,
+        visual_embeddings_type: Optional[Tensor] = None,
+        position_embeddings_visual: Optional[Tensor] = None,
+        image_text_alignment: Optional[Tensor] = None,
+    ) -> Tensor:
         """
         input_ids = [batch_size, sequence_length]
         token_type_ids = [batch_size, sequence_length]
@@ -460,7 +446,7 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
         text_embeddings = self.encode_text(input_ids, token_type_ids=token_type_ids)
 
         # visual embeddings
-        if visual_embeddings is not None:
+        if visual_embeddings is not None and visual_embeddings_type is not None:
             v_embeddings = self.encode_image(
                 visual_embeddings,
                 visual_embeddings_type=visual_embeddings_type,

--- a/mmf/modules/hf_layers.py
+++ b/mmf/modules/hf_layers.py
@@ -1,0 +1,211 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import math
+from typing import Optional
+
+import torch
+from torch import Tensor, nn
+from transformers.modeling_bert import (
+    BertAttention,
+    BertIntermediate,
+    BertOutput,
+    BertSelfAttention,
+    BertSelfOutput,
+)
+
+
+class BertSelfAttentionJit(BertSelfAttention):
+    """
+    Torchscriptable version of `BertSelfAttention` from Huggingface transformers v2.3.0
+    https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py # noqa
+
+    Modifies the `forward` function and `transpose_for_scores` function
+    """
+
+    def transpose_for_scores(self, x):
+        new_x_shape = x.size()[:-1] + (
+            self.num_attention_heads,
+            self.attention_head_size,
+        )
+        x = x.view(new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask: Optional[Tensor] = None,
+        head_mask: Optional[Tensor] = None,
+        encoder_hidden_states: Optional[Tensor] = None,
+        encoder_attention_mask: Optional[Tensor] = None,
+    ):
+        mixed_query_layer = self.query(hidden_states)
+
+        # If this is instantiated as a cross-attention module, the keys
+        # and values come from an encoder; the attention mask needs to be
+        # such that the encoder's padding tokens are not attended to.
+        if encoder_hidden_states is not None:
+            mixed_key_layer = self.key(encoder_hidden_states)
+            mixed_value_layer = self.value(encoder_hidden_states)
+            attention_mask = encoder_attention_mask
+        else:
+            mixed_key_layer = self.key(hidden_states)
+            mixed_value_layer = self.value(hidden_states)
+
+        query_layer = self.transpose_for_scores(mixed_query_layer)
+        key_layer = self.transpose_for_scores(mixed_key_layer)
+        value_layer = self.transpose_for_scores(mixed_value_layer)
+
+        # Take the dot product between "query" and "key" to get the raw attention
+        # scores.
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        if attention_mask is not None:
+            # Apply the attention mask is (precomputed for all layers in BertModel
+            # forward() function)
+            attention_scores = attention_scores + attention_mask
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+
+        # This is actually dropping out entire tokens to attend to, which might
+        # seem a bit unusual, but is taken from the original Transformer paper.
+        attention_probs = self.dropout(attention_probs)
+
+        # Mask heads if we want to
+        if head_mask is not None:
+            attention_probs = attention_probs * head_mask
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        context_layer = context_layer.view(new_context_layer_shape)
+
+        outputs = (context_layer, attention_probs)
+        return outputs
+
+
+class BertAttentionJit(BertAttention):
+    """
+    Torchscriptable version of `BertAttention` from Huggingface transformers v2.3.0
+    https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py # noqa
+
+    Modifies the `forward` function as well as uses scriptable `BertSelfAttentionJit`
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.self = BertSelfAttentionJit(config)
+        self.output = BertSelfOutput(config)
+        self.pruned_heads = set()
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask: Optional[Tensor] = None,
+        head_mask: Optional[Tensor] = None,
+        encoder_hidden_states: Optional[Tensor] = None,
+        encoder_attention_mask: Optional[Tensor] = None,
+    ):
+        self_outputs = self.self(
+            hidden_states,
+            attention_mask,
+            head_mask,
+            encoder_hidden_states,
+            encoder_attention_mask,
+        )
+        attention_output = self.output(self_outputs[0], hidden_states)
+        outputs = (attention_output,) + self_outputs[
+            1:
+        ]  # add attentions if we output them
+        return outputs
+
+
+class BertLayerJit(nn.Module):
+    """
+    Torchscriptable version of `BertLayer` from Huggingface transformers v2.3.0
+    https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py # noqa
+
+    Modifies the `forward` function as well as uses scriptable `BertAttentionJit`
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.attention = BertAttentionJit(config)
+        self.intermediate = BertIntermediate(config)
+        self.output = BertOutput(config)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask: Optional[Tensor] = None,
+        head_mask: Optional[Tensor] = None,
+        encoder_hidden_states: Optional[Tensor] = None,
+        encoder_attention_mask: Optional[Tensor] = None,
+    ):
+        self_attention_outputs = self.attention(
+            hidden_states, attention_mask, head_mask
+        )
+        attention_output = self_attention_outputs[0]
+        outputs = self_attention_outputs[
+            1:
+        ]  # add self attentions if we output attention weights
+
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output, attention_output)
+        outputs = (layer_output,) + outputs
+        return outputs
+
+
+class BertEncoderJit(nn.Module):
+    """
+    Torchscriptable version of `BertEncoder` from Huggingface transformers v2.3.0
+    https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py # noqa
+
+    Modifies the `forward` function as well as uses scriptable `BertLayerJit`
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.output_attentions = config.output_attentions
+        self.output_hidden_states = config.output_hidden_states
+        self.layer = nn.ModuleList(
+            [BertLayerJit(config) for _ in range(config.num_hidden_layers)]
+        )
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor],
+        encoder_hidden_states: Optional[Tensor] = None,
+        encoder_attention_mask: Optional[Tensor] = None,
+    ):
+        all_hidden_states = ()
+        all_attentions = ()
+        for i, layer_module in enumerate(self.layer):
+            if not torch.jit.is_scripting() and self.output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            layer_outputs = layer_module(
+                hidden_states,
+                attention_mask,
+                None,
+                encoder_hidden_states,
+                encoder_attention_mask,
+            )
+            hidden_states = layer_outputs[0]
+
+            if not torch.jit.is_scripting() and self.output_attentions:
+                all_attentions = all_attentions + (layer_outputs[1],)
+
+        # Add last layer
+        if not torch.jit.is_scripting() and self.output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        outputs = (hidden_states,)
+        if not torch.jit.is_scripting():
+            if self.output_hidden_states:
+                outputs = outputs + (all_hidden_states,)
+            if self.output_attentions:
+                outputs = outputs + (all_attentions,)
+        return outputs  # last-layer hidden state, (all hidden states), (all attentions)

--- a/tests/models/test_visual_bert_script.py
+++ b/tests/models/test_visual_bert_script.py
@@ -1,0 +1,122 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import io
+import itertools
+import unittest
+
+import torch
+from mmf.common.registry import registry
+from mmf.utils.configuration import Configuration
+from mmf.utils.env import setup_imports
+
+from tests.test_utils import dummy_args
+
+
+class TestVisualBertTorchscript(unittest.TestCase):
+    def setUp(self):
+        setup_imports()
+        model_name = "visual_bert"
+        args = dummy_args(model=model_name)
+        configuration = Configuration(args)
+        config = configuration.get_config()
+        model_class = registry.get_model_class(model_name)
+        self.pretrain_model = model_class(config.model_config[model_name])
+        self.pretrain_model.build()
+
+        config.model_config[model_name]["training_head_type"] = "classification"
+        config.model_config[model_name]["num_labels"] = 2
+        self.finetune_model = model_class(config.model_config[model_name])
+        self.finetune_model.build()
+
+    def assertModulesEqual(self, mod1, mod2, message=None):
+        for p1, p2 in itertools.zip_longest(mod1.parameters(), mod2.parameters()):
+            self.assertTrue(p1.equal(p2), message)
+
+    def test_load_save_pretrain_model(self):
+        self.pretrain_model.model.eval()
+        script_model = torch.jit.script(self.pretrain_model.model)
+        buffer = io.BytesIO()
+        torch.jit.save(script_model, buffer)
+        buffer.seek(0)
+        loaded_model = torch.jit.load(buffer)
+        self.assertModulesEqual(script_model, loaded_model)
+
+    def test_pretrained_model(self):
+        self.pretrain_model.model.eval()
+
+        input_ids = torch.randint(low=0, high=30255, size=(1, 128)).long()
+        input_mask = torch.ones((1, 128)).long()
+        attention_mask = torch.ones((1, 228)).long()
+        token_type_ids = torch.zeros(1, 128).long()
+        visual_embeddings = torch.rand((1, 100, 2048)).float()
+        visual_embeddings_type = torch.zeros(1, 100).long()
+        masked_lm_labels = torch.zeros((1, 228), dtype=torch.long).fill_(-1)
+
+        self.pretrain_model.eval()
+
+        with torch.no_grad():
+            model_output = self.pretrain_model.model(
+                input_ids=input_ids,
+                input_mask=input_mask,
+                attention_mask=attention_mask,
+                token_type_ids=token_type_ids,
+                visual_embeddings=visual_embeddings,
+                visual_embeddings_type=visual_embeddings_type,
+                masked_lm_labels=masked_lm_labels,
+            )
+        script_model = torch.jit.script(self.pretrain_model.model)
+        with torch.no_grad():
+            script_output = script_model(
+                input_ids=input_ids,
+                input_mask=input_mask,
+                attention_mask=attention_mask,
+                token_type_ids=token_type_ids,
+                visual_embeddings=visual_embeddings,
+                visual_embeddings_type=visual_embeddings_type,
+                masked_lm_labels=masked_lm_labels,
+            )
+        self.assertEqual(
+            model_output["masked_lm_loss"], script_output["masked_lm_loss"]
+        )
+
+    def test_load_save_finetune_model(self):
+        self.finetune_model.model.eval()
+        script_model = torch.jit.script(self.finetune_model.model)
+        buffer = io.BytesIO()
+        torch.jit.save(script_model, buffer)
+        buffer.seek(0)
+        loaded_model = torch.jit.load(buffer)
+        self.assertModulesEqual(script_model, loaded_model)
+
+    def test_finetune_model(self):
+
+        self.finetune_model.model.eval()
+        input_ids = torch.randint(low=0, high=30255, size=(1, 128)).long()
+        input_mask = torch.ones((1, 128)).long()
+        attention_mask = torch.ones((1, 228)).long()
+        token_type_ids = torch.zeros(1, 128).long()
+        visual_embeddings = torch.rand((1, 100, 2048)).float()
+        visual_embeddings_type = torch.zeros(1, 100).long()
+
+        with torch.no_grad():
+            model_output = self.finetune_model.model(
+                input_ids=input_ids,
+                input_mask=input_mask,
+                attention_mask=attention_mask,
+                token_type_ids=token_type_ids,
+                visual_embeddings=visual_embeddings,
+                visual_embeddings_type=visual_embeddings_type,
+            )
+
+        script_model = torch.jit.script(self.finetune_model.model)
+        with torch.no_grad():
+            script_output = script_model(
+                input_ids=input_ids,
+                input_mask=input_mask,
+                attention_mask=attention_mask,
+                token_type_ids=token_type_ids,
+                visual_embeddings=visual_embeddings,
+                visual_embeddings_type=visual_embeddings_type,
+            )
+
+        self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))

--- a/tests/models/test_visual_bert_script.py
+++ b/tests/models/test_visual_bert_script.py
@@ -9,14 +9,14 @@ from mmf.common.registry import registry
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 
-from tests.test_utils import dummy_args
+import tests.test_utils as test_utils
 
 
 class TestVisualBertTorchscript(unittest.TestCase):
     def setUp(self):
         setup_imports()
         model_name = "visual_bert"
-        args = dummy_args(model=model_name)
+        args = test_utils.dummy_args(model=model_name)
         configuration = Configuration(args)
         config = configuration.get_config()
         model_class = registry.get_model_class(model_name)
@@ -32,6 +32,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
         for p1, p2 in itertools.zip_longest(mod1.parameters(), mod2.parameters()):
             self.assertTrue(p1.equal(p2), message)
 
+    @test_utils.skip_if_no_network
     def test_load_save_pretrain_model(self):
         self.pretrain_model.model.eval()
         script_model = torch.jit.script(self.pretrain_model.model)
@@ -41,6 +42,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
         loaded_model = torch.jit.load(buffer)
         self.assertModulesEqual(script_model, loaded_model)
 
+    @test_utils.skip_if_no_network
     def test_pretrained_model(self):
         self.pretrain_model.model.eval()
 
@@ -79,6 +81,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
             model_output["masked_lm_loss"], script_output["masked_lm_loss"]
         )
 
+    @test_utils.skip_if_no_network
     def test_load_save_finetune_model(self):
         self.finetune_model.model.eval()
         script_model = torch.jit.script(self.finetune_model.model)
@@ -88,6 +91,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
         loaded_model = torch.jit.load(buffer)
         self.assertModulesEqual(script_model, loaded_model)
 
+    @test_utils.skip_if_no_network
     def test_finetune_model(self):
 
         self.finetune_model.model.eval()


### PR DESCRIPTION
- Adds scriptable `VisualBERTForClassification` model and `VisualBERTForPretraining` model
- Adds scriptable versions of some [transformer](https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py) package BERT model layers : `BertSelfAttentionJit`, `BertAttentionJit`, `BertLayerJit`, `BertEncoderJit`
- Changes to `BertVisioLinguisticEmbeddings` to make it scriptable
- Add tests for `VisualBERT` model


Test Plan:
- Run tests
- Run validation of model on old checkpoints and verify accuracy