### PR TITLE
[fixup] don't init early_stopping from ckpt when resetting counts

### DIFF
--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -200,10 +200,11 @@ class Checkpoint:
             if not reset_optimizer:
                 self._load_optimizer(ckpt)
 
-            self.trainer.early_stop_callback.early_stopping.init_from_checkpoint(ckpt)
             reset_counts = ckpt_config.reset.all or ckpt_config.reset.counts
-
             if not reset_counts:
+                self.trainer.early_stop_callback.early_stopping.init_from_checkpoint(
+                    ckpt
+                )
                 self._load_counts_and_lr_scheduler(ckpt)
         else:
             self._load_pretrained(state_dict)


### PR DESCRIPTION
Since the docs in mmf/configs/defaults.yaml on `reset.count` mention that "All counts such as best_update, current_iteration etc will be reset", the early stopping criteria (`best_iteration` and `best_metric_value`) should not be initialized from the ckpt when `reset.count` is on.

Test plan: tested internally on a DETR-related model when initializing from an earlier model's checkpoint.