### PR TITLE
[fix] Fix KDD tutorial dataset config

### DIFF
--- a/notebooks/kdd_tutorial.ipynb
+++ b/notebooks/kdd_tutorial.ipynb
@@ -431,6 +431,8 @@
         "  && wget -q https://raw.githubusercontent.com/facebookresearch/mmf/master/mmf/configs/datasets/okvqa/defaults.yaml \\\n",
         "  -O \"/content/configs/okvqa_colab.yaml\" \\\n",
         "  && sed -i \"s/okvqa:/okvqa_colab:/g\" /content/configs/okvqa_colab.yaml \\\n",
+        "  && sed -i \"s/okvqa\\//okvqa_colab\\//g\" /content/configs/okvqa_colab.yaml \\\n",
+        "  && sed -i \"s/okvqa\\.defaults/okvqa_colab\\.defaults/g\" /content/configs/okvqa_colab.yaml \\\n",
         "  && cat /content/configs/okvqa_colab.yaml"
       ],
       "execution_count": null,


### PR DESCRIPTION
Fix the KDD tutorial, downloaded dataset config's `okvqa` names have to be replaced by `okvqa_colab` since zoo downloads to `okvqa_colab` folder.

Thanks @ytsheng for reporting the issue!
