### PR TITLE
 [feat] Add torchscript support for MMBT

### DIFF
--- a/mmf/modules/hf_layers.py
+++ b/mmf/modules/hf_layers.py
@@ -7,11 +7,67 @@ import torch
 from torch import Tensor, nn
 from transformers.modeling_bert import (
     BertAttention,
+    BertEmbeddings,
+    BertEncoder,
     BertIntermediate,
+    BertLayer,
+    BertModel,
     BertOutput,
     BertSelfAttention,
     BertSelfOutput,
 )
+
+
+def replace_with_jit():
+    """
+    Monkey patch some transformer functions to replace with scriptable ones.
+    """
+    BertEmbeddings.forward = BertEmbeddingsJit.forward
+    BertEncoder.forward = BertEncoderJit.forward
+    BertLayer.forward = BertLayerJit.forward
+    BertAttention.forward = BertAttentionJit.forward
+    BertSelfAttention.forward = BertSelfAttentionJit.forward
+    BertSelfAttention.transpose_for_scores = BertSelfAttentionJit.transpose_for_scores
+    BertModel.forward = BertModelJit.forward
+
+
+class BertEmbeddingsJit(BertEmbeddings):
+    """
+    Torchscriptable version of `BertEmbeddings` from Huggingface transformers v2.3.0
+    https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py # noqa
+
+    Modifies the `forward` function
+    """
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        token_type_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        inputs_embeds: Optional[Tensor] = None,
+    ):
+        if input_ids is not None:
+            input_shape = input_ids.size()
+        else:
+            input_shape = inputs_embeds.size()[:-1]
+
+        seq_length = input_shape[1]
+        device = inputs_embeds.device if inputs_embeds is not None else input_ids.device
+        if position_ids is None:
+            position_ids = torch.arange(seq_length, dtype=torch.long, device=device)
+            position_ids = position_ids.unsqueeze(0).expand(input_shape)
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+        if inputs_embeds is None:
+            inputs_embeds = self.word_embeddings(input_ids)
+        position_embeddings = self.position_embeddings(position_ids)
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        embeddings = inputs_embeds + position_embeddings + token_type_embeddings
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings
 
 
 class BertSelfAttentionJit(BertSelfAttention):
@@ -227,3 +283,112 @@ class BertEncoderJit(nn.Module):
             if self.output_attentions:
                 outputs = outputs + (all_attentions,)
         return outputs  # last-layer hidden state, (all hidden states), (all attentions)
+
+
+class BertModelJit(BertModel):
+    """
+    Torchscriptable version of `BertModel` from Huggingface transformers v2.3.0
+    https://github.com/huggingface/transformers/blob/v2.3.0/transformers/modeling_bert.py # noqa
+
+    Modifies the `forward` function
+
+    Changes to `forward` function ::
+        Typings for input, modifications to device, change output type to
+        Tuple[Tensor, Tensor, List[Tensor]]
+    """
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask: Optional[Tensor] = None,
+        token_type_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        head_mask: Optional[Tensor] = None,
+        inputs_embeds: Optional[Tensor] = None,
+        encoder_hidden_states: Optional[Tensor] = None,
+        encoder_attention_mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor, List[Tensor]]:
+        """ Forward pass on the Model.
+        The model can behave as an encoder (with only self-attention) as well
+        as a decoder, in which case a layer of cross-attention is added between
+        the self-attention layers, following the architecture described in
+        `Attention is all you need`_ by Ashish Vaswani, Noam Shazeer, Niki Parmar,
+        Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser and
+        Illia Polosukhin.
+        To behave as an decoder the model needs to be initialized with the
+        `is_decoder` argument of the configuration set to `True`; an
+        `encoder_hidden_states` is expected as an input to the forward pass.
+        .. _`Attention is all you need`:
+            https://arxiv.org/abs/1706.03762
+        """
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time"
+            )
+        elif input_ids is not None:
+            input_shape = input_ids.size()
+        elif inputs_embeds is not None:
+            input_shape = inputs_embeds.size()[:-1]
+        else:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        device = inputs_embeds.device if inputs_embeds is not None else input_ids.device
+
+        if attention_mask is None:
+            attention_mask = torch.ones(input_shape, device=device)
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+        # We can provide a self-attention mask of dimensions
+        # [batch_size, from_seq_length, to_seq_length]
+        # ourselves in which case we just need to make it broadcastable to all heads.
+        if attention_mask.dim() == 3:
+            extended_attention_mask = attention_mask[:, None, :, :]
+        elif attention_mask.dim() == 2:
+            # Provided a padding mask of dimensions [batch_size, seq_length]
+            # - if the model is a decoder, apply a causal mask in addition to
+            # the padding mask
+            # - if the model is an encoder, make the mask broadcastable to
+            # [batch_size, num_heads, seq_length, seq_length]
+            extended_attention_mask = attention_mask[:, None, None, :]
+        else:
+            raise ValueError(
+                f"Wrong shape for input_ids (shape {input_shape}) or "
+                + f"attention_mask (shape {attention_mask.shape})"
+            )
+
+        # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
+        # masked positions, this operation will create a tensor which is 0.0 for
+        # positions we want to attend and -10000.0 for masked positions.
+        # Since we are adding it to the raw scores before the softmax, this is
+        # effectively the same as removing these entirely.
+        # Python builtin next is currently not supported in Torchscript
+        if not torch.jit.is_scripting():
+            extended_attention_mask = extended_attention_mask.to(
+                dtype=next(self.parameters()).dtype
+            )  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+
+        # If a 2D ou 3D attention mask is provided for the cross-attention
+        # we need to make broadcastabe to
+        # [batch_size, num_heads, seq_length, seq_length]
+        encoder_extended_attention_mask = None
+
+        embedding_output = self.embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+            inputs_embeds=inputs_embeds,
+        )
+        encoder_outputs = self.encoder(
+            embedding_output,
+            attention_mask=extended_attention_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_extended_attention_mask,
+        )
+        sequence_output = encoder_outputs[0]
+        pooled_output = self.pooler(sequence_output)
+
+        # add hidden_states and attentions if they are here
+        outputs = (sequence_output, pooled_output, encoder_outputs[1:])
+        return outputs  # sequence_output, pooled_output, (hidden_states), (attentions)

--- a/tests/models/test_mmbt_script.py
+++ b/tests/models/test_mmbt_script.py
@@ -1,0 +1,62 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import io
+import unittest
+
+import torch
+from mmf.common.registry import registry
+from mmf.utils.configuration import Configuration
+from mmf.utils.env import setup_imports
+
+import tests.test_utils as test_utils
+
+
+class TestMMBTTorchscript(unittest.TestCase):
+    def setUp(self):
+        setup_imports()
+        model_name = "mmbt"
+        args = test_utils.dummy_args(model=model_name)
+        configuration = Configuration(args)
+        config = configuration.get_config()
+        model_class = registry.get_model_class(model_name)
+        config.model_config[model_name]["training_head_type"] = "classification"
+        config.model_config[model_name]["num_labels"] = 2
+        self.finetune_model = model_class(config.model_config[model_name])
+        self.finetune_model.build()
+
+    @test_utils.skip_if_no_network
+    def test_load_save_finetune_model(self):
+        self.finetune_model.model.eval()
+        script_model = torch.jit.script(self.finetune_model.model)
+        buffer = io.BytesIO()
+        torch.jit.save(script_model, buffer)
+        buffer.seek(0)
+        loaded_model = torch.jit.load(buffer)
+        self.assertTrue(test_utils.assertModulesEqual(script_model, loaded_model))
+
+    @test_utils.skip_if_no_network
+    def test_finetune_model(self):
+        self.finetune_model.model.eval()
+        input_ids = torch.randint(low=0, high=30255, size=(1, 128)).long()
+        input_mask = torch.ones((1, 128)).long()
+        segment_ids = torch.zeros(1, 128).long()
+        visual_embeddings = torch.rand((1, 3, 300, 300)).float()
+
+        with torch.no_grad():
+            model_output = self.finetune_model.model(
+                input_modal=visual_embeddings,
+                input_ids=input_ids,
+                segment_ids=segment_ids,
+                input_mask=input_mask,
+            )
+
+        script_model = torch.jit.script(self.finetune_model.model)
+        with torch.no_grad():
+            script_output = script_model(
+                input_modal=visual_embeddings,
+                input_ids=input_ids,
+                segment_ids=segment_ids,
+                input_mask=input_mask,
+            )
+
+        self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))

--- a/tests/models/test_visual_bert_script.py
+++ b/tests/models/test_visual_bert_script.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import io
-import itertools
 import unittest
 
 import torch
@@ -28,10 +27,6 @@ class TestVisualBertTorchscript(unittest.TestCase):
         self.finetune_model = model_class(config.model_config[model_name])
         self.finetune_model.build()
 
-    def assertModulesEqual(self, mod1, mod2, message=None):
-        for p1, p2 in itertools.zip_longest(mod1.parameters(), mod2.parameters()):
-            self.assertTrue(p1.equal(p2), message)
-
     @test_utils.skip_if_no_network
     def test_load_save_pretrain_model(self):
         self.pretrain_model.model.eval()
@@ -40,7 +35,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
         torch.jit.save(script_model, buffer)
         buffer.seek(0)
         loaded_model = torch.jit.load(buffer)
-        self.assertModulesEqual(script_model, loaded_model)
+        self.assertTrue(test_utils.assertModulesEqual(script_model, loaded_model))
 
     @test_utils.skip_if_no_network
     def test_pretrained_model(self):
@@ -89,7 +84,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
         torch.jit.save(script_model, buffer)
         buffer.seek(0)
         loaded_model = torch.jit.load(buffer)
-        self.assertModulesEqual(script_model, loaded_model)
+        self.assertTrue(test_utils.assertModulesEqual(script_model, loaded_model))
 
     @test_utils.skip_if_no_network
     def test_finetune_model(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import argparse
+import itertools
 import platform
 import random
 import socket
@@ -116,3 +117,8 @@ class SimpleModel(torch.nn.Module):
         batch = prepared_batch[DATA_ITEM_KEY]
         model_output = {"losses": {"loss": torch.sum(self.linear(batch))}}
         return model_output
+
+
+def assertModulesEqual(mod1, mod2):
+    for p1, p2 in itertools.zip_longest(mod1.parameters(), mod2.parameters()):
+        return p1.equal(p2)


### PR DESCRIPTION
- Adds torchscript support for MMBT model
- Adds `BertEmbeddingsJit` and `BertModelJit` layers which are torchscriptable versions of `BertEmbeddings` and `BertModel` layers from transformers package
- Replaces transformers Bert model layers with scriptable layers by monkey patching, function `replace_with_jit`
- Adds tests

Test Plan:
- Run tests
- Run old pretrained checkpoints for MMBT and verify results