### PR TITLE
[chores] Upgrade to pytorch 1.6 and torchvision 0.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ install_dep_windows: &install_dep_windows
       command: |
         source activate mmf
         pip install --upgrade setuptools certifi
-        pip install --progress-bar off torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install --progress-bar off torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         pip install -r requirements.txt
         pip install --progress-bar off flake8==3.7.9
         pip install --progress-bar off black==19.3b0

--- a/.github/workflows/cpu_test.yaml
+++ b/.github/workflows/cpu_test.yaml
@@ -48,7 +48,7 @@ jobs:
         conda activate mmf
         python -m pip install --upgrade pip
         pip install --upgrade setuptools certifi
-        pip install --progress-bar off torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install --progress-bar off torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off scipy==1.4.1 pybind11==2.5.0
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.5.0
-torchvision==0.6.0
+torch==1.6.0
+torchvision==0.7.0
 numpy>=1.16.6
 tqdm>=4.43.0
 demjson==2.2.4

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -165,18 +165,8 @@ class TestUtilsCheckpoint(unittest.TestCase):
             self.assertFalse(
                 self._compare_optimizers(self.trainer.optimizer, best_optimizer)
             )
-            self.assertFalse(
-                self._compare_optimizers(
-                    self.trainer.optimizer, best_optimizer, skip_keys=True
-                )
-            )
-            self.assertFalse(
-                self._compare_optimizers(self.trainer.optimizer, current_optimizer)
-            )
             self.assertTrue(
-                self._compare_optimizers(
-                    self.trainer.optimizer, current_optimizer, skip_keys=True
-                )
+                self._compare_optimizers(self.trainer.optimizer, current_optimizer)
             )
 
             base_0_weight_current = self.trainer.model.base[0].weight.data.clone()
@@ -192,21 +182,11 @@ class TestUtilsCheckpoint(unittest.TestCase):
                     self.trainer.model.state_dict(), best_model.state_dict()
                 )
             )
-            self.assertFalse(
-                self._compare_optimizers(self.trainer.optimizer, best_optimizer)
-            )
             self.assertTrue(
-                self._compare_optimizers(
-                    self.trainer.optimizer, best_optimizer, skip_keys=True
-                )
+                self._compare_optimizers(self.trainer.optimizer, best_optimizer)
             )
             self.assertFalse(
                 self._compare_optimizers(self.trainer.optimizer, current_optimizer)
-            )
-            self.assertFalse(
-                self._compare_optimizers(
-                    self.trainer.optimizer, current_optimizer, skip_keys=True
-                )
             )
             base_0_weight_best = self.trainer.model.base[0].weight.data.clone()
 
@@ -312,14 +292,8 @@ class TestUtilsCheckpoint(unittest.TestCase):
                     self.trainer.model.state_dict(), after_a_pass.state_dict()
                 )
             )
-            self.assertFalse(
-                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
-            )
-            # Keys will not be same as we just updated the model
             self.assertTrue(
-                self._compare_optimizers(
-                    self.trainer.optimizer, original_optimizer, skip_keys=True
-                )
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
             )
 
     def test_resets(self):
@@ -345,13 +319,8 @@ class TestUtilsCheckpoint(unittest.TestCase):
                 )
             )
 
-            self.assertFalse(
-                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
-            )
             self.assertTrue(
-                self._compare_optimizers(
-                    self.trainer.optimizer, original_optimizer, skip_keys=True
-                )
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
             )
             self.assertEqual(self.trainer.num_updates, 0)
             self.assertEqual(self.trainer.current_iteration, 0)
@@ -369,13 +338,8 @@ class TestUtilsCheckpoint(unittest.TestCase):
                 )
             )
 
-            self.assertFalse(
-                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
-            )
             self.assertTrue(
-                self._compare_optimizers(
-                    self.trainer.optimizer, original_optimizer, skip_keys=True
-                )
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
             )
 
             self.assertEqual(self.trainer.num_updates, 2000)
@@ -396,9 +360,7 @@ class TestUtilsCheckpoint(unittest.TestCase):
             )
 
             self.assertTrue(
-                self._compare_optimizers(
-                    self.trainer.optimizer, original_optimizer, skip_keys=True
-                )
+                self._compare_optimizers(self.trainer.optimizer, original_optimizer)
             )
             self.assertEqual(self.trainer.num_updates, 0)
             self.assertEqual(self.trainer.current_iteration, 0)
@@ -423,11 +385,7 @@ class TestUtilsCheckpoint(unittest.TestCase):
             self.assertFalse(
                 self._compare_optimizers(self.trainer.optimizer, original_optimizer)
             )
-            self.assertFalse(
-                self._compare_optimizers(
-                    self.trainer.optimizer, original_optimizer, skip_keys=True
-                )
-            )
+
             self.assertEqual(self.trainer.num_updates, 1000)
             self.assertEqual(self.trainer.current_iteration, 1000)
             self.assertEqual(self.trainer.current_epoch, 3)
@@ -567,16 +525,15 @@ class TestUtilsCheckpoint(unittest.TestCase):
         self.trainer.optimizer.step()
         self.trainer.lr_scheduler_callback._scheduler.step()
 
-    def _compare_optimizers(self, a, b, skip_keys=False):
+    def _compare_optimizers(self, a, b):
         state_dict_a = a.state_dict()
         state_dict_b = b.state_dict()
         state_a = state_dict_a["state"]
         state_b = state_dict_b["state"]
 
         same = True
-        if not skip_keys:
-            same = same and list(state_a.keys()) == list(state_b.keys())
-            same = same and state_dict_a["param_groups"] == state_dict_b["param_groups"]
+        same = same and list(state_a.keys()) == list(state_b.keys())
+        same = same and state_dict_a["param_groups"] == state_dict_b["param_groups"]
 
         for item1, item2 in zip(state_a.values(), state_b.values()):
             same = same and compare_state_dicts(item1, item2)

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -154,17 +154,17 @@ class TestUtilsText(unittest.TestCase):
 
         # these are expected tokens for sum_threshold = 0.5
         expected_tokens = [
-            1.0000e00,
-            2.9140e03,
-            5.9210e03,
-            2.2040e03,
-            5.0550e03,
-            9.2240e03,
-            4.5120e03,
-            1.8200e02,
-            3.6490e03,
-            6.4090e03,
-            2.0000e00,
+            1.0,
+            6319.0,
+            1516.0,
+            3214.0,
+            8798.0,
+            4036.0,
+            282.0,
+            4706.0,
+            8346.0,
+            8620.0,
+            2.0,
         ]
 
         self.assertEqual(tokens[0].tolist(), expected_tokens)

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -4,7 +4,7 @@ title: Installation
 sidebar_label: Installation
 ---
 
-MMF has been tested on Python 3.7+ and PyTorch 1.5. We recommend using a conda environment to install MMF.
+MMF has been tested on Python 3.7+ and PyTorch 1.6. We recommend using a conda environment to install MMF.
 
 ## Creating a conda environment [Optional]
 


### PR DESCRIPTION
- Upgrading to pytorch 1.6, which comes with new features required for upcoming torchscript changes
- Optimizer keys are no longer non-deterministic in PT1.6, check pytorch [PR](https://github.com/pytorch/pytorch/pull/37347 ). Remove `skip_keys` check from checkpoint optimizer tests.
- Fixed nucleus sampling tests
- Update docs to reflect support for pytorch 1.6
- Update CI tests, CircleCI and Actions to use pytorch 1.6, torchvision 0.7


Test Plan :
- Tested with visual bert and mmbt models on Hateful Memes
- Running internally at FB (runs on pytorch master)