### PR TITLE
[fix] Discrepancy in tests isort b/w oss and fbcode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 known_third_party = [
     "PIL", "cv2", "demjson", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "mmf",
     "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
-    "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "torch",
+    "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
     "torchtext", "torchvision", "tqdm", "transformers"
 ]
 skip_glob = "**/build/**,website/**"

--- a/tests/common/test_batch_collator.py
+++ b/tests/common/test_batch_collator.py
@@ -2,11 +2,10 @@
 
 import unittest
 
+import tests.test_utils as test_utils
 import torch
 from mmf.common.batch_collator import BatchCollator
 from mmf.common.sample import Sample
-
-import tests.test_utils as test_utils
 
 
 class TestBatchCollator(unittest.TestCase):

--- a/tests/common/test_sample.py
+++ b/tests/common/test_sample.py
@@ -1,10 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import tests.test_utils as test_utils
 import torch
 from mmf.common.sample import Sample, to_device
-
-import tests.test_utils as test_utils
 
 
 class TestSample(unittest.TestCase):

--- a/tests/configs/test_configs_for_keys.py
+++ b/tests/configs/test_configs_for_keys.py
@@ -7,7 +7,6 @@ from io import StringIO
 from mmf.common.registry import registry
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
-
 from tests.test_utils import dummy_args
 
 

--- a/tests/configs/test_zoo_urls.py
+++ b/tests/configs/test_zoo_urls.py
@@ -8,7 +8,6 @@ from mmf.common.typings import DictConfig, DownloadableFileType
 from mmf.utils.configuration import load_yaml
 from mmf.utils.download import DownloadableFile, check_header
 from omegaconf import OmegaConf
-
 from tests.test_utils import skip_if_macos, skip_if_no_network
 
 

--- a/tests/models/interfaces/test_interfaces.py
+++ b/tests/models/interfaces/test_interfaces.py
@@ -3,9 +3,8 @@
 import unittest
 
 import numpy as np
-from mmf.models.mmbt import MMBT
-
 import tests.test_utils as test_utils
+from mmf.models.mmbt import MMBT
 
 
 class TestModelInterfaces(unittest.TestCase):

--- a/tests/models/test_cnn_lstm.py
+++ b/tests/models/test_cnn_lstm.py
@@ -9,7 +9,6 @@ from mmf.common.sample import Sample, SampleList
 from mmf.models.cnn_lstm import CNNLSTM
 from mmf.utils.configuration import Configuration
 from mmf.utils.general import get_mmf_root
-
 from tests.test_utils import dummy_args
 
 

--- a/tests/models/test_mmbt.py
+++ b/tests/models/test_mmbt.py
@@ -3,13 +3,12 @@
 import io
 import unittest
 
+import tests.test_utils as test_utils
 import torch
 from mmf.common.registry import registry
 from mmf.common.sample import Sample, SampleList
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
-
-import tests.test_utils as test_utils
 
 
 class TestMMBTTorchscript(unittest.TestCase):
@@ -40,7 +39,7 @@ class TestMMBTTorchscript(unittest.TestCase):
         self.finetune_model.eval()
         test_sample = Sample()
         test_sample.input_ids = torch.randint(low=0, high=30255, size=(128,)).long()
-        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.input_mask = torch.ones(128).long()
         test_sample.segment_ids = torch.zeros(128).long()
         test_sample.image = torch.rand((3, 300, 300)).float()
         test_sample_list = SampleList([test_sample])

--- a/tests/models/test_mmf_transformer.py
+++ b/tests/models/test_mmf_transformer.py
@@ -3,13 +3,12 @@
 import io
 import unittest
 
+import tests.test_utils as test_utils
 import torch
 from mmf.common.registry import registry
 from mmf.common.sample import Sample, SampleList
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
-
-import tests.test_utils as test_utils
 
 
 class TestMMFTransformerTorchscript(unittest.TestCase):
@@ -40,7 +39,7 @@ class TestMMFTransformerTorchscript(unittest.TestCase):
         self.finetune_model.eval()
         test_sample = Sample()
         test_sample.input_ids = torch.randint(low=0, high=30255, size=(128,)).long()
-        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.input_mask = torch.ones(128).long()
         test_sample.segment_ids = torch.zeros(128).long()
         test_sample.image = torch.rand((3, 300, 300)).float()
         test_sample_list = SampleList([test_sample])
@@ -62,7 +61,7 @@ class TestMMFTransformerTorchscript(unittest.TestCase):
         model.eval()
         test_sample = Sample()
         test_sample.input_ids = torch.randint(low=0, high=50265, size=(128,)).long()
-        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.input_mask = torch.ones(128).long()
         test_sample.segment_ids = torch.zeros(128).long()
         test_sample.image = torch.rand((3, 300, 300)).float()
         test_sample_list = SampleList([test_sample])
@@ -86,7 +85,7 @@ class TestMMFTransformerTorchscript(unittest.TestCase):
         model.eval()
         test_sample = Sample()
         test_sample.input_ids = torch.randint(low=0, high=250002, size=(128,)).long()
-        test_sample.input_mask = torch.ones((128)).long()
+        test_sample.input_mask = torch.ones(128).long()
         test_sample.segment_ids = torch.zeros(128).long()
         test_sample.image = torch.rand((3, 300, 300)).float()
         test_sample_list = SampleList([test_sample])

--- a/tests/models/test_visual_bert.py
+++ b/tests/models/test_visual_bert.py
@@ -3,12 +3,11 @@
 import io
 import unittest
 
+import tests.test_utils as test_utils
 import torch
 from mmf.common.registry import registry
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
-
-import tests.test_utils as test_utils
 
 
 class TestVisualBertTorchscript(unittest.TestCase):

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -8,7 +8,6 @@ from mmf.common.sample import SampleList
 from mmf.trainers.core.profiling import TrainerProfilingMixin
 from mmf.trainers.core.training_loop import TrainerTrainingLoopMixin
 from omegaconf import OmegaConf
-
 from tests.test_utils import NumbersDataset, SimpleModel
 
 

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -18,7 +18,6 @@ from mmf.utils.checkpoint import Checkpoint
 from mmf.utils.configuration import load_yaml
 from mmf.utils.file_io import PathManager
 from omegaconf import OmegaConf
-
 from tests.test_utils import compare_state_dicts
 
 

--- a/tests/utils/test_configuration.py
+++ b/tests/utils/test_configuration.py
@@ -5,7 +5,6 @@ import unittest
 from mmf.utils.configuration import Configuration, get_zoo_config
 from mmf.utils.env import setup_imports
 from mmf.utils.general import get_mmf_root
-
 from tests.test_utils import dummy_args
 
 

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -8,7 +8,6 @@ from io import StringIO
 from unittest import mock
 
 import mmf.utils.download as download
-
 import tests.test_utils as test_utils
 
 

--- a/tests/utils/test_text.py
+++ b/tests/utils/test_text.py
@@ -10,7 +10,6 @@ from mmf.common.sample import Sample, SampleList
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 from mmf.utils.general import get_mmf_root
-
 from tests.test_utils import dummy_args
 from tests.utils.test_model import TestDecoderModel
 


### PR DESCRIPTION
- fbcode treats tests as third party
- This fixes the sync

Test Plan:
Tested and compared sorting in the two

