### PR TITLE
[feat] First e2e test with emphasis on user dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ eggs/
 .vscode/*
 *.so
 *-checkpoint.ipynb
+!tests/data

--- a/tests/data/user_dir/__init__.py
+++ b/tests/data/user_dir/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# flake8: noqa: F401
+
+from . import datasets, models

--- a/tests/data/user_dir/configs/always_one.yaml
+++ b/tests/data/user_dir/configs/always_one.yaml
@@ -1,0 +1,2 @@
+dataset_config:
+  always_one: x

--- a/tests/data/user_dir/configs/experiment.yaml
+++ b/tests/data/user_dir/configs/experiment.yaml
@@ -1,0 +1,22 @@
+model_config:
+  simple:
+    losses:
+    - type: cross_entropy
+
+optimizer:
+  type: SGD
+  params:
+    lr: 1e-3
+
+evaluation:
+    metrics:
+    - accuracy
+
+training:
+  batch_size: 8
+  lr_scheduler: false
+  max_updates: 50
+  early_stop:
+    criteria: always_one/accuracy
+    minimize: false
+  log_format: json

--- a/tests/data/user_dir/configs/simple.yaml
+++ b/tests/data/user_dir/configs/simple.yaml
@@ -1,0 +1,4 @@
+model_config:
+  simple:
+    in_dim: 1
+    data_item_key: input

--- a/tests/data/user_dir/datasets/__init__.py
+++ b/tests/data/user_dir/datasets/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# flake8: noqa: F401
+
+from . import always_one

--- a/tests/data/user_dir/datasets/always_one.py
+++ b/tests/data/user_dir/datasets/always_one.py
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.common.registry import registry
+from mmf.datasets.base_dataset_builder import BaseDatasetBuilder
+from tests.test_utils import NumbersDataset
+
+
+DATASET_LEN = 20
+
+
+@registry.register_builder("always_one")
+class AlwaysOneBuilder(BaseDatasetBuilder):
+    def __init__(self):
+        super().__init__("always_one")
+
+    def build(self, *args, **Kwargs):
+        pass
+
+    @classmethod
+    def config_path(cls):
+        return "configs/always_one.yaml"
+
+    def load(self, config, dataset_type="train", *args, **kwargs):
+        dataset = NumbersDataset(DATASET_LEN, data_item_key="input", always_one=True)
+        dataset.dataset_name = self.dataset_name
+        dataset.dataset_type = dataset_type
+        return dataset

--- a/tests/data/user_dir/models/__init__.py
+++ b/tests/data/user_dir/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# flake8: noqa: F401
+
+from . import simple

--- a/tests/data/user_dir/models/simple.py
+++ b/tests/data/user_dir/models/simple.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.common.registry import registry
+from tests.test_utils import SimpleModel
+
+
+@registry.register_model("simple")
+class CustomSimpleModel(SimpleModel):
+    @classmethod
+    def config_path(cls):
+        return "configs/simple.yaml"
+
+    def forward(self, sample_list):
+        return {"scores": self.classifier(sample_list.input)}

--- a/tests/modules/test_optimizers.py
+++ b/tests/modules/test_optimizers.py
@@ -16,8 +16,8 @@ class TestOptimizers(unittest.TestCase):
         )
 
     def test_build_optimizer_simple_model(self):
-        model = SimpleModel(1)
-
+        model = SimpleModel({"in_dim": 1})
+        model.build()
         optimizer = build_optimizer(model, self.config)
         self.assertTrue(isinstance(optimizer, torch.optim.Optimizer))
         self.assertEqual(len(optimizer.param_groups), 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,18 +1,24 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import argparse
+import contextlib
 import itertools
+import json
 import os
 import platform
 import random
 import socket
 import tempfile
 import unittest
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
 
-import pytorch_lightning as pl
 import torch
 from mmf.common.sample import Sample, SampleList
+from mmf.models.base_model import BaseModel
 from mmf.utils.general import get_current_device
+from omegaconf import OmegaConf
+from torch import Tensor
 
 
 def compare_tensors(a, b):
@@ -79,6 +85,17 @@ def compare_state_dicts(a, b):
     return same
 
 
+@contextlib.contextmanager
+def make_temp_dir():
+    temp_dir = tempfile.TemporaryDirectory()
+    try:
+        yield temp_dir.name
+    finally:
+        # Don't clean up on Windows, as it always results in an error
+        if "Windows" not in platform.system():
+            temp_dir.cleanup()
+
+
 def build_random_sample_list():
     first = Sample()
     first.x = random.randint(0, 100)
@@ -101,40 +118,56 @@ DATA_ITEM_KEY = "test"
 
 
 class NumbersDataset(torch.utils.data.Dataset):
-    def __init__(self, num_examples, data_item_key=DATA_ITEM_KEY):
+    def __init__(
+        self,
+        num_examples: int,
+        data_item_key: str = DATA_ITEM_KEY,
+        always_one: bool = False,
+    ):
         self.num_examples = num_examples
         self.data_item_key = data_item_key
+        self.always_one = always_one
 
-    def __getitem__(self, idx):
-        return {
-            self.data_item_key: torch.tensor(idx, dtype=torch.float32).unsqueeze(-1)
-        }
+    def __getitem__(self, idx: int) -> Sample:
+        sample = Sample()
+        sample[self.data_item_key] = torch.tensor(idx, dtype=torch.float32).unsqueeze(
+            -1
+        )
+        if self.always_one:
+            sample.targets = torch.tensor(0, dtype=torch.long)
+        return sample
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.num_examples
 
 
-class SimpleModel(torch.nn.Module):
-    def __init__(self, size):
-        super().__init__()
-        self.linear = torch.nn.Linear(size, 1)
+class SimpleModel(BaseModel):
+    @dataclass
+    class Config(BaseModel.Config):
+        in_dim: int = 1
+        out_dim: int = 1
+        data_item_key: str = DATA_ITEM_KEY
 
-    def forward(self, prepared_batch):
+    def __init__(self, config: Config, *args, **kwargs):
+        config = OmegaConf.merge(OmegaConf.structured(self.Config), config)
+        super().__init__(config)
+        self.data_item_key = config.data_item_key
+
+    def build(self):
+        self.classifier = torch.nn.Linear(self.config.in_dim, self.config.out_dim)
+
+    def forward(self, prepared_batch: Dict[str, Tensor]):
         input_sample = SampleList(prepared_batch)
-        batch = prepared_batch[DATA_ITEM_KEY]
-        output = self.linear(batch)
+        batch = prepared_batch[self.data_item_key]
+        output = self.classifier(batch)
         loss = torch.nn.MSELoss()(-1 * output, batch)
         return {"losses": {"loss": loss}, "logits": output, "input_batch": input_sample}
 
 
-class SimpleLightningModel(pl.LightningModule):
-    def __init__(self, size, config=None):
-        super().__init__()
-        self.model = SimpleModel(size)
-        self.config = config
-
-    def forward(self, prepared_batch):
-        return self.model(prepared_batch)
+class SimpleLightningModel(SimpleModel):
+    def __init__(self, config: SimpleModel.Config, trainer_config=None):
+        super().__init__(config)
+        self.trainer_config = trainer_config
 
     def training_step(self, batch, batch_idx, *args, **kwargs):
         output = self(batch)
@@ -147,7 +180,7 @@ class SimpleLightningModel(pl.LightningModule):
         else:
             from mmf.utils.build import build_lightning_optimizers
 
-            return build_lightning_optimizers(self, self.config)
+            return build_lightning_optimizers(self, self.trainer_config)
 
 
 def assertModulesEqual(mod1, mod2):
@@ -195,3 +228,47 @@ def verify_torchscript_models(model):
         torch.jit.save(script_model, tmp)
         loaded_model = torch.jit.load(tmp.name)
     return assertModulesEqual(script_model, loaded_model)
+
+
+def search_log(log_file: str, search_condition: Optional[List[Callable]] = None):
+    """Searches a log file for a particular search conditions which can be list
+    of functions and returns it back
+
+    Args:
+        log_file (str): Log file in which search needs to be performed
+        search_condition (List[Callable], optional): Search conditions in form of list.
+            Each corresponding to a function to test a condition. Defaults to None.
+
+    Returns:
+        JSONObject: Json representation of the search line
+
+    Throws:
+        AssertionError: If no log line is found meeting the conditions
+    """
+    if search_condition is None:
+        search_condition = {}
+
+    lines = []
+
+    with open(log_file) as f:
+        lines = f.readlines()
+
+    filtered_line = None
+    for line in lines:
+        line = line.strip()
+        if "progress" not in line:
+            continue
+        info_index = line.find(" : ")
+        line = line[info_index + 3 :]
+        res = json.loads(line)
+
+        meets_condition = True
+        for condition_fn in search_condition:
+            meets_condition = meets_condition and condition_fn(res)
+
+        if meets_condition:
+            filtered_line = res
+            break
+
+    assert filtered_line is not None, "No match for search condition in log file"
+    return filtered_line

--- a/tests/trainers/lightning/test_utils.py
+++ b/tests/trainers/lightning/test_utils.py
@@ -68,7 +68,10 @@ def get_lightning_trainer(
         gradient_clip_val=gradient_clip_val,
         precision=precision,
     )
-    trainer.model = SimpleLightningModel(model_size, config=trainer.config)
+    trainer.model = SimpleLightningModel(
+        {"in_dim": model_size}, trainer_config=trainer.config
+    )
+    trainer.model.build()
     trainer.model.train()
     prepare_lightning_trainer(trainer)
     return trainer
@@ -85,7 +88,8 @@ def get_mmf_trainer(
     grad_clipping_config=None,
 ):
     torch.random.manual_seed(2)
-    model = SimpleModel(model_size)
+    model = SimpleModel({"in_dim": model_size})
+    model.build()
     model.train()
     trainer_config = get_trainer_config()
     optimizer = build_optimizer(model, trainer_config)

--- a/tests/trainers/test_fp16.py
+++ b/tests/trainers/test_fp16.py
@@ -12,7 +12,7 @@ class SimpleModelWithFp16Assert(SimpleModel):
         batch_tensor = sample_list[list(sample_list.keys())[0]]
         # Start should be fp32
         assert batch_tensor.dtype == torch.float32
-        batch_tensor = self.linear(batch_tensor)
+        batch_tensor = self.classifier(batch_tensor)
 
         # In between operation should be fp16
         assert batch_tensor.dtype == torch.float16
@@ -35,7 +35,8 @@ class MMFTrainerMock(TrainerTrainingLoopMock):
             assert (
                 torch.cuda.is_available()
             ), "MMFTrainerMock fp16 requires cuda enabled"
-            self.model = SimpleModelWithFp16Assert(1)
+            self.model = SimpleModelWithFp16Assert({"in_dim": 1})
+            self.model.build()
             self.model = self.model.cuda()
         self.optimizer = torch.optim.SGD(self.model.parameters(), lr=1e-3)
 

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -46,7 +46,8 @@ class TrainerTrainingLoopMock(MMFTrainer):
         if max_epochs is not None:
             self.training_config["max_epochs"] = max_epochs
 
-        self.model = SimpleModel(1)
+        self.model = SimpleModel({"in_dim": 1})
+        self.model.build()
         if torch.cuda.is_available():
             self.model = self.model.cuda()
             self.device = "cuda"
@@ -186,7 +187,8 @@ class TestTrainingLoop(unittest.TestCase):
         on_update_end_fn=None,
     ):
         torch.random.manual_seed(2)
-        model = SimpleModel(1)
+        model = SimpleModel({"in_dim": 1})
+        model.build()
         opt = torch.optim.SGD(model.parameters(), lr=0.01)
         trainer = TrainerTrainingLoopMock(
             num_train_data,

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import contextlib
+import io
+import os
+import unittest
+
+from mmf.utils.general import get_mmf_root
+from tests.test_utils import make_temp_dir, search_log
+
+from mmf_cli.run import run
+
+
+class TestUtilsEnv(unittest.TestCase):
+    def test_user_import(self):
+        MAX_UPDATES = 50
+        user_dir = os.path.join(get_mmf_root(), "..", "tests", "data", "user_dir")
+        with make_temp_dir() as temp_dir:
+            opts = [
+                "model=simple",
+                "run_type=train_val_test",
+                "dataset=always_one",
+                "config=tests/data/user_dir/configs/experiment.yaml",
+                f"env.user_dir={user_dir}",
+                "training.seed=1",
+                "training.num_workers=3",
+                f"training.max_updates={MAX_UPDATES}",
+                f"env.save_dir={temp_dir}",
+            ]
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                run(opts)
+            train_log = os.path.join(temp_dir, "train.log")
+            log_line = search_log(
+                train_log,
+                search_condition=[
+                    lambda x: x["progress"] == f"{MAX_UPDATES}/{MAX_UPDATES}",
+                    lambda x: "best_val/always_one/accuracy" in x,
+                ],
+            )
+            self.assertEqual(float(log_line["val/always_one/accuracy"]), 1)
+
+            log_line = search_log(
+                train_log,
+                search_condition=[
+                    lambda x: x["progress"] == f"{MAX_UPDATES}/{MAX_UPDATES}",
+                    lambda x: "test/always_one/accuracy" in x,
+                ],
+            )
+            self.assertEqual(float(log_line["test/always_one/accuracy"]), 1)


### PR DESCRIPTION
This PR introduces first e2e test which uses `mmf_cli.run` programmatic
API and log parsing to check for log file. Specifically in this PR we
test for user_dir import by creating our own simple model and a dataset
that always generate one.

For a more friendly `user_dir` support, now we override default config
in configuration with user_cmd_opts as well so that MMF can discover
configs relative to user dir if needed.

We run the usual run command and expect the model to overfit and always
return 1.

Test Plan:

Tested locally on devfair using `pytest -v ./tests`.

