### PR TITLE
[feat] Add torchscriptable version for MMF Transformer

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -21,6 +21,7 @@ Various decorators for registry different kind of classes with unique keys
 - Register a optimizer: ``@registry.register_optimizer``
 - Register a scheduler: ``@registry.register_scheduler``
 - Register a decoder: ``@registry.register_decoder``
+- Register a transformer backend: ``@registry.register_transformer_backend``
 """
 from mmf.utils.env import setup_imports
 
@@ -47,6 +48,7 @@ class Registry:
         "scheduler_name_mapping": {},
         "processor_name_mapping": {},
         "decoder_name_mapping": {},
+        "transformer_backend_name_mapping": {},
         "state": {},
     }
 
@@ -266,6 +268,14 @@ class Registry:
         return wrap
 
     @classmethod
+    def register_transformer_backend(cls, name):
+        def wrap(func):
+            cls.mapping["transformer_backend_name_mapping"][name] = func
+            return func
+
+        return wrap
+
+    @classmethod
     def register_decoder(cls, name):
         r"""Register a decoder to registry with key 'name'
 
@@ -353,6 +363,10 @@ class Registry:
     @classmethod
     def get_decoder_class(cls, name):
         return cls.mapping["decoder_name_mapping"].get(name, None)
+
+    @classmethod
+    def get_transformer_backend_class(cls, name):
+        return cls.mapping["transformer_backend_name_mapping"].get(name, None)
 
     @classmethod
     def get(cls, name, default=None, no_warning=False):

--- a/mmf/configs/models/mmf_transformer/defaults.yaml
+++ b/mmf/configs/models/mmf_transformer/defaults.yaml
@@ -2,11 +2,17 @@ model_config:
   mmf_transformer:
     transformer_base: bert-base-uncased
     training_head_type: classification
+    backend:
+      type: huggingface
+      params: {}
     num_labels: 2
     modalities:
       - type: text
         key: text
+        position_dim: 512
         segment_id: 0
+        layer_norm_eps: 1e-12
+        hidden_dropout_prob: 0.1
       - type: image
         key: image
         embedding_dim: 2048

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -170,8 +170,10 @@ class BaseModel(nn.Module):
             assert isinstance(
                 model_output["losses"], collections.abc.Mapping
             ), "'losses' must be a dict."
-        else:
+        elif hasattr(self, "losses"):
             model_output["losses"] = self.losses(sample_list, model_output)
+        else:
+            model_output["losses"] = {}
 
         return model_output
 

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-from copy import deepcopy
-from typing import Any, Dict, List, Type
+from typing import Dict, List
 
 import torch
 from mmf.common.registry import registry
@@ -32,156 +31,21 @@ class ImageEncoder(MultiModalEncoderBase):
         return self.encoder(x)
 
 
-class MMFTransformerEmbeddings(nn.Module):
-    """Embedding class that can take any number of image or text modalities, each can
-    have their input id, position id and segment id. We generate embeddings of
-    dimension config.hidden_size for each and then first add the three embeddings
-    for each modality to have a modality specific embedding. We then concat the
-    modality specific embeddings to have a joint embedding.
-    """
-
-    def __init__(
-        self,
-        model_config: BaseTransformerConfigType,
-        transformer_config: Dict[str, Any],
-        transformer: Type[nn.Module],
-        *args,
-        **kwargs,
-    ):
-        super().__init__()
-        self.model_config = model_config
-        self.transformer_config = transformer_config
-
-        self.token_embeddings = nn.ModuleList()
-        self.pos_embeddings = nn.ModuleList()
-        self.layer_norms = nn.ModuleList()
-        self.dropouts = nn.ModuleList()
-        self.modality_keys: List = []
-
-        # Build layers for each modality and initialize
-        self.build_layers()
-        self.init_weights(transformer)
-
-        assert (
-            len(self.token_embeddings)
-            == len(self.pos_embeddings)
-            == len(self.layer_norms)
-            == len(self.dropouts)
-            == len(self.model_config.modalities)
-        )
-
-    def build_layers(self):
-
-        for modality in self.model_config.modalities:
-            self.modality_keys.append(modality.key)
-            layer_norm_eps = modality.get(
-                "layer_norm_eps", self.transformer_config.layer_norm_eps
-            )
-            position_dim = modality.get(
-                "position_dim", self.transformer_config.max_position_embeddings
-            )
-            hidden_dropout_prob = modality.get(
-                "hidden_dropout_prob", self.transformer_config.hidden_dropout_prob
-            )
-            if modality.type == "text":
-                self.token_embeddings.append(
-                    nn.Embedding(
-                        self.transformer_config.vocab_size,
-                        self.transformer_config.hidden_size,
-                        padding_idx=self.transformer_config.pad_token_id,
-                    )
-                )
-            elif modality.type == "image":
-                self.token_embeddings.append(
-                    nn.Sequential(
-                        nn.Linear(
-                            modality.embedding_dim, self.transformer_config.hidden_size
-                        ),
-                        torch.nn.LayerNorm(
-                            self.transformer_config.hidden_size, eps=layer_norm_eps
-                        ),
-                    )
-                )
-            self.pos_embeddings.append(
-                nn.Embedding(position_dim, self.transformer_config.hidden_size)
-            )
-            self.layer_norms.append(
-                torch.nn.LayerNorm(
-                    self.transformer_config.hidden_size, eps=layer_norm_eps
-                )
-            )
-            self.dropouts.append(nn.Dropout(hidden_dropout_prob))
-
-        self.token_type_embeddings = nn.Embedding(
-            len(self.model_config.modalities), self.transformer_config.hidden_size
-        )
-
-    def init_weights(self, transformer: Type[nn.Module]):
-        for idx, modality in enumerate(self.model_config.modalities):
-            if modality.type == "text":
-                self.token_embeddings[idx] = transformer.embeddings.word_embeddings
-                self.layer_norms[idx] = transformer.embeddings.LayerNorm
-
-            self.pos_embeddings[idx].weight = nn.Parameter(
-                deepcopy(transformer.embeddings.position_embeddings.weight.data),
-                requires_grad=True,
-            )
-
-        # Token Type or Segment Embeddings
-        if hasattr(transformer.embeddings, "token_type_embeddings"):
-            token_vocab_size = self.transformer_config.type_vocab_size
-            self.token_type_embeddings.weight.data[:token_vocab_size].copy_(
-                transformer.embeddings.token_type_embeddings.weight
-            )
-            for idx in range(token_vocab_size, len(self.model_config.modalities)):
-                self.token_type_embeddings.weight.data[idx].copy_(
-                    transformer.embeddings.token_type_embeddings.weight.data.mean(dim=0)
-                )
-                # Add random normal noise
-                self.token_type_embeddings.weight.data[idx] += torch.normal(
-                    self.model_config.token_noise_mean,
-                    self.model_config.token_noise_std,
-                    size=self.token_type_embeddings.weight.data[idx].size(),
-                )
-
-    def forward(
-        self,
-        input_ids: Dict[str, Tensor],
-        position_ids: Dict[str, Tensor],
-        segment_ids: Dict[str, Tensor],
-    ) -> Tensor:
-        list_embeddings = []
-        for idx, (token_emb, pos_emb, layer_norm, dropout) in enumerate(
-            zip(
-                self.token_embeddings,
-                self.pos_embeddings,
-                self.layer_norms,
-                self.dropouts,
-            )
-        ):
-            modality_name = self.modality_keys[idx]
-            total_embedding = token_emb(input_ids[modality_name])
-            if modality_name in position_ids:
-                total_embedding += pos_emb(position_ids[modality_name])
-
-            if modality_name in segment_ids:
-                total_embedding += self.token_type_embeddings(
-                    segment_ids[modality_name]
-                )
-
-            list_embeddings.append(dropout(layer_norm(total_embedding)))
-
-        return torch.cat(list_embeddings, dim=1)
-
-
 @registry.register_model("mmf_transformer")
 class MMFTransformer(BaseTransformer):
     def __init__(self, config: BaseTransformerConfigType, *args, **kwargs):
         super().__init__(config)
         self.num_labels = self.config.num_labels
         self.modality_keys: List = []
+        self.modality_type: List = []
+        self.modality_segments: List = []
         for modality in self.config.modalities:
             self.modality_keys.append(modality.key)
+            self.modality_type.append(modality.type)
+            if "segment_id" in modality:
+                self.modality_segments.append(modality.segment_id)
+            else:
+                self.modality_segments.append(-1)
 
     @classmethod
     def config_path(cls) -> str:
@@ -193,15 +57,6 @@ class MMFTransformer(BaseTransformer):
             for param in self.image_encoder.parameters():
                 param.requires_grad = False
 
-    def build_embeddings(self):
-        """Initialize the embedding class we will use for multiple
-        modalities (here just text and image). For the text embeeddings we will use the
-        pretrained weights from the trasnformer model rather than training from scratch.
-        """
-        self.embeddings = MMFTransformerEmbeddings(
-            self.config, self.transformer_config, self.transformer
-        )
-
     def build_heads(self):
         """Initialize the classifier head. It takes the output of the
         transformer encoder and passes it through a pooler (we use the pooler from BERT
@@ -209,14 +64,15 @@ class MMFTransformer(BaseTransformer):
         followed by activation and layer norm) and lastly a linear layer projecting the
         hidden output to classification labels.
         """
+        transformer_config = self.backend.get_config()
+        self.pooler = BertPooler(transformer_config)
         self.classifier = nn.Sequential(
-            BertPooler(self.transformer_config),
-            nn.Dropout(self.transformer_config.hidden_dropout_prob),
-            BertPredictionHeadTransform(self.transformer_config),
-            nn.Linear(self.transformer_config.hidden_size, self.config.num_labels),
+            nn.Dropout(transformer_config.hidden_dropout_prob),
+            BertPredictionHeadTransform(transformer_config),
+            nn.Linear(transformer_config.hidden_size, self.config.num_labels),
         )
 
-    def preprocess_sample(self, sample_list: Dict[str, Any]) -> BaseTransformerInput:
+    def preprocess_sample(self, sample_list: Dict[str, Tensor]) -> BaseTransformerInput:
         """Preprocess the sample list elements and form a BaseTransformerInput
         type object. This object standardizes how we represent multiple modalities.
         Check the definition of this dataclass in BaseTransformer.
@@ -224,102 +80,88 @@ class MMFTransformer(BaseTransformer):
 
         # Input IDs (or text tokens/image features)
         input_ids: Dict[str, Tensor] = {}
-        for idx, modality in enumerate(self.config.modalities):
-            if modality.type == "text":
-                if sample_list.input_ids.dim() > 2:
-                    input_ids[modality.key] = sample_list.input_ids[:, idx]
+        for idx, modality in enumerate(self.modality_keys):
+            if self.modality_type[idx] == "text":
+                if sample_list["input_ids"].dim() > 2:
+                    input_ids[modality] = sample_list["input_ids"][:, idx]
                 else:
-                    input_ids[modality.key] = sample_list.input_ids
-            elif modality.type == "image":
+                    input_ids[modality] = sample_list["input_ids"]
+            elif self.modality_type[idx] == "image":
                 if "image" in sample_list:
-                    image_modal = sample_list.image
+                    image_modal = sample_list["image"]
                 else:
-                    image_modal = sample_list.image_feature_0
-                input_ids[modality.key] = self.image_encoder(image_modal)
+                    image_modal = sample_list["image_feature_0"]
+                input_ids[modality] = self.image_encoder(image_modal)
 
         # Position IDs
         position_ids: Dict[str, Tensor] = {}
-        for modality in self.config.modalities:
-            position_ids[modality.key] = (
+        for modality in self.modality_keys:
+            position_ids[modality] = (
                 torch.arange(
                     0,
-                    input_ids[modality.key].size(1),
+                    input_ids[modality].size(1),
                     dtype=torch.long,
-                    device=input_ids[modality.key].device,
+                    device=input_ids[modality].device,
                 )
                 .unsqueeze(0)
-                .expand(input_ids[modality.key].size()[:2])
+                .expand(input_ids[modality].size()[:2])
             )
 
         # Segment IDs
         segment_ids: Dict[str, Tensor] = {}
-        for idx, modality in enumerate(self.config.modalities):
-            if modality.type == "text" and hasattr(sample_list, "segment_ids"):
-                if sample_list.segment_ids.dim() > 2:
-                    segment_ids[modality.key] = sample_list.segment_ids[:, idx]
+        for idx, modality in enumerate(self.modality_keys):
+            if self.modality_segments[idx] == -1:
+                continue
+            if self.modality_type[idx] == "text" and "segment_ids" in sample_list:
+                if sample_list["segment_ids"].dim() > 2:
+                    segment_ids[modality] = sample_list["segment_ids"][:, idx]
                 else:
-                    segment_ids[modality.key] = sample_list.segment_ids
-            elif hasattr(modality, "segment_id"):
-                segment_ids[modality.key] = torch.zeros(
-                    input_ids[modality.key].size()[:2],
+                    segment_ids[modality] = sample_list["segment_ids"]
+            else:
+                segment_ids[modality] = torch.zeros(
+                    input_ids[modality].size()[:2],
                     dtype=torch.long,
-                    device=input_ids[modality.key].device,
-                ).fill_(modality.segment_id)
+                    device=input_ids[modality].device,
+                ).fill_(self.modality_segments[idx])
 
         # Masks
         masks: Dict[str, Tensor] = {}
-        for idx, modality in enumerate(self.config.modalities):
-            if modality.type == "text":
-                if sample_list.input_mask.dim() > 2:
-                    masks[modality.key] = sample_list.input_mask[:, idx]
+        for idx, modality in enumerate(self.modality_keys):
+            if self.modality_type[idx] == "text":
+                if sample_list["input_mask"].dim() > 2:
+                    masks[modality] = sample_list["input_mask"][:, idx]
                 else:
-                    masks[modality.key] = sample_list.input_mask
+                    masks[modality] = sample_list["input_mask"]
 
-            elif modality.type == "image":
+            elif self.modality_type[idx] == "image":
                 if "image_mask" in sample_list:
-                    masks[modality.key] = sample_list.image_mask
+                    masks[modality] = sample_list["image_mask"]
                 else:
-                    masks[modality.key] = torch.ones(
-                        input_ids[modality.key].size()[:-1],
+                    masks[modality] = torch.ones(
+                        input_ids[modality].size()[:-1],
                         dtype=torch.long,
-                        device=input_ids[modality.key].device,
+                        device=input_ids[modality].device,
                     )
 
         return BaseTransformerInput(input_ids, position_ids, segment_ids, masks)
-
-    def transformer_encode(self, embedding, attention_mask):
-        return self.transformer.encoder(
-            embedding, attention_mask, [None] * len(self.transformer.encoder.layer)
-        )
 
     def forward(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
         # Sample preprocess
         output = self.preprocess_sample(sample_list)
 
-        # Transformer Input Embeddings
-        embedding_output = self.embeddings(
-            input_ids=output["input_ids"],
-            position_ids=output["position_ids"],
-            segment_ids=output["segment_ids"],
-        )
-
-        # Transformer Attention mask
-        # concat the attention masks for all modalities
+        # Arrange masks in a list
         masks = []
         for modality in self.modality_keys:
-            masks.append(output["masks"][modality])
-        attention_mask = torch.cat(masks, dim=-1)
-        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
-        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+            masks.append(output.masks[modality])
 
-        # Transformer Encoder
-        encoded_layers = self.transformer_encode(
-            embedding_output,  # combined embedding
-            extended_attention_mask,  # combined attention mask
+        # Call transformer backend
+        sequence_output, _ = self.backend(
+            output.input_ids, output.position_ids, output.segment_ids, masks
         )
 
         # Transformer Heads
-        head_output = self.classifier(encoded_layers[0])
+        pooled_output = self.pooler(sequence_output)
+        head_output = self.classifier(pooled_output)
 
         # Postprocess outputs
         return self.postprocess_output(head_output)

--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -1,0 +1,231 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from copy import deepcopy
+from typing import Any, Dict, List, Type
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.transformers.base import (
+    BaseTransformerBackend,
+    BaseTransformerConfigType,
+)
+from mmf.modules.hf_layers import replace_with_jit
+from omegaconf import OmegaConf
+from torch import Tensor, nn
+from transformers import AutoConfig, AutoModel
+
+
+class HuggingfaceEmbeddings(nn.Module):
+    """Embedding class that can take any number of image or text modalities, each can
+    have their input id, position id and segment id. We generate embeddings of
+    dimension config.hidden_size for each and then first add the three embeddings
+    for each modality to have a modality specific embedding. We then concat the
+    modality specific embeddings to have a joint embedding.
+    """
+
+    def __init__(
+        self,
+        model_config: BaseTransformerConfigType,
+        transformer_config: Dict[str, Any],
+        transformer: Type[nn.Module],
+        *args,
+        **kwargs,
+    ):
+        super().__init__()
+        self.model_config = model_config
+        self.transformer_config = transformer_config
+
+        self.token_embeddings = nn.ModuleList()
+        self.pos_embeddings = nn.ModuleList()
+        self.layer_norms = nn.ModuleList()
+        self.dropouts = nn.ModuleList()
+        self.modality_keys: List = []
+
+        # Build layers for each modality and initialize
+        self.build_layers()
+        self.init_weights(transformer)
+
+        assert (
+            len(self.token_embeddings)
+            == len(self.pos_embeddings)
+            == len(self.layer_norms)
+            == len(self.dropouts)
+            == len(self.model_config.modalities)
+        )
+
+    def build_layers(self):
+
+        for modality in self.model_config.modalities:
+            self.modality_keys.append(modality.key)
+            layer_norm_eps = modality.get(
+                "layer_norm_eps", self.transformer_config.layer_norm_eps
+            )
+            position_dim = modality.get(
+                "position_dim", self.transformer_config.max_position_embeddings
+            )
+            hidden_dropout_prob = modality.get(
+                "hidden_dropout_prob", self.transformer_config.hidden_dropout_prob
+            )
+            if modality.type == "text":
+                self.token_embeddings.append(
+                    nn.Embedding(
+                        self.transformer_config.vocab_size,
+                        self.transformer_config.hidden_size,
+                        padding_idx=self.transformer_config.pad_token_id,
+                    )
+                )
+            elif modality.type == "image":
+                self.token_embeddings.append(
+                    nn.Sequential(
+                        nn.Linear(
+                            modality.embedding_dim, self.transformer_config.hidden_size
+                        ),
+                        torch.nn.LayerNorm(
+                            self.transformer_config.hidden_size, eps=layer_norm_eps
+                        ),
+                    )
+                )
+            self.pos_embeddings.append(
+                nn.Embedding(position_dim, self.transformer_config.hidden_size)
+            )
+            self.layer_norms.append(
+                torch.nn.LayerNorm(
+                    self.transformer_config.hidden_size, eps=layer_norm_eps
+                )
+            )
+            self.dropouts.append(nn.Dropout(hidden_dropout_prob))
+
+        self.token_type_embeddings = nn.Embedding(
+            len(self.model_config.modalities), self.transformer_config.hidden_size
+        )
+
+    def init_weights(self, transformer: Type[nn.Module]):
+        for idx, modality in enumerate(self.model_config.modalities):
+            if modality.type == "text":
+                self.token_embeddings[idx] = transformer.embeddings.word_embeddings
+                self.layer_norms[idx] = transformer.embeddings.LayerNorm
+
+            self.pos_embeddings[idx].weight = nn.Parameter(
+                deepcopy(transformer.embeddings.position_embeddings.weight.data),
+                requires_grad=True,
+            )
+
+        # Token Type or Segment Embeddings
+        if hasattr(transformer.embeddings, "token_type_embeddings"):
+            token_vocab_size = self.transformer_config.type_vocab_size
+            self.token_type_embeddings.weight.data[:token_vocab_size].copy_(
+                transformer.embeddings.token_type_embeddings.weight
+            )
+            for idx in range(token_vocab_size, len(self.model_config.modalities)):
+                self.token_type_embeddings.weight.data[idx].copy_(
+                    transformer.embeddings.token_type_embeddings.weight.data.mean(dim=0)
+                )
+                # Add random normal noise
+                self.token_type_embeddings.weight.data[idx] += torch.normal(
+                    self.model_config.token_noise_mean,
+                    self.model_config.token_noise_std,
+                    size=self.token_type_embeddings.weight.data[idx].size(),
+                )
+
+    def forward(
+        self,
+        tokens_ids: Dict[str, Tensor],
+        position_ids: Dict[str, Tensor],
+        segment_ids: Dict[str, Tensor],
+    ) -> Tensor:
+        list_embeddings = []
+        for idx, (token_emb, pos_emb, layer_norm, dropout) in enumerate(
+            zip(
+                self.token_embeddings,
+                self.pos_embeddings,
+                self.layer_norms,
+                self.dropouts,
+            )
+        ):
+            modality_name = self.modality_keys[idx]
+            total_embedding = token_emb(tokens_ids[modality_name])
+            if modality_name in position_ids:
+                total_embedding += pos_emb(position_ids[modality_name])
+
+            if modality_name in segment_ids:
+                total_embedding += self.token_type_embeddings(
+                    segment_ids[modality_name]
+                )
+
+            list_embeddings.append(dropout(layer_norm(total_embedding)))
+
+        return torch.cat(list_embeddings, dim=1)
+
+
+@registry.register_transformer_backend("huggingface")
+class HuggingfaceBackend(BaseTransformerBackend):
+    """Transformer backend wih Huggingface transformer models
+    """
+
+    def __init__(self, config: BaseTransformerConfigType, *args, **kwargs):
+        super().__init__(config)
+
+        # Replace transformer layers with scriptable JIT layers
+        replace_with_jit()
+
+    def build_transformer_config(self):
+        """Build the transformer base model config.
+        """
+        self.transformer_config = AutoConfig.from_pretrained(
+            self.config.transformer_base, **OmegaConf.to_container(self.config)
+        )
+
+    def build_transformer_base(self):
+        """Build the transformer base model.
+        """
+        self.transformer = AutoModel.from_pretrained(
+            self.config.transformer_base, config=self.transformer_config
+        )
+
+    def build_embeddings(self):
+        """Build the multimodal embeddings using the transformer base
+        embeddings.
+        """
+        self.embeddings = HuggingfaceEmbeddings(
+            self.config, self.transformer_config, self.transformer
+        )
+
+    def get_config(self):
+        """Return the transformer configuration.
+        """
+        return self.transformer_config
+
+    def generate_embeddings(
+        self,
+        tokens_ids: Dict[str, Tensor],
+        position_ids: Dict[str, Tensor],
+        segment_ids: Dict[str, Tensor],
+        attention_mask: Tensor,
+    ) -> Tensor:
+        """Generate multimodal embeddings.
+        """
+        return self.embeddings(
+            tokens_ids=tokens_ids, position_ids=position_ids, segment_ids=segment_ids
+        )
+
+    def generate_attention_mask(self, masks: List[Tensor]) -> Tensor:
+        """Generate attention mask.
+        """
+        attention_mask = torch.cat(masks, dim=-1)
+        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+
+        return extended_attention_mask
+
+    def generate_encoded_layers(self, embedding, attention_mask) -> List[Tensor]:
+        """Generate the output from transformer layers. For huggingface models the
+        output encoded layers is a Tuple(last layer output, all layers). So the
+        order is reversed to match the output order of other backends.
+        """
+        if torch.jit.is_scripting():
+            encoded_layers = self.transformer.encoder(embedding, attention_mask)
+        else:
+            encoded_layers = self.transformer.encoder(
+                embedding, attention_mask, [None] * len(self.transformer.encoder.layer)
+            )
+        return encoded_layers[-1], encoded_layers[0]

--- a/mmf/utils/modeling.py
+++ b/mmf/utils/modeling.py
@@ -47,7 +47,7 @@ def get_optimizer_parameters_for_bert(module, config):
     model_config = getattr(config.model_config, config.model, {})
     finetune_lr_multiplier = getattr(model_config, "finetune_lr_multiplier", 1)
     # Finetune the bert pretrained part with finetune_lr_multiplier if it is set
-    encoder = module.transformer if hasattr(module, "transformer") else module.bert
+    encoder = module.backend if hasattr(module, "backend") else module.bert
     parameters = get_bert_configured_parameters(encoder, lr * finetune_lr_multiplier)
     # Classifier will be trained on the normal lr
     parameters += get_bert_configured_parameters(module.classifier, lr)

--- a/tests/models/test_mmf_transformer.py
+++ b/tests/models/test_mmf_transformer.py
@@ -1,0 +1,101 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import io
+import unittest
+
+import torch
+from mmf.common.registry import registry
+from mmf.common.sample import Sample, SampleList
+from mmf.utils.configuration import Configuration
+from mmf.utils.env import setup_imports
+
+import tests.test_utils as test_utils
+
+
+class TestMMFTransformerTorchscript(unittest.TestCase):
+    def setUp(self):
+        setup_imports()
+        self.model_name = "mmf_transformer"
+        args = test_utils.dummy_args(model=self.model_name)
+        configuration = Configuration(args)
+        self.config = configuration.get_config()
+        self.model_class = registry.get_model_class(self.model_name)
+        self.finetune_model = self.model_class(
+            self.config.model_config[self.model_name]
+        )
+        self.finetune_model.build()
+
+    @test_utils.skip_if_no_network
+    def test_load_save_finetune_model(self):
+        self.finetune_model.eval()
+        script_model = torch.jit.script(self.finetune_model)
+        buffer = io.BytesIO()
+        torch.jit.save(script_model, buffer)
+        buffer.seek(0)
+        loaded_model = torch.jit.load(buffer)
+        self.assertTrue(test_utils.assertModulesEqual(script_model, loaded_model))
+
+    @test_utils.skip_if_no_network
+    def test_finetune_bert_base(self):
+        self.finetune_model.eval()
+        test_sample = Sample()
+        test_sample.input_ids = torch.randint(low=0, high=30255, size=(128,)).long()
+        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.segment_ids = torch.zeros(128).long()
+        test_sample.image = torch.rand((3, 300, 300)).float()
+        test_sample_list = SampleList([test_sample])
+
+        with torch.no_grad():
+            model_output = self.finetune_model(test_sample_list)
+
+        script_model = torch.jit.script(self.finetune_model)
+        with torch.no_grad():
+            script_output = script_model(test_sample_list)
+
+        self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))
+
+    @test_utils.skip_if_no_network
+    def test_finetune_roberta_base(self):
+        self.config.model_config[self.model_name]["transformer_base"] = "roberta-base"
+        model = self.model_class(self.config.model_config[self.model_name])
+        model.build()
+        model.eval()
+        test_sample = Sample()
+        test_sample.input_ids = torch.randint(low=0, high=50265, size=(128,)).long()
+        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.segment_ids = torch.zeros(128).long()
+        test_sample.image = torch.rand((3, 300, 300)).float()
+        test_sample_list = SampleList([test_sample])
+
+        with torch.no_grad():
+            model_output = model(test_sample_list)
+
+        script_model = torch.jit.script(model)
+        with torch.no_grad():
+            script_output = script_model(test_sample_list)
+
+        self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))
+
+    @test_utils.skip_if_no_network
+    def test_finetune_xlmr_base(self):
+        self.config.model_config[self.model_name][
+            "transformer_base"
+        ] = "xlm-roberta-base"
+        model = self.model_class(self.config.model_config[self.model_name])
+        model.build()
+        model.eval()
+        test_sample = Sample()
+        test_sample.input_ids = torch.randint(low=0, high=250002, size=(128,)).long()
+        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.segment_ids = torch.zeros(128).long()
+        test_sample.image = torch.rand((3, 300, 300)).float()
+        test_sample_list = SampleList([test_sample])
+
+        with torch.no_grad():
+            model_output = model(test_sample_list)
+
+        script_model = torch.jit.script(model)
+        with torch.no_grad():
+            script_output = script_model(test_sample_list)
+
+        self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))


### PR DESCRIPTION
Summary:

- Modifications to MMF transformer `preprocess_sample` to be scriptable friendly.
- Refactor out backends : Added a `BaseTransformerBackend` abstract class.
- Added a new scriptable backend for MMF Transformer that supports only Huggingface Bert, Roberta and XLMR transformer models.  Here we are implementing a version of MMF Transformer that supports torchscriptable layers and works only for BERT, RoBERTa and XLMR models
- Add scriptable `RobertaEmbeddingsJIT`
- Add tests for MMF Transformer

Differential Revision: D23569352

