### PR TITLE
[feat] Added the localized narratives dataset

### DIFF
--- a/mmf/configs/datasets/coco2017/masked.yaml
+++ b/mmf/configs/datasets/coco2017/masked.yaml
@@ -1,0 +1,37 @@
+dataset_config:
+  masked_coco2017:
+    data_dir: ${env.data_dir}/datasets
+    depth_first: false
+    fast_read: false
+    use_images: false
+    use_features: true
+    zoo_requirements:
+    - coco.defaults
+    features:
+      train:
+      - coco/defaults/features/coco_train2017.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      val:
+      - coco/defaults/features/coco_val2017.lmdb
+    annotations:
+      train:
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00000-of-00004.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00001-of-00004.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00002-of-00004.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00003-of-00004.jsonl
+      val:
+      - localized_narratives/defaults/annotations/coco_val_localized_narratives.jsonl
+    max_features: 100
+    use_image_feature_masks: false
+    processors:
+      masked_token_processor:
+        type: masked_token
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0.15
+          max_seq_length: 64

--- a/mmf/configs/datasets/flickr30k/masked.yaml
+++ b/mmf/configs/datasets/flickr30k/masked.yaml
@@ -1,0 +1,35 @@
+dataset_config:
+  masked_flickr30k:
+    data_dir: ${env.data_dir}/datasets
+    depth_first: false
+    fast_read: false
+    use_images: false
+    use_features: true
+    zoo_requirements:
+    - flickr30k.defaults
+    features:
+      train:
+      - flickr30k/defaults/features/detectron.lmdb
+      val:
+      - flickr30k/defaults/features/detectron.lmdb
+      test:
+      - flickr30k/defaults/features/detectron.lmdb
+    annotations:
+      train:
+      - localized_narratives/defaults/annotations/flickr30k_train_localized_narratives.jsonl
+      val:
+      - localized_narratives/defaults/annotations/flickr30k_val_localized_narratives.jsonl
+      test:
+      - localized_narratives/defaults/annotations/flickr30k_test_localized_narratives.jsonl
+    max_features: 100
+    use_image_feature_masks: false
+    processors:
+      masked_token_processor:
+        type: masked_token
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0.15
+          max_seq_length: 64

--- a/mmf/configs/datasets/localized_narratives/masked.yaml
+++ b/mmf/configs/datasets/localized_narratives/masked.yaml
@@ -1,0 +1,73 @@
+dataset_config:
+  masked_localized_narratives:
+    data_dir: ${env.data_dir}/datasets
+    use_images: False
+    use_features: True
+    zoo_requirements:
+    - localized_narratives.defaults
+    - ade20k.defaults
+    - coco.defaults
+    - flickr30k.defaults
+    features:
+      train:
+      - flickr30k/defaults/features/detectron.lmdb
+      - ade20k/defaults/features/ade20k_train.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      - coco/defaults/features/coco_train2017.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      - localized_narratives/defaults/features/ln_open_images_train.lmdb
+      val:
+      - flickr30k/defaults/features/detectron.lmdb
+      - ade20k/defaults/features/ade20k_val.lmdb
+      - localized_narratives/defaults/features/open_images_val.lmdb
+      - coco/defaults/features/coco_val2017.lmdb
+      test:
+      - flickr30k/defaults/features/detectron.lmdb
+      - localized_narratives/defaults/features/open_images_test.lmdb
+    annotations:
+      train:
+      - localized_narratives/defaults/annotations/flickr30k_train_localized_narratives.jsonl
+      - localized_narratives/defaults/annotations/ade20k_train_localized_narratives.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00000-of-00004.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00001-of-00004.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00002-of-00004.jsonl
+      - localized_narratives/defaults/annotations/coco_train_localized_narratives-00003-of-00004.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00000-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00001-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00002-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00003-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00004-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00005-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00006-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00007-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00008-of-00010.jsonl
+      - localized_narratives/defaults/annotations/open_images_train_v6_localized_narratives-00009-of-00010.jsonl
+      val:
+      - localized_narratives/defaults/annotations/flickr30k_val_localized_narratives.jsonl
+      - localized_narratives/defaults/annotations/ade20k_validation_localized_narratives.jsonl
+      - localized_narratives/defaults/annotations/open_images_validation_localized_narratives.jsonl
+      - localized_narratives/defaults/annotations/coco_val_localized_narratives.jsonl
+      test:
+      - localized_narratives/defaults/annotations/flickr30k_test_localized_narratives.jsonl
+      - localized_narratives/defaults/annotations/open_images_test_localized_narratives.jsonl
+    processors:
+      masked_token_processor:
+        type: masked_token
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: True
+          mask_probability: 0.15
+          max_seq_length: 64
+

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -177,6 +177,12 @@ coco:
       - url: mmf://datasets/coco/defaults/features/trainval2014.tar.gz
         file_name: trainval2014.tar.gz
         hashcode: 242b4a2bf3ab930c3275d3ab9b4e1dccd1fb1745d3e939f8d50482d83e1fd1ad
+      - url: mmf://datasets/coco/defaults/features/coco_val2017.tar.gz
+        file_name: coco_val2017.tar.gz
+        hashcode: f9ca8004d59cff6d6cd9b1b2a8c20fdcfd8b69247b8fa85a980769bce07365f3
+      - url: mmf://datasets/coco/defaults/features/coco_train2017.tar.gz
+        file_name: coco_train2017.tar.gz
+        hashcode: 7815fa155f3ab438bbb753bd0ae746add35bafedfbd3db582141c2b99b817ddc
       annotations:
       - url: mmf://datasets/coco/defaults/annotations/annotations.tar.gz
         file_name: annotations.tar.gz
@@ -398,3 +404,103 @@ vqacp_v2:
         - url: https://computing.ece.vt.edu/~aish/vqacp/vqacp_v2_test_questions.json
           file_name: vqacp_v2_test_questions.json
           compressed: false
+
+ade20k:
+  defaults:
+    version: 1.0_2020_09_14
+    resources:
+      features:
+        - url: mmf://datasets/ade20k/defaults/features/ade20k_train_features.tar.gz
+          file_name: ade20k_train_features.tar.gz
+          hashcode: 723750c87a4ea374424bf3c45ff1bbfdd5baee3ba45141a21e266d6adf9dc906
+          compressed: true
+        - url: mmf://datasets/ade20k/defaults/features/ade20k_val_features.tar.gz
+          file_name: ade20k_val_features.tar.gz
+          hashcode: 3cb968ec4ae62dcc58f38476afd5e3dcb171387ef3fb2f0c37aee1d418f1f4c2
+          compressed: true
+
+localized_narratives:
+  defaults:
+    version: 1.0_2020_09_14
+    resources:
+      features:
+        - url: mmf://datasets/localized_narratives/defaults/features/ln_open_images_train_features.tar.gz
+          file_name: ln_open_images_train_features.tar.gz
+          hashcode: 2f664c3d31da2772f2bc7303b2f88454b814f0f528618df06514c55f127585ec
+          compressed: true
+        - url: mmf://datasets/localized_narratives/defaults/features/open_images_val.tar.gz
+          file_name: open_images_val.tar.gz
+          hashcode: 8b500f64f55cc50544ddc051b57397104749ab95374fedc7c27cffe7af76222c
+          compressed: true
+        - url: mmf://datasets/localized_narratives/defaults/features/open_images_test.tar.gz
+          file_name: open_images_test.tar.gz
+          hashcode: 18a91a9dfd5ed93fc7f416360ec6723ac929109f4821b5889b12d7e430e972e0
+          compressed: true
+      annotations:
+        - url: https://storage.googleapis.com/localized-narratives/annotations/flickr30k_test_localized_narratives.jsonl
+          file_name: flickr30k_test_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_validation_localized_narratives.jsonl
+          file_name: open_images_validation_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/coco_val_localized_narratives.jsonl
+          file_name: coco_val_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/flickr30k_val_localized_narratives.jsonl
+          file_name: flickr30k_val_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/ade20k_train_localized_narratives.jsonl
+          file_name: ade20k_train_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/coco_train_localized_narratives-00000-of-00004.jsonl
+          file_name: coco_train_localized_narratives-00000-of-00004.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/coco_train_localized_narratives-00001-of-00004.jsonl
+          file_name: coco_train_localized_narratives-00001-of-00004.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/coco_train_localized_narratives-00002-of-00004.jsonl
+          file_name: coco_train_localized_narratives-00002-of-00004.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/coco_train_localized_narratives-00003-of-00004.jsonl
+          file_name: coco_train_localized_narratives-00003-of-00004.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/flickr30k_train_localized_narratives.jsonl
+          file_name: flickr30k_train_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00000-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00000-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00001-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00001-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00002-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00002-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00003-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00003-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00004-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00004-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00005-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00005-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00006-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00006-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00007-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00007-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00008-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00008-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_train_v6_localized_narratives-00009-of-00010.jsonl
+          file_name: open_images_train_v6_localized_narratives-00009-of-00010.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/ade20k_validation_localized_narratives.jsonl
+          file_name: ade20k_validation_localized_narratives.jsonl
+          compressed: false
+        - url: https://storage.googleapis.com/localized-narratives/annotations/open_images_test_localized_narratives.jsonl
+          file_name: open_images_test_localized_narratives.jsonl
+          compressed: false
+

--- a/mmf/datasets/builders/coco2017/masked_builder.py
+++ b/mmf/datasets/builders/coco2017/masked_builder.py
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.builders.coco2017.masked_dataset import MaskedCoco2017Dataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("masked_coco2017")
+class MaskedFlickr30kBuilder(MMFDatasetBuilder):
+    def __init__(
+        self,
+        dataset_name="masked_coco2017",
+        dataset_class=MaskedCoco2017Dataset,
+        *args,
+        **kwargs
+    ):
+        super().__init__(dataset_name, dataset_class, *args, **kwargs)
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/coco2017/masked.yaml"

--- a/mmf/datasets/builders/coco2017/masked_dataset.py
+++ b/mmf/datasets/builders/coco2017/masked_dataset.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.common.typings import MMFDatasetConfigType
+from mmf.datasets.builders.localized_narratives.masked_dataset import (
+    MaskedLocalizedNarrativesDatasetMixin,
+)
+from mmf.datasets.mmf_dataset import MMFDataset
+
+
+class MaskedCoco2017Dataset(MaskedLocalizedNarrativesDatasetMixin, MMFDataset):
+    def __init__(
+        self,
+        config: MMFDatasetConfigType,
+        dataset_type: str,
+        index: int,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            "masked_coco2017", config, dataset_type, index, *args, **kwargs
+        )

--- a/mmf/datasets/builders/flickr30k/masked_builder.py
+++ b/mmf/datasets/builders/flickr30k/masked_builder.py
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.builders.flickr30k.masked_dataset import MaskedFlickr30kDataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("masked_flickr30k")
+class MaskedFlickr30kBuilder(MMFDatasetBuilder):
+    def __init__(
+        self,
+        dataset_name="masked_flickr30k",
+        dataset_class=MaskedFlickr30kDataset,
+        *args,
+        **kwargs
+    ):
+        super().__init__(dataset_name, dataset_class, *args, **kwargs)
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/flickr30k/masked.yaml"

--- a/mmf/datasets/builders/flickr30k/masked_dataset.py
+++ b/mmf/datasets/builders/flickr30k/masked_dataset.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.common.typings import MMFDatasetConfigType
+from mmf.datasets.builders.localized_narratives.masked_dataset import (
+    MaskedLocalizedNarrativesDatasetMixin,
+)
+from mmf.datasets.mmf_dataset import MMFDataset
+
+
+class MaskedFlickr30kDataset(MaskedLocalizedNarrativesDatasetMixin, MMFDataset):
+    def __init__(
+        self,
+        config: MMFDatasetConfigType,
+        dataset_type: str,
+        index: int,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            "masked_flickr30k", config, dataset_type, index, *args, **kwargs
+        )

--- a/mmf/datasets/builders/localized_narratives/database.py
+++ b/mmf/datasets/builders/localized_narratives/database.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import json
+from typing import List, NamedTuple
+
+from mmf.datasets.databases.annotation_database import AnnotationDatabase
+
+
+class TimedPoint(NamedTuple):
+    x: float
+    y: float
+    t: float
+
+
+class TimedUtterance(NamedTuple):
+    utterance: str
+    start_time: float
+    end_time: float
+
+
+class LocalizedNarrative(NamedTuple):
+    dataset_id: str
+    image_id: str
+    annotator_id: int
+    caption: str
+    timed_caption: List[TimedUtterance]
+    traces: List[List[TimedPoint]]
+    voice_recording: str
+
+    def __repr__(self):
+        truncated_caption = (
+            self.caption[:60] + "..." if len(self.caption) > 63 else self.caption
+        )
+        truncated_timed_caption = self.timed_caption[0].__str__()
+        truncated_traces = self.traces[0][0].__str__()
+        return (
+            f"{{\n"
+            f" dataset_id: {self.dataset_id},\n"
+            f" image_id: {self.image_id},\n"
+            f" annotator_id: {self.annotator_id},\n"
+            f" caption: {truncated_caption},\n"
+            f" timed_caption: [{truncated_timed_caption}, ...],\n"
+            f" traces: [[{truncated_traces}, ...], ...],\n"
+            f" voice_recording: {self.voice_recording}\n"
+            f"}}"
+        )
+
+
+class LocalizedNarrativesAnnotationDatabase(AnnotationDatabase):
+    def __init__(self, config, path, *args, **kwargs):
+        super().__init__(config, path, *args, **kwargs)
+
+    def load_annotation_db(self, path):
+        data = []
+        with open(path) as f:
+            for line in f:
+                annotation = json.loads(line)
+                loc_narr = LocalizedNarrative(**annotation)
+                data.append(
+                    {
+                        "dataset_id": loc_narr.dataset_id,
+                        "image_id": loc_narr.image_id,
+                        "caption": loc_narr.caption,
+                        "feature_path": self._feature_path(
+                            loc_narr.dataset_id, loc_narr.image_id
+                        ),
+                    }
+                )
+        self.data = data
+
+    def _feature_path(self, dataset_id, image_id):
+        if "mscoco" in dataset_id.lower():
+            return image_id.rjust(12, "0") + ".npy"
+
+        return image_id + ".npy"

--- a/mmf/datasets/builders/localized_narratives/masked_builder.py
+++ b/mmf/datasets/builders/localized_narratives/masked_builder.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.builders.localized_narratives.masked_dataset import (
+    MaskedLocalizedNarrativesDataset,
+)
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("masked_localized_narratives")
+class MaskedLocalizedNarrativesBuilder(MMFDatasetBuilder):
+    def __init__(
+        self,
+        dataset_name="masked_localized_narratives",
+        dataset_class=MaskedLocalizedNarrativesDataset,
+        *args,
+        **kwargs
+    ):
+        super().__init__(dataset_name, dataset_class, *args, **kwargs)
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/localized_narratives/masked.yaml"

--- a/mmf/datasets/builders/localized_narratives/masked_dataset.py
+++ b/mmf/datasets/builders/localized_narratives/masked_dataset.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from abc import ABC
+
+from mmf.common.sample import Sample
+from mmf.common.typings import MMFDatasetConfigType
+from mmf.datasets.builders.localized_narratives.database import (
+    LocalizedNarrativesAnnotationDatabase,
+)
+from mmf.datasets.mmf_dataset import MMFDataset
+
+
+class MaskedLocalizedNarrativesDatasetMixin(ABC):
+    def build_annotation_db(self) -> LocalizedNarrativesAnnotationDatabase:
+        annotation_path = self._get_path_based_on_index(
+            self.config, "annotations", self._index
+        )
+        return LocalizedNarrativesAnnotationDatabase(self.config, annotation_path)
+
+    def __getitem__(self, idx: int) -> Sample:
+        sample_info = self.annotation_db[idx]
+        current_sample = Sample()
+        processed_caption = self.masked_token_processor(
+            {"text_a": sample_info["caption"], "text_b": "", "is_correct": True}
+        )
+        current_sample.update(processed_caption)
+        current_sample.image_id = sample_info["image_id"]
+        current_sample.feature_path = sample_info["feature_path"]
+
+        # Get the image features
+        if self._use_features:
+            features = self.features_db[idx]
+            image_info_0 = features["image_info_0"]
+            if image_info_0 and "image_id" in image_info_0.keys():
+                image_info_0["feature_path"] = image_info_0["image_id"]
+                image_info_0.pop("image_id")
+            current_sample.update(features)
+
+        return current_sample
+
+
+class MaskedLocalizedNarrativesDataset(
+    MaskedLocalizedNarrativesDatasetMixin, MMFDataset
+):
+    def __init__(
+        self,
+        config: MMFDatasetConfigType,
+        dataset_type: str,
+        index: int,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            "masked_localized_narratives", config, dataset_type, index, *args, **kwargs
+        )

--- a/projects/visual_bert/configs/localized_narratives/defaults.yaml
+++ b/projects/visual_bert/configs/localized_narratives/defaults.yaml
@@ -1,0 +1,34 @@
+model_config:
+  visual_bert:
+    hidden_size: 768
+    hidden_dropout_prob: 0.1
+    training_head_type: classification
+    num_labels: 3129
+
+dataset_config:
+  masked_localized_narratives:
+    return_features_info: true
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 1000
+    num_training_steps: 11000
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  num_workers: 0
+  # Don't forget to update schedule_attributes if you update this
+  max_updates: 88000
+  find_unused_parameters: true
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert

--- a/projects/visual_bert/configs/localized_narratives/pretrain.yaml
+++ b/projects/visual_bert/configs/localized_narratives/pretrain.yaml
@@ -1,0 +1,32 @@
+includes:
+- ../../../../mmf/configs/datasets/coco2017/masked.yaml
+- ../../../../mmf/configs/datasets/flickr30k/masked.yaml
+- ../../../../mmf/configs/datasets/localized_narratives/masked.yaml
+
+model_config:
+  visual_bert:
+    training_head_type: pretraining
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 1000
+    num_training_steps: 11000
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  num_workers: 0
+  # Don't forget to update schedule_attributes if you update this
+  max_updates: 88000
+  find_unused_parameters: true
+
+checkpoint:
+  pretrained_state_mapping:
+    model.bert: model.bert


### PR DESCRIPTION
- Add the masked language modeling task for localized narratives using just caption data.
- Create Flickr30k and Coco2017 dataset builder that shares the same mixin as localizednarratives dataset