### PR TITLE
[refactor] Refactor MMF Transformer embeddings to support scriptability

### DIFF
--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 from copy import deepcopy
-from typing import Any, Dict, Type
+from typing import Any, Dict, List, Type
 
 import torch
 from mmf.common.registry import registry
@@ -51,29 +51,48 @@ class MMFTransformerEmbeddings(nn.Module):
         super().__init__()
         self.model_config = model_config
         self.transformer_config = transformer_config
+
+        self.token_embeddings = nn.ModuleList()
+        self.pos_embeddings = nn.ModuleList()
+        self.layer_norms = nn.ModuleList()
+        self.dropouts = nn.ModuleList()
+        self.modality_keys: List = []
+
+        # Build layers for each modality and initialize
         self.build_layers()
         self.init_weights(transformer)
+
+        assert (
+            len(self.token_embeddings)
+            == len(self.pos_embeddings)
+            == len(self.layer_norms)
+            == len(self.dropouts)
+            == len(self.model_config.modalities)
+        )
 
     def build_layers(self):
 
         for modality in self.model_config.modalities:
-            layer_norm_eps = getattr(
-                modality, "layer_norm_eps", self.transformer_config.layer_norm_eps
+            self.modality_keys.append(modality.key)
+            layer_norm_eps = modality.get(
+                "layer_norm_eps", self.transformer_config.layer_norm_eps
+            )
+            position_dim = modality.get(
+                "position_dim", self.transformer_config.max_position_embeddings
+            )
+            hidden_dropout_prob = modality.get(
+                "hidden_dropout_prob", self.transformer_config.hidden_dropout_prob
             )
             if modality.type == "text":
-                setattr(
-                    self,
-                    modality.key + "_embedding",
+                self.token_embeddings.append(
                     nn.Embedding(
                         self.transformer_config.vocab_size,
                         self.transformer_config.hidden_size,
                         padding_idx=self.transformer_config.pad_token_id,
-                    ),
+                    )
                 )
             elif modality.type == "image":
-                setattr(
-                    self,
-                    modality.key + "_embedding",
+                self.token_embeddings.append(
                     nn.Sequential(
                         nn.Linear(
                             modality.embedding_dim, self.transformer_config.hidden_size
@@ -81,56 +100,29 @@ class MMFTransformerEmbeddings(nn.Module):
                         torch.nn.LayerNorm(
                             self.transformer_config.hidden_size, eps=layer_norm_eps
                         ),
-                    ),
+                    )
                 )
-
-            # Set the position embeddings
-            position_dim = getattr(
-                modality,
-                "position_dim",
-                self.transformer_config.max_position_embeddings,
+            self.pos_embeddings.append(
+                nn.Embedding(position_dim, self.transformer_config.hidden_size)
             )
-            setattr(
-                self,
-                modality.key + "_pos_embedding",
-                nn.Embedding(position_dim, self.transformer_config.hidden_size),
-            )
-
-            # Layer norm
-            setattr(
-                self,
-                modality.key + "_layer_norm",
+            self.layer_norms.append(
                 torch.nn.LayerNorm(
                     self.transformer_config.hidden_size, eps=layer_norm_eps
-                ),
+                )
             )
-
-            # Dropout
-            hidden_dropout_prob = getattr(
-                modality,
-                "hidden_dropout_prob",
-                self.transformer_config.hidden_dropout_prob,
-            )
-            setattr(self, modality.key + "_dropout", nn.Dropout(hidden_dropout_prob))
+            self.dropouts.append(nn.Dropout(hidden_dropout_prob))
 
         self.token_type_embeddings = nn.Embedding(
             len(self.model_config.modalities), self.transformer_config.hidden_size
         )
 
     def init_weights(self, transformer: Type[nn.Module]):
-        for modality in self.model_config.modalities:
+        for idx, modality in enumerate(self.model_config.modalities):
             if modality.type == "text":
-                setattr(
-                    self,
-                    modality.key + "_embedding",
-                    transformer.embeddings.word_embeddings,
-                )
-                setattr(
-                    self, modality.key + "_layer_norm", transformer.embeddings.LayerNorm
-                )
+                self.token_embeddings[idx] = transformer.embeddings.word_embeddings
+                self.layer_norms[idx] = transformer.embeddings.LayerNorm
 
-            pos_embedding_layer = getattr(self, modality.key + "_pos_embedding")
-            pos_embedding_layer.weight = nn.Parameter(
+            self.pos_embeddings[idx].weight = nn.Parameter(
                 deepcopy(transformer.embeddings.position_embeddings.weight.data),
                 requires_grad=True,
             )
@@ -159,21 +151,25 @@ class MMFTransformerEmbeddings(nn.Module):
         segment_ids: Dict[str, Tensor],
     ) -> Tensor:
         list_embeddings = []
-        for modality in self.model_config.modalities:
-            total_embedding = getattr(self, modality.key + "_embedding")(
-                input_ids[modality.key]
+        for idx, (token_emb, pos_emb, layer_norm, dropout) in enumerate(
+            zip(
+                self.token_embeddings,
+                self.pos_embeddings,
+                self.layer_norms,
+                self.dropouts,
             )
-            if modality.key not in position_ids:
-                total_embedding += getattr(self, modality.key + "_pos_embedding")(
-                    position_ids[modality.key]
+        ):
+            modality_name = self.modality_keys[idx]
+            total_embedding = token_emb(input_ids[modality_name])
+            if modality_name in position_ids:
+                total_embedding += pos_emb(position_ids[modality_name])
+
+            if modality_name in segment_ids:
+                total_embedding += self.token_type_embeddings(
+                    segment_ids[modality_name]
                 )
 
-            if modality.key in segment_ids:
-                total_embedding += self.token_type_embeddings(segment_ids[modality.key])
-
-            layer_norm_layer = getattr(self, modality.key + "_layer_norm")
-            dropout_layer = getattr(self, modality.key + "_dropout")
-            list_embeddings.append(dropout_layer(layer_norm_layer(total_embedding)))
+            list_embeddings.append(dropout(layer_norm(total_embedding)))
 
         return torch.cat(list_embeddings, dim=1)
 
@@ -182,6 +178,10 @@ class MMFTransformerEmbeddings(nn.Module):
 class MMFTransformer(BaseTransformer):
     def __init__(self, config: BaseTransformerConfigType, *args, **kwargs):
         super().__init__(config)
+        self.num_labels = self.config.num_labels
+        self.modality_keys: List = []
+        for modality in self.config.modalities:
+            self.modality_keys.append(modality.key)
 
     @classmethod
     def config_path(cls) -> str:
@@ -287,31 +287,35 @@ class MMFTransformer(BaseTransformer):
 
         return BaseTransformerInput(input_ids, position_ids, segment_ids, masks)
 
-    def forward(self, sample_list: Dict[str, Any]) -> Dict[str, Tensor]:
+    def transformer_encode(self, embedding, attention_mask):
+        return self.transformer.encoder(
+            embedding, attention_mask, [None] * len(self.transformer.encoder.layer)
+        )
+
+    def forward(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
         # Sample preprocess
         output = self.preprocess_sample(sample_list)
 
         # Transformer Input Embeddings
         embedding_output = self.embeddings(
-            input_ids=output.input_ids,
-            position_ids=output.position_ids,
-            segment_ids=output.segment_ids,
+            input_ids=output["input_ids"],
+            position_ids=output["position_ids"],
+            segment_ids=output["segment_ids"],
         )
 
         # Transformer Attention mask
         # concat the attention masks for all modalities
         masks = []
-        for modality in self.config.modalities:
-            masks.append(output.masks[modality.key])
+        for modality in self.modality_keys:
+            masks.append(output["masks"][modality])
         attention_mask = torch.cat(masks, dim=-1)
         extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
 
         # Transformer Encoder
-        encoded_layers = self.transformer.encoder(
+        encoded_layers = self.transformer_encode(
             embedding_output,  # combined embedding
             extended_attention_mask,  # combined attention mask
-            [None] * len(self.transformer.encoder.layer),  # head masks
         )
 
         # Transformer Heads
@@ -325,5 +329,5 @@ class MMFTransformer(BaseTransformer):
         This will be used to calculate losses and metrics in mmf.
         """
         output_dict = {}
-        output_dict["scores"] = output.contiguous().view(-1, self.config.num_labels)
+        output_dict["scores"] = output.contiguous().view(-1, self.num_labels)
         return output_dict

--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -19,6 +19,10 @@ class BaseTransformerInput:
     segment_ids: Dict[str, Tensor]  # dict of segment/token type ids for all modalities
     masks: Dict[str, Tensor]  # dict of masks for all modalities
 
+    def __getitem__(self, item):
+        # to access dataclass as a dict, for torchscript support
+        return getattr(self, item)
+
 
 @dataclass
 class BaseModalityConfigType:


### PR DESCRIPTION
- Changes to support torchscript for mmf transformer derivatives
- Changes to `MMFTransformerEmbeddings` by modifying the different modality embeddings to `nn.ModuleList` to make it scriptable.
- Some changes to the forward function 

Note: It is difficult to make MMF transformer scriptable as a whole since its base can be any type of transformer and making that scriptable is dependent on other libraries. The idea is to have derived models from MMF transformer that can be scripted. For example: We will have a version of MMF transformer that works with Bert, Roberta and XLMR that will be scriptable.

Test Plan:
- Test with hateful memes dataset