### PR TITLE
[feat] Add init dataclasses for mmbt and encoders

### DIFF
--- a/mmf/configs/models/mmbt/defaults.yaml
+++ b/mmf/configs/models/mmbt/defaults.yaml
@@ -8,6 +8,7 @@ model_config:
     freeze_modal: false
     freeze_complete_base: false
     finetune_lr_multiplier: 1
+    fused_feature_only: false
     # Dimension of the embedding finally returned by the modal encoder
     modal_hidden_size: 2048
     # Dimension of the embedding finally returned by the text encoder

--- a/mmf/models/m4c.py
+++ b/mmf/models/m4c.py
@@ -122,7 +122,7 @@ class M4C(BaseModel):
 
         # OCR appearance feature: Faster R-CNN
         self.ocr_faster_rcnn_fc7 = build_image_encoder(
-            self._build_encoder_config, direct_features=True
+            self._build_encoder_config(), direct_features=True
         )
         self.finetune_modules.append(
             {"module": self.ocr_faster_rcnn_fc7, "lr_scale": self.config.lr_scale_frcn}

--- a/mmf/models/movie_mcan.py
+++ b/mmf/models/movie_mcan.py
@@ -12,8 +12,8 @@ from mmf.modules.embeddings import (
     TextEmbedding,
     TwoBranchEmbedding,
 )
-from mmf.modules.encoders import ImageFeatureEncoder
 from mmf.modules.layers import BranchCombineLayer, ClassifierLayer
+from mmf.utils.build import build_image_encoder
 from mmf.utils.general import filter_grads
 
 
@@ -68,12 +68,10 @@ class MoVieMcan(BaseModel):
         feature_dim = self.config[attr + "_feature_dim"]
         setattr(self, attr + "_feature_dim", feature_dim)
 
-        encoder_type = feat_encoder.type
-        encoder_kwargs = copy.deepcopy(feat_encoder.params)
-        encoder_kwargs.model_data_dir = self.config.model_data_dir
-        encoder_kwargs.cond_features = self.text_embeddings_out_dim
-
-        feat_model = ImageFeatureEncoder(encoder_type, feature_dim, **encoder_kwargs)
+        feat_encoder_config = copy.deepcopy(feat_encoder)
+        feat_encoder_config.params.model_data_dir = self.config.model_data_dir
+        feat_encoder_config.params.in_dim = feature_dim
+        feat_model = build_image_encoder(feat_encoder_config, direct_features=True)
 
         setattr(self, attr + "_feature_dim", feat_model.out_dim)
         setattr(self, attr + "_feature_encoders", feat_model)

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -262,7 +262,7 @@ def build_image_encoder(config, direct_features=False, **kwargs):
     from mmf.modules.encoders import ImageEncoder, ImageFeatureEncoder
 
     if direct_features:
-        module = ImageFeatureEncoder(config.type, **config.params)
+        module = ImageFeatureEncoder(config)
     else:
         module = ImageEncoder(config)
     return module.module


### PR DESCRIPTION
Summary:
As step one of FAIM integration, we allow building our models from config so that the models are purely decoupled from configuration and users know what the model expects.

We first do this for the MMBT model.

- Adds configs for MMBT and respective encoders.
- Also adds from_params method for MMBT

There is an issue with OmegaConf that doesn't let us use Union in structured configs. Take a look at https://github.com/omry/omegaconf/issues/144

Differential Revision: D23699688

