### PR TITLE
[feat] Enable torchscript on full VisualBERT model

### DIFF
--- a/mmf/models/visual_bert.py
+++ b/mmf/models/visual_bert.py
@@ -14,6 +14,7 @@ from mmf.modules.embeddings import BertVisioLinguisticEmbeddings
 from mmf.modules.hf_layers import BertEncoderJit, BertLayerJit
 from mmf.utils.configuration import get_mmf_cache_dir
 from mmf.utils.modeling import get_optimizer_parameters_for_bert
+from mmf.utils.torchscript import getattr_torchscriptable
 from mmf.utils.transform import (
     transform_to_batch_sequence,
     transform_to_batch_sequence_dim,
@@ -66,7 +67,6 @@ class VisualBERTBase(BertPreTrainedModel):
         attention_mask: Optional[Tensor] = None,
         token_type_ids: Optional[Tensor] = None,
         visual_embeddings: Optional[Tensor] = None,
-        position_embeddings_visual: Optional[Tensor] = None,
         visual_embeddings_type: Optional[Tensor] = None,
         image_text_alignment: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor, List[Tensor]]:
@@ -99,7 +99,6 @@ class VisualBERTBase(BertPreTrainedModel):
             input_ids,
             token_type_ids,
             visual_embeddings=visual_embeddings,
-            position_embeddings_visual=position_embeddings_visual,
             visual_embeddings_type=visual_embeddings_type,
             image_text_alignment=image_text_alignment,
         )
@@ -231,7 +230,6 @@ class VisualBERTForPretraining(nn.Module):
         attention_mask: Optional[Tensor] = None,
         token_type_ids: Optional[Tensor] = None,
         visual_embeddings: Optional[Tensor] = None,
-        position_embeddings_visual: Optional[Tensor] = None,
         visual_embeddings_type: Optional[Tensor] = None,
         image_text_alignment: Optional[Tensor] = None,
         masked_lm_labels: Optional[Tensor] = None,
@@ -241,7 +239,6 @@ class VisualBERTForPretraining(nn.Module):
             attention_mask,
             token_type_ids,
             visual_embeddings,
-            position_embeddings_visual,
             visual_embeddings_type,
             image_text_alignment,
         )
@@ -340,7 +337,6 @@ class VisualBERTForClassification(nn.Module):
         attention_mask: Optional[Tensor] = None,
         token_type_ids: Optional[Tensor] = None,
         visual_embeddings: Optional[Tensor] = None,
-        position_embeddings_visual: Optional[Tensor] = None,
         visual_embeddings_type: Optional[Tensor] = None,
         image_text_alignment: Optional[Tensor] = None,
         masked_lm_labels: Optional[Tensor] = None,
@@ -350,7 +346,6 @@ class VisualBERTForClassification(nn.Module):
             attention_mask,
             token_type_ids,
             visual_embeddings,
-            position_embeddings_visual,
             visual_embeddings_type,
             image_text_alignment,
         )
@@ -398,13 +393,14 @@ class VisualBERT(BaseModel):
     def __init__(self, config):
         super().__init__(config)
         self.config = config
+        self.training_head_type: str = self.config.training_head_type
 
     @classmethod
     def config_path(cls):
         return "configs/models/visual_bert/pretrain.yaml"
 
     def build(self):
-        if self.config.training_head_type == "pretraining":
+        if self.training_head_type == "pretraining":
             self.model = VisualBERTForPretraining(self.config)
         else:
             self.model = VisualBERTForClassification(self.config)
@@ -416,123 +412,131 @@ class VisualBERT(BaseModel):
             for p in self.model.bert.parameters():
                 p.requires_grad = False
 
-    def flatten(self, sample_list, to_be_flattened=None, to_be_flattened_dim=None):
-        if to_be_flattened is None:
-            to_be_flattened = {}
-        if to_be_flattened_dim is None:
-            to_be_flattened_dim = {}
+    def flatten(
+        self,
+        sample_list: Dict[str, Tensor],
+        to_be_flattened: List[str],
+        to_be_flattened_dim: List[str],
+    ) -> Dict[str, Tensor]:
         for key in to_be_flattened:
             # Make sure these keys are present or otherwise set these keys to None
-            sample_list[key] = getattr(sample_list, key, None)
             sample_list[key] = transform_to_batch_sequence(sample_list[key])
         for key in to_be_flattened_dim:
-            sample_list[key] = getattr(sample_list, key, None)
             sample_list[key] = transform_to_batch_sequence_dim(sample_list[key])
+        return sample_list
 
-        if sample_list.visual_embeddings_type is None:
-            if sample_list.image_mask is not None:
-                sample_list.visual_embeddings_type = torch.zeros_like(
-                    sample_list.image_mask
-                )
+    def add_post_flatten_params(
+        self, sample_list: Dict[str, Tensor]
+    ) -> Dict[str, Tensor]:
+        sample_list["visual_embeddings_type"] = torch.zeros_like(
+            sample_list["image_mask"]
+        )
+        attention_mask = torch.cat(
+            (sample_list["input_mask"], sample_list["image_mask"]), dim=-1
+        )
+        sample_list["attention_mask"] = attention_mask
 
-        if sample_list.image_mask is not None:
-            attention_mask = torch.cat(
-                (sample_list.input_mask, sample_list.image_mask), dim=-1
-            )
-            if sample_list.masked_lm_labels is not None:
-                assert sample_list.masked_lm_labels.size(
-                    -1
-                ) == sample_list.input_mask.size(-1)
-                new_lm_labels = torch.ones_like(attention_mask) * -1
-                size_masked_lm_labels = sample_list.masked_lm_labels.size()
-                assert len(size_masked_lm_labels) == 2
-                new_lm_labels[
-                    : size_masked_lm_labels[0], : size_masked_lm_labels[1]
-                ] = sample_list.masked_lm_labels
-                sample_list.masked_lm_labels = new_lm_labels
-        else:
-            attention_mask = sample_list.input_mask
-
-        sample_list.attention_mask = attention_mask
+        if self.training_head_type == "pretraining":
+            assert sample_list["masked_lm_labels"].size(-1) == sample_list[
+                "input_mask"
+            ].size(-1)
+            new_lm_labels = torch.ones_like(attention_mask) * -1
+            size_masked_lm_labels = sample_list["masked_lm_labels"].size()
+            assert len(size_masked_lm_labels) == 2
+            new_lm_labels[
+                : size_masked_lm_labels[0], : size_masked_lm_labels[1]
+            ] = sample_list["masked_lm_labels"]
+            sample_list["masked_lm_labels"] = new_lm_labels
 
         return sample_list
 
     def get_optimizer_parameters(self, config):
         return get_optimizer_parameters_for_bert(self.model, config)
 
-    def flatten_for_bert(self, sample_list, **kwargs):
-        to_be_flattened = [
-            "input_ids",
-            "token_type_ids",
-            "input_mask",
-            "image_mask",
-            "masked_lm_labels",
-            "position_embeddings_visual",
-            "visual_embeddings_type",
-        ]
-        to_be_flattened_dim = ["image_text_alignment", "visual_embeddings"]
+    def flatten_for_bert(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        to_be_flattened = ["input_ids", "token_type_ids", "input_mask", "image_mask"]
+        to_be_flattened_dim = ["visual_embeddings"]
+
+        if self.training_head_type == "pretraining":
+            to_be_flattened.append("masked_lm_labels")
 
         # We want to convert everything into: batch x sequence_length x (dim).
         flattened = self.flatten(sample_list, to_be_flattened, to_be_flattened_dim)
         return flattened
 
-    def update_sample_list_based_on_head(self, sample_list):
-        bert_input_ids = sample_list.input_ids
-        bert_input_mask = sample_list.input_mask
-        bert_input_type_ids = sample_list.segment_ids
+    def update_sample_list_based_on_head(
+        self, sample_list: Dict[str, Tensor]
+    ) -> Dict[str, Tensor]:
+        bert_input_ids = sample_list["input_ids"]
+        bert_input_mask = sample_list["input_mask"]
+        bert_input_type_ids = sample_list["segment_ids"]
 
-        if self.config.training_head_type == "nlvr2":
-            bert_input_ids = torch.cat([bert_input_ids, bert_input_ids])
-            bert_input_mask = torch.cat([bert_input_mask, bert_input_mask])
-            bert_input_type_ids = torch.cat([bert_input_type_ids, bert_input_type_ids])
+        if self.training_head_type == "nlvr2":
+            if not torch.jit.is_scripting():
+                bert_input_ids = torch.cat([bert_input_ids, bert_input_ids])
+                bert_input_mask = torch.cat([bert_input_mask, bert_input_mask])
+                bert_input_type_ids = torch.cat(
+                    [bert_input_type_ids, bert_input_type_ids]
+                )
 
-            # image input
-            img0 = getattr(sample_list, "img0", {})
-            image_info = getattr(img0, "image_info_0", {})
-            image_dim_variable_0 = getattr(image_info, "max_features", None)
-            image_feat_variable_0 = getattr(img0, "image_feature_0", None)
+                # image input
+                img0 = getattr(sample_list, "img0", {})
+                image_feat_variable_0 = getattr(img0, "image_feature_0", None)
+                img1 = getattr(sample_list, "img1", {})
+                image_feat_variable_1 = getattr(img1, "image_feature_0", None)
+                image_feat_variable = torch.cat(
+                    [image_feat_variable_0, image_feat_variable_1]
+                )
 
-            img1 = getattr(sample_list, "img1", {})
-            image_info = getattr(img1, "image_info_0", {})
-            image_dim_variable_1 = getattr(image_info, "max_features", None)
-            image_feat_variable_1 = getattr(img1, "image_feature_0", None)
-
-            image_feat_variable = torch.cat(
-                [image_feat_variable_0, image_feat_variable_1]
-            )
-            image_dim_variable = torch.cat([image_dim_variable_0, image_dim_variable_1])
+                image_info = getattr(img0, "image_info_0", {})
+                image_dim_variable_0 = getattr(image_info, "max_features", None)
+                image_info = getattr(img1, "image_info_0", {})
+                image_dim_variable_1 = getattr(image_info, "max_features", None)
+                image_dim_variable = torch.cat(
+                    [image_dim_variable_0, image_dim_variable_1]
+                )
+            else:
+                raise RuntimeError("nlvr2 head doesn't support scripting as of now")
         else:
-            image_info = getattr(sample_list, "image_info_0", {})
-            image_dim_variable = getattr(image_info, "max_features", None)
-            image_feat_variable = getattr(sample_list, "image_feature_0", None)
 
-        sample_list.visual_embeddings = image_feat_variable
-        sample_list.image_dim = image_dim_variable
-        sample_list.input_ids = bert_input_ids
-        sample_list.input_mask = bert_input_mask
-        sample_list.token_type_ids = bert_input_type_ids
+            if not torch.jit.is_scripting():
+                image_info = getattr(sample_list, "image_info_0", {})
+                image_dim_variable = getattr(image_info, "max_features", None)
+                image_feat_variable = getattr(sample_list, "image_feature_0", None)
+            else:
+                image_feat_variable = sample_list["image_feature_0"]
+                image_dim_variable = None
+
+        if image_dim_variable is None:
+            image_dim_variable = sample_list["image_feature_0"].new_full(
+                size=(image_feat_variable.size(0), 1),
+                fill_value=image_feat_variable.size(1),
+            )
+
+        sample_list["visual_embeddings"] = image_feat_variable
+        sample_list["image_dim"] = image_dim_variable
+        sample_list["input_ids"] = bert_input_ids
+        sample_list["input_mask"] = bert_input_mask
+        sample_list["token_type_ids"] = bert_input_type_ids
         return sample_list
 
-    def add_custom_params(self, sample_list):
-        visual_embeddings = getattr(sample_list, "visual_embeddings", None)
-        image_dim = getattr(sample_list, "image_dim", None)
-        # pretraining labels
-        sample_list.masked_lm_labels = getattr(sample_list, "lm_label_ids", None)
+    def add_custom_params(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        visual_embeddings = sample_list["visual_embeddings"]
+        image_dim = sample_list["image_dim"]
+
+        if self.training_head_type == "pretraining":
+            # pretraining labels
+            sample_list["masked_lm_labels"] = sample_list["lm_label_ids"]
         # image_feat_variable = batch x ( num_choice x ) image_feature_length x dim
         # Prepare Mask
-        if visual_embeddings is not None and image_dim is not None:
-            image_mask = torch.arange(
-                visual_embeddings.size(-2), device=visual_embeddings.device
-            ).expand(*visual_embeddings.size()[:-1])
-            if len(image_dim.size()) < len(image_mask.size()):
-                image_dim = image_dim.unsqueeze(-1)
-                assert len(image_dim.size()) == len(image_mask.size())
-            image_mask = image_mask < image_dim
-            sample_list.image_mask = image_mask.long()
-        else:
-            sample_list.image_mask = None
-
-        sample_list.position_embeddings_visual = None
+        image_mask = torch.arange(
+            visual_embeddings.size(-2), device=visual_embeddings.device
+        ).expand(visual_embeddings.size()[:-1])
+        if len(image_dim.size()) < len(image_mask.size()):
+            image_dim = image_dim.unsqueeze(-1)
+            assert len(image_dim.size()) == len(image_mask.size())
+        image_mask = image_mask < image_dim
+        sample_list["image_mask"] = image_mask.long()
 
         return sample_list
 
@@ -545,30 +549,38 @@ class VisualBERT(BaseModel):
             .replace("bert.classifier", "model.classifier")
         )
 
-    def forward(self, sample_list):
+    def forward(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        if torch.jit.is_scripting():
+            assert (
+                "image_feature_0" in sample_list
+            ), "Key 'image_feature_0' is required in TorchScript model"
+
         sample_list = self.update_sample_list_based_on_head(sample_list)
         sample_list = self.add_custom_params(sample_list)
         sample_list = self.flatten_for_bert(sample_list)
+        sample_list = self.add_post_flatten_params(sample_list)
 
         output_dict = self.model(
-            sample_list.input_ids,
-            sample_list.input_mask,
-            sample_list.attention_mask,
-            sample_list.token_type_ids,
-            sample_list.visual_embeddings,
-            sample_list.position_embeddings_visual,
-            sample_list.visual_embeddings_type,
-            sample_list.image_text_alignment,
-            sample_list.masked_lm_labels,
+            sample_list["input_ids"],
+            sample_list["input_mask"],
+            sample_list["attention_mask"],
+            sample_list["token_type_ids"],
+            sample_list["visual_embeddings"],
+            sample_list["visual_embeddings_type"],
+            getattr_torchscriptable(sample_list, "image_text_alignment", None),
+            getattr_torchscriptable(sample_list, "masked_lm_labels", None),
         )
 
-        if "pretraining" in self.config.training_head_type:
-            loss_key = "{}/{}".format(
-                sample_list.dataset_name, sample_list.dataset_type
-            )
-            output_dict["losses"] = {}
-            output_dict["losses"][loss_key + "/masked_lm_loss"] = output_dict.pop(
-                "masked_lm_loss"
-            )
+        if self.training_head_type == "pretraining":
+            if not torch.jit.is_scripting():
+                loss_key = "{}/{}".format(
+                    sample_list["dataset_name"], sample_list["dataset_type"]
+                )
+                output_dict["losses"] = {}
+                output_dict["losses"][loss_key + "/masked_lm_loss"] = output_dict.pop(
+                    "masked_lm_loss"
+                )
+            else:
+                raise RuntimeError("Pretraining head can't be used in script mode.")
 
         return output_dict

--- a/mmf/modules/embeddings.py
+++ b/mmf/modules/embeddings.py
@@ -344,7 +344,6 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
         self,
         visual_embeddings: Tensor,
         visual_embeddings_type: Tensor,
-        position_embeddings_visual: Optional[Tensor] = None,
         image_text_alignment: Optional[Tensor] = None,
     ) -> Tensor:
 
@@ -356,9 +355,7 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
         # get position_embeddings
         # this depends on image_text_alignment
         position_embeddings_visual = self.get_position_embeddings_visual(
-            visual_embeddings,
-            image_text_alignment=image_text_alignment,
-            position_embeddings_visual=position_embeddings_visual,
+            visual_embeddings, image_text_alignment=image_text_alignment
         )
 
         # calculate visual embeddings
@@ -370,10 +367,7 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
         return v_embeddings
 
     def get_position_embeddings_visual(
-        self,
-        visual_embeddings: Tensor,
-        image_text_alignment: Optional[Tensor] = None,
-        position_embeddings_visual: Optional[Tensor] = None,
+        self, visual_embeddings: Tensor, image_text_alignment: Optional[Tensor] = None
     ) -> Tensor:
 
         if image_text_alignment is not None:
@@ -430,7 +424,6 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
         token_type_ids: Optional[Tensor] = None,
         visual_embeddings: Optional[Tensor] = None,
         visual_embeddings_type: Optional[Tensor] = None,
-        position_embeddings_visual: Optional[Tensor] = None,
         image_text_alignment: Optional[Tensor] = None,
     ) -> Tensor:
         """
@@ -448,7 +441,6 @@ class BertVisioLinguisticEmbeddings(BertEmbeddings):
             v_embeddings = self.encode_image(
                 visual_embeddings,
                 visual_embeddings_type=visual_embeddings_type,
-                position_embeddings_visual=position_embeddings_visual,
                 image_text_alignment=image_text_alignment,
             )
 

--- a/mmf/utils/torchscript.py
+++ b/mmf/utils/torchscript.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Dict, Optional
+
+from torch import Tensor
+
+
+def getattr_torchscriptable(
+    dictionary: Dict[str, Tensor], key: str, default: Optional[Tensor] = None
+) -> Optional[Tensor]:
+    if key in dictionary:
+        return dictionary[key]
+    else:
+        return default

--- a/mmf/utils/transform.py
+++ b/mmf/utils/transform.py
@@ -1,23 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+from torch import Tensor
 
-def transform_to_batch_sequence(tensor):
-    if tensor is not None:
-        if len(tensor.size()) == 2:
-            return tensor
-        else:
-            assert len(tensor.size()) == 3
-            return tensor.contiguous().view(-1, tensor.size(-1))
+
+def transform_to_batch_sequence(tensor: Tensor) -> Tensor:
+    if len(tensor.size()) == 2:
+        return tensor
     else:
-        return None
+        assert len(tensor.size()) == 3
+        return tensor.contiguous().view(-1, tensor.size(-1))
 
 
-def transform_to_batch_sequence_dim(tensor):
-    if tensor is not None:
-        if len(tensor.size()) == 3:
-            return tensor
-        else:
-            assert len(tensor.size()) == 4
-            return tensor.contiguous().view(-1, tensor.size(-2), tensor.size(-1))
+def transform_to_batch_sequence_dim(tensor: Tensor) -> Tensor:
+    if len(tensor.size()) == 3:
+        return tensor
     else:
-        return None
+        assert len(tensor.size()) == 4
+        return tensor.contiguous().view(-1, tensor.size(-2), tensor.size(-1))

--- a/tests/models/test_visual_bert.py
+++ b/tests/models/test_visual_bert.py
@@ -6,6 +6,8 @@ import unittest
 import tests.test_utils as test_utils
 import torch
 from mmf.common.registry import registry
+from mmf.common.sample import SampleList
+from mmf.modules.hf_layers import replace_with_jit
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 
@@ -13,6 +15,7 @@ from mmf.utils.env import setup_imports
 class TestVisualBertTorchscript(unittest.TestCase):
     def setUp(self):
         setup_imports()
+        replace_with_jit()
         model_name = "visual_bert"
         args = test_utils.dummy_args(model=model_name)
         configuration = Configuration(args)
@@ -27,58 +30,41 @@ class TestVisualBertTorchscript(unittest.TestCase):
         self.finetune_model.build()
 
     @test_utils.skip_if_no_network
-    def test_load_save_pretrain_model(self):
-        self.pretrain_model.model.eval()
-        script_model = torch.jit.script(self.pretrain_model.model)
-        buffer = io.BytesIO()
-        torch.jit.save(script_model, buffer)
-        buffer.seek(0)
-        loaded_model = torch.jit.load(buffer)
-        self.assertTrue(test_utils.assertModulesEqual(script_model, loaded_model))
+    def test_pretrained_model_jit_assertion(self):
+        self.pretrain_model.eval()
+        self.assertRaises(RuntimeError, torch.jit.script(self.pretrain_model))
 
     @test_utils.skip_if_no_network
     def test_pretrained_model(self):
-        self.pretrain_model.model.eval()
+        self.pretrain_model.eval()
 
-        input_ids = torch.randint(low=0, high=30255, size=(1, 128)).long()
-        input_mask = torch.ones((1, 128)).long()
-        attention_mask = torch.ones((1, 228)).long()
-        token_type_ids = torch.zeros(1, 128).long()
-        visual_embeddings = torch.rand((1, 100, 2048)).float()
-        visual_embeddings_type = torch.zeros(1, 100).long()
-        masked_lm_labels = torch.zeros((1, 228), dtype=torch.long).fill_(-1)
+        sample_list = SampleList()
+
+        sample_list.add_field(
+            "input_ids", torch.randint(low=0, high=30255, size=(1, 128)).long()
+        )
+        sample_list.add_field("input_mask", torch.ones((1, 128)).long())
+        sample_list.add_field("segment_ids", torch.zeros(1, 128).long())
+        sample_list.add_field("image_feature_0", torch.rand((1, 100, 2048)).float())
+        sample_list.add_field(
+            "lm_label_ids", torch.zeros((1, 128), dtype=torch.long).fill_(-1)
+        )
 
         self.pretrain_model.eval()
 
+        sample_list.dataset_name = "random"
+        sample_list.dataset_type = "test"
         with torch.no_grad():
-            model_output = self.pretrain_model.model(
-                input_ids=input_ids,
-                input_mask=input_mask,
-                attention_mask=attention_mask,
-                token_type_ids=token_type_ids,
-                visual_embeddings=visual_embeddings,
-                visual_embeddings_type=visual_embeddings_type,
-                masked_lm_labels=masked_lm_labels,
-            )
-        script_model = torch.jit.script(self.pretrain_model.model)
-        with torch.no_grad():
-            script_output = script_model(
-                input_ids=input_ids,
-                input_mask=input_mask,
-                attention_mask=attention_mask,
-                token_type_ids=token_type_ids,
-                visual_embeddings=visual_embeddings,
-                visual_embeddings_type=visual_embeddings_type,
-                masked_lm_labels=masked_lm_labels,
-            )
-        self.assertEqual(
-            model_output["masked_lm_loss"], script_output["masked_lm_loss"]
-        )
+            model_output = self.pretrain_model(sample_list)
+
+        self.assertTrue("losses" in model_output)
+        self.assertTrue("random/test/masked_lm_loss" in model_output["losses"])
+        self.assertTrue(model_output["losses"]["random/test/masked_lm_loss"] == 0)
 
     @test_utils.skip_if_no_network
     def test_load_save_finetune_model(self):
-        self.finetune_model.model.eval()
-        script_model = torch.jit.script(self.finetune_model.model)
+        self.finetune_model.eval()
+        script_model = torch.jit.script(self.finetune_model)
         buffer = io.BytesIO()
         torch.jit.save(script_model, buffer)
         buffer.seek(0)
@@ -87,34 +73,21 @@ class TestVisualBertTorchscript(unittest.TestCase):
 
     @test_utils.skip_if_no_network
     def test_finetune_model(self):
+        self.finetune_model.eval()
+        sample_list = SampleList()
 
-        self.finetune_model.model.eval()
-        input_ids = torch.randint(low=0, high=30255, size=(1, 128)).long()
-        input_mask = torch.ones((1, 128)).long()
-        attention_mask = torch.ones((1, 228)).long()
-        token_type_ids = torch.zeros(1, 128).long()
-        visual_embeddings = torch.rand((1, 100, 2048)).float()
-        visual_embeddings_type = torch.zeros(1, 100).long()
+        sample_list.add_field(
+            "input_ids", torch.randint(low=0, high=30255, size=(1, 128)).long()
+        )
+        sample_list.add_field("input_mask", torch.ones((1, 128)).long())
+        sample_list.add_field("segment_ids", torch.zeros(1, 128).long())
+        sample_list.add_field("image_feature_0", torch.rand((1, 100, 2048)).float())
 
         with torch.no_grad():
-            model_output = self.finetune_model.model(
-                input_ids=input_ids,
-                input_mask=input_mask,
-                attention_mask=attention_mask,
-                token_type_ids=token_type_ids,
-                visual_embeddings=visual_embeddings,
-                visual_embeddings_type=visual_embeddings_type,
-            )
+            model_output = self.finetune_model(sample_list)
 
-        script_model = torch.jit.script(self.finetune_model.model)
+        script_model = torch.jit.script(self.finetune_model)
         with torch.no_grad():
-            script_output = script_model(
-                input_ids=input_ids,
-                input_mask=input_mask,
-                attention_mask=attention_mask,
-                token_type_ids=token_type_ids,
-                visual_embeddings=visual_embeddings,
-                visual_embeddings_type=visual_embeddings_type,
-            )
+            script_output = script_model(sample_list)
 
         self.assertTrue(torch.equal(model_output["scores"], script_output["scores"]))


### PR DESCRIPTION
- This removes opinions on module getting torchscripted rather than the
full model. This will also enable us to keep the signature of Dict[str,
Tensor] same for all of the MMF models
- Modifies code flow according to scripting model and pretraining model
conditions
- Add helps function around getattr
- Modifies the test to play nice with new API which looks better

Test Plan:
Modifies VisualBERT tests for TorchScript to script and test the whole
model
