### PR TITLE
[feat] Add fp16 support to MMFTrainer

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -286,3 +286,5 @@ checkpoint:
         optimizer: false
         # All counts such as best_update, current_iteration etc will be reset
         counts: false
+        # If fp16 scaler should be reset or not
+        fp16_scaler: false

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -126,6 +126,8 @@ training:
     # only be used for debugging purposes
     detect_anomaly: false
 
+    fp16: false
+
 # Configuration for evaluation
 evaluation:
     # Metrics for evaluation

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -126,6 +126,9 @@ training:
     # only be used for debugging purposes
     detect_anomaly: false
 
+    # FP16 support through torch.cuda.amp autocast and grad scaler.
+    # Set to true to activate fp16 for faster performance with negligible
+    # drop in results.
     fp16: false
 
 # Configuration for evaluation

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -62,7 +62,8 @@ class TrainerEvaluationLoopMixin(ABC):
                 for batch in tqdm.tqdm(dataloader):
                     prepared_batch = reporter.prepare_batch(batch)
                     prepared_batch = to_device(prepared_batch, torch.device("cuda"))
-                    model_output = self.model(prepared_batch)
+                    with torch.cuda.amp.autocast(enabled=self.training_config.fp16):
+                        model_output = self.model(prepared_batch)
                     report = Report(prepared_batch, model_output)
                     reporter.add_to_report(report, self.model)
 

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -197,6 +197,7 @@ class TrainerTrainingLoopMixin(ABC):
                 self.num_updates,
                 self.logistics_callback.tb_writer,
                 self.config,
+                scale=self.scaler.get_scale(),
             )
 
         self.scaler.step(self.optimizer)

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -288,7 +288,7 @@ class Checkpoint:
     def _load_fp16_scaler(self, ckpt):
         scaler = getattr(self.trainer, "scaler", None)
         scaler_dict = ckpt.get("fp16_scaler", None)
-        if scaler_dict is not None:
+        if scaler is not None and scaler_dict is not None:
             scaler.load_state_dict(scaler_dict)
 
     def _load_pretrained(self, ckpt):

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -24,24 +24,17 @@ def lr_lambda_update(i_iter, cfg):
         return pow(cfg.training.lr_ratio, idx)
 
 
-def clip_gradients(model, i_iter, writer, config):
-    # TODO: Fix question model retrieval
+def clip_gradients(model, i_iter, writer, config, scale=1.0):
     max_grad_l2_norm = config.training.max_grad_l2_norm
     clip_norm_mode = config.training.clip_norm_mode
 
     if max_grad_l2_norm is not None:
         if clip_norm_mode == "all":
-            norm = nn.utils.clip_grad_norm_(model.parameters(), max_grad_l2_norm)
-            if writer is not None:
-                writer.add_scalars({"grad_norm": norm}, i_iter)
-
-        elif clip_norm_mode == "question":
-            question_embedding = model.module.question_embedding_module
-            norm = nn.utils.clip_grad_norm(
-                question_embedding.parameters(), max_grad_l2_norm
+            norm = nn.utils.clip_grad_norm_(
+                model.parameters(), max_grad_l2_norm * scale
             )
             if writer is not None:
-                writer.add_scalars({"question_grad_norm": norm}, i_iter)
+                writer.add_scalars({"grad_norm": norm}, i_iter)
         else:
             raise NotImplementedError(
                 "Clip norm mode %s not implemented" % clip_norm_mode

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,7 +106,9 @@ class NumbersDataset(torch.utils.data.Dataset):
         self.data_item_key = data_item_key
 
     def __getitem__(self, idx):
-        return {self.data_item_key: torch.tensor(idx, dtype=torch.float32)}
+        return {
+            self.data_item_key: torch.tensor(idx, dtype=torch.float32).unsqueeze(-1)
+        }
 
     def __len__(self):
         return self.num_examples

--- a/tests/trainers/test_fp16.py
+++ b/tests/trainers/test_fp16.py
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+
+import torch
+from mmf.trainers.mmf_trainer import MMFTrainer
+from tests.test_utils import SimpleModel, skip_if_no_cuda
+from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+
+
+class SimpleModelWithFp16Assert(SimpleModel):
+    def forward(self, sample_list):
+        batch_tensor = sample_list[list(sample_list.keys())[0]]
+        # Start should be fp32
+        assert batch_tensor.dtype == torch.float32
+        batch_tensor = self.linear(batch_tensor)
+
+        # In between operation should be fp16
+        assert batch_tensor.dtype == torch.float16
+        loss = torch.sum(batch_tensor)
+
+        # Sum should convert it back to fp32
+        assert loss.dtype == torch.float32
+
+        model_output = {"losses": {"loss": loss}}
+        return model_output
+
+
+class MMFTrainerMock(TrainerTrainingLoopMock, MMFTrainer):
+    def __init__(
+        self, num_train_data, max_updates, max_epochs, device="cuda", fp16_model=False
+    ):
+        super().__init__(num_train_data, max_updates, max_epochs)
+        self.device = torch.device(device)
+        if fp16_model:
+            assert (
+                torch.cuda.is_available()
+            ), "MMFTrainerMock fp16 requires cuda enabled"
+            self.model = SimpleModelWithFp16Assert(1)
+            self.model = self.model.cuda()
+        self.optimizer = torch.optim.SGD(self.model.parameters(), lr=1e-3)
+
+
+class TestFp16(unittest.TestCase):
+    @skip_if_no_cuda
+    def test_fp16_works(self):
+        trainer = MMFTrainerMock(100, 2, 0.04)
+        trainer.load_fp16_scaler()
+        self.assertTrue(isinstance(trainer.scaler, torch.cuda.amp.GradScaler))
+        self.assertEqual(trainer.current_iteration, 0)
+        trainer.training_loop()
+        self.assertEqual(trainer.current_iteration, 4)
+
+    @skip_if_no_cuda
+    def test_fp16_values(self):
+        trainer = MMFTrainerMock(100, 2, 0.04, fp16_model=True)
+        trainer.load_fp16_scaler()
+        trainer.training_loop()

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -18,6 +18,7 @@ class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
                 "detect_anomaly": False,
                 "evaluation_interval": 10000,
                 "update_frequency": 1,
+                "fp16": True,
             }
         )
         if max_updates is not None:
@@ -47,7 +48,12 @@ class TrainerTrainingLoopMock(TrainerTrainingLoopMixin, TrainerProfilingMixin):
         self.on_batch_end = MagicMock(return_value=None)
         self.on_update_end = MagicMock(return_value=None)
         self.meter = MagicMock(return_value=None)
+        loss_mock = MagicMock()
+        loss_mock.backward = MagicMock()
         self.after_training_loop = MagicMock(return_value=None)
+        self.scaler = MagicMock()
+        self.scaler.scale = MagicMock(return_value=loss_mock)
+        self.scaler.step = MagicMock(return_value=None)
 
 
 class TestTrainingLoop(unittest.TestCase):

--- a/website/docs/notes/training_tricks.md
+++ b/website/docs/notes/training_tricks.md
@@ -1,0 +1,11 @@
+---
+id: training_tricks
+title: Training Tricks
+sidebar_label: Training Tricks
+---
+
+# FP16
+
+MMF supports FP16 training for faster performance with negligible impact on
+the results through `torch.cuda.amp` module. Append `training.fp16=True` to
+the end of your command to enable fp16 training in the trainer.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -26,6 +26,7 @@ module.exports = {
     Notes: [
       'notes/concepts',
       'notes/configuration',
+      'notes/training_tricks',
       'notes/dataset_zoo',
       'notes/model_zoo',
       'notes/pretrained_models',


### PR DESCRIPTION
This PR adds support for fp16 to MMF.

Extensive benchmarking on different models and different datasets shows that fp16 runs are comparable in performance but quite faster on longer runs.

## Task Items
- [x] Save and load state_dict of scaler into/from checkpoint
- [x] fp16 on validation/other loops as well
- [x] grad scaling on clip grad
- [x] tests
- [x] benchmark on (i) TextVQA/M4C (ii) VisualBERT/VQA2 (iii) MMBT/HM
- [x] docs 


## Benchmarking numbers

### MMBT on Hateful Memes

Reported metrics are ROC-AUC on validation set and time taken to complete the run
| fp16                 | Enabled        | Disabled       |
|----------------------|----------------|----------------|
| bs128.lr5e-5.mu22000 | 69.72/3h24m28s | 70.14/3h54m55s |
| bs64.lr5e-5.mu22000  | 68.47/2h34m38s | 66.56/2h22m49s |


### VisualBERT on VQA2

Reported metrics are VQA accuracy on validation set and time taken to complete the run.

| fp16                 | Enabled         | Disabled       |
|----------------------|-----------------|----------------|
| bs128.lr5e-5.mu88000 | 66.08/05h09m22s | 65.89/7h28m46s |
| bs64.lr5e-5.mu88000  | 66.82/04h14m10s | 66.69/6h04m30s |

### M4C on TextVQA

Reported metrics are TextVQA accuracy on validation set and time taken to complete the run

| fp16          | Enabled        | Disabled        |
|---------------|----------------|-----------------|
| bs128.mu24000 | 38.7/01h35m10s | 39.01/01h42m06s |