### PR TITLE
[fix] Fix tests with larger CPU resource, fail-fast set to false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ orbs:
 # Environments to run the jobs in
 # -------------------------------------------------------------------------------------
 cpu: &cpu
-  docker:
-    - image: circleci/python:3.7
-  resource_class: medium
+  machine:
+    image: ubuntu-1604:201903-01
+  resource_class: large
 
 gpu: &gpu
   environment:

--- a/.github/workflows/cpu_test.yaml
+++ b/.github/workflows/cpu_test.yaml
@@ -9,6 +9,7 @@ jobs:
     # by the push to the branch.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'facebookresearch/mmf'
     strategy:
+      fail-fast: false
       max-parallel: 12
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
- Increase resource size for CircleCI CPU tests, change to machine executor which have larger RAM
- set fail-fast to false for Actions fto be able to pinpoint which matrix combinations cause failures


Test Plan:
 - Run the tests and check if they pass 

