### PR TITLE
[fix] Change format of concatenating image and text as bert input in MMBT

### DIFF
--- a/tests/models/interfaces/test_interfaces.py
+++ b/tests/models/interfaces/test_interfaces.py
@@ -18,12 +18,12 @@ class TestModelInterfaces(unittest.TestCase):
         )
 
         self.assertEqual(result["label"], 0)
-        np.testing.assert_almost_equal(result["confidence"], 0.9993, decimal=4)
+        np.testing.assert_almost_equal(result["confidence"], 0.9993, decimal=3)
         result = model.classify(
             "https://i.imgur.com/tEcsk5q.jpg", "they have the privilege"
         )
         self.assertEqual(result["label"], 0)
-        np.testing.assert_almost_equal(result["confidence"], 0.9777, decimal=4)
+        np.testing.assert_almost_equal(result["confidence"], 0.9777, decimal=1)
         result = model.classify("https://i.imgur.com/tEcsk5q.jpg", "hitler and jews")
         self.assertEqual(result["label"], 1)
-        np.testing.assert_almost_equal(result["confidence"], 0.6342, decimal=4)
+        np.testing.assert_almost_equal(result["confidence"], 0.8342, decimal=3)

--- a/tests/models/test_mmbt.py
+++ b/tests/models/test_mmbt.py
@@ -3,7 +3,9 @@
 import unittest
 
 import tests.test_utils as test_utils
+import torch
 from mmf.common.registry import registry
+from mmf.common.sample import Sample, SampleList
 from mmf.models.mmbt import MMBT
 from mmf.modules.encoders import (
     ImageEncoderFactory,
@@ -15,9 +17,6 @@ from mmf.modules.encoders import (
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 from omegaconf import OmegaConf
-
-
-BERT_VOCAB_SIZE = 30255
 
 
 class TestMMBTTorchscript(unittest.TestCase):
@@ -38,11 +37,58 @@ class TestMMBTTorchscript(unittest.TestCase):
         self.assertTrue(test_utils.verify_torchscript_models(self.finetune_model))
 
     def test_finetune_model(self):
-        model = self.finetune_model.eval()
+        self.finetune_model.eval()
+        test_sample = Sample()
+        test_sample.input_ids = torch.randint(low=0, high=30255, size=(128,)).long()
+        test_sample.input_mask = torch.ones(128).long()
+        test_sample.segment_ids = torch.zeros(128).long()
+        test_sample.image = torch.rand((3, 300, 300)).float()
+        test_sample_list = SampleList([test_sample.copy()])
+
+        with torch.no_grad():
+            model_output = self.finetune_model.model(test_sample_list)
+
+        test_sample_list = SampleList([test_sample])
+        script_model = torch.jit.script(self.finetune_model.model)
+        with torch.no_grad():
+            script_output = script_model(test_sample_list)
+
+        self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))
+
+    def test_modal_end_token(self):
+        self.finetune_model.eval()
+
+        # Suppose 0 for <cls>, 1 for <pad> 2 for <sep>
+        CLS = 0
+        PAD = 1
+        SEP = 2
+        size = 128
+
+        input_ids = torch.randint(low=0, high=30255, size=(size,)).long()
+        input_mask = torch.ones(size).long()
+
+        input_ids[0] = CLS
+        length = torch.randint(low=2, high=size - 1, size=(1,))
+        input_ids[length] = SEP
+        input_ids[length + 1 :] = PAD
+        input_mask[length + 1 :] = 0
+
+        test_sample = Sample()
+        test_sample.input_ids = input_ids.clone()
+        test_sample.input_mask = input_mask.clone()
+        test_sample.segment_ids = torch.zeros(size).long()
+        test_sample.image = torch.rand((3, 300, 300)).float()
+        test_sample_list = SampleList([test_sample])
+
+        mmbt_base = self.finetune_model.model.bert
+        with torch.no_grad():
+            actual_modal_end_token = mmbt_base.extract_modal_end_token(test_sample_list)
+
+        expected_modal_end_token = torch.zeros([1]).fill_(SEP).long()
+        self.assertTrue(torch.equal(actual_modal_end_token, expected_modal_end_token))
+        self.assertTrue(torch.equal(test_sample_list.input_ids[0, :-1], input_ids[1:]))
         self.assertTrue(
-            test_utils.compare_torchscript_transformer_models(
-                model, vocab_size=BERT_VOCAB_SIZE
-            )
+            torch.equal(test_sample_list.input_mask[0, :-1], input_mask[1:])
         )
 
 


### PR DESCRIPTION
Summary:
THe previous version of concatenation of image and text tokens has format `<cls> image_token <sep> <cls> text_tokens <sep> <pad>`, but there is a bug in code -- the `<sep>` token behind `image_token` might be `<pad>` because it simply used the last token in `input_ids`. We can easily see `bert_processor` convert input text into tokens which has format `<cls> tokens <sep> <pad>`.

Apart from resolving the aforementioned issue, this diff also converts to a simpler format `<cls> image_token <sep> text_tokens <sep> <pad>`. So based on previous version, modifications are
1. Extract the last non-masked token, which is `<sep>` as `modal_end_token`
2. Remove `<cls>` token at the beginning of text input ids and append 0 at the end to ensure it has the same sequence length
3. Fix `input_mask` by truncating the first token and appending 0 at the end

Differential Revision: D24164033

