### PR TITLE
[feat] check unused model parameters in optimizer

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -161,7 +161,11 @@ run_type: train_inference
 
 # Configuration for optimizer, examples can be found in models' configs in
 # configs folder
-optimizer: {}
+optimizer:
+    # Whether to allow some of the model's parameters not to be used by the
+    # optimizer. Default is false to guard against missing parameters due to
+    # implementation errors in a model's get_optimizer_parameters
+    allow_unused_parameters: false
 
 # Configuration for scheduler, examples can be found in models' configs
 scheduler: {}

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -143,7 +143,33 @@ def get_optimizer_parameters(model, config):
     if is_parallel and hasattr(model.module, "get_optimizer_parameters"):
         parameters = model.module.get_optimizer_parameters(config)
 
+    for group in parameters:
+        group["params"] = list(group["params"])
+
+    check_unused_parameters(parameters, model, config)
+
     return parameters
+
+
+def check_unused_parameters(parameters, model, config):
+    optimizer_param_set = {p for group in parameters for p in group["params"]}
+    unused_param_names = []
+    for n, p in model.named_parameters():
+        if p.requires_grad and p not in optimizer_param_set:
+            unused_param_names.append(n)
+    if len(unused_param_names) > 0:
+        logger.info(
+            "Model parameters not used by optimizer: {}".format(
+                " ".join(unused_param_names)
+            )
+        )
+        if not config.optimizer.allow_unused_parameters:
+            raise Exception(
+                "Found model parameters not used by optimizer. Please check the "
+                "model's get_optimizer_parameters and add all parameters. If this "
+                "is intended, set optimizer.allow_unused_parameters to True to "
+                "ignore it."
+            )
 
 
 def dict_to_string(dictionary):


### PR DESCRIPTION
This PR adds optimizer option on whether to allow some of the model's parameters not to be used by the optimizer. Default is false to guard against missing parameters due to implementation errors in a model's `get_optimizer_parameters`. Previously `get_optimizer_parameters` is error-prong as the users need to remember to update `get_optimizer_parameters` whenever adding a new submodule, and the error is hard to spot when the users forget to do so.

Test plan: tested locally w/ VisualBERT, against correctly and
incorrectly implemented `get_optimizer_parameters`.
