### PR TITLE
[fix] Typo in pretrain train+val config of visual bert

### DIFF
--- a/projects/visual_bert/configs/masked_coco/pretrain_train_val.yaml
+++ b/projects/visual_bert/configs/masked_coco/pretrain_train_val.yaml
@@ -8,8 +8,8 @@ dataset_config:
     use_features: true
     features:
       train:
-      - coco/defaults/features/coco_trainval2014.lmdb
-      - coco/defaults/features/coco_trainval2014.lmdb
+      - coco/defaults/features/trainval2014.lmdb
+      - coco/defaults/features/trainval2014.lmdb
     annotations:
       train:
       - coco/defaults/annotations/imdb_karpathy_train_by_image.npy


### PR DESCRIPTION
fix typo in the name of the features files
