### PR TITLE
[refactor] Use config object for ImageFeatureEncoder init

### DIFF
--- a/mmf/models/movie_mcan.py
+++ b/mmf/models/movie_mcan.py
@@ -12,8 +12,8 @@ from mmf.modules.embeddings import (
     TextEmbedding,
     TwoBranchEmbedding,
 )
-from mmf.modules.encoders import ImageFeatureEncoder
 from mmf.modules.layers import BranchCombineLayer, ClassifierLayer
+from mmf.utils.build import build_image_encoder
 from mmf.utils.general import filter_grads
 
 
@@ -68,12 +68,10 @@ class MoVieMcan(BaseModel):
         feature_dim = self.config[attr + "_feature_dim"]
         setattr(self, attr + "_feature_dim", feature_dim)
 
-        encoder_type = feat_encoder.type
-        encoder_kwargs = copy.deepcopy(feat_encoder.params)
-        encoder_kwargs.model_data_dir = self.config.model_data_dir
-        encoder_kwargs.cond_features = self.text_embeddings_out_dim
-
-        feat_model = ImageFeatureEncoder(encoder_type, feature_dim, **encoder_kwargs)
+        feat_encoder_config = copy.deepcopy(feat_encoder)
+        feat_encoder_config.params.model_data_dir = self.config.model_data_dir
+        feat_encoder_config.params.in_dim = feature_dim
+        feat_model = build_image_encoder(feat_encoder_config, direct_features=True)
 
         setattr(self, attr + "_feature_dim", feat_model.out_dim)
         setattr(self, attr + "_feature_encoders", feat_model)

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -259,7 +259,7 @@ def build_image_encoder(config, direct_features=False, **kwargs):
     from mmf.modules.encoders import ImageEncoder, ImageFeatureEncoder
 
     if direct_features:
-        module = ImageFeatureEncoder(config.type, **config.params)
+        module = ImageFeatureEncoder(config)
     else:
         module = ImageEncoder(config)
     return module.module


### PR DESCRIPTION
Summary: There has been a mismatch between ImageFeatureEncoder and ImageEncoder signatures which doesn't allow us to create same config types for them even though that's how they are used. This is confusing and should be same. This diff aims to fix this discrepancy.

Differential Revision: D23712213

