### PR TITLE
[feat] Add encoder registry and differentiate encoder factory

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -20,6 +20,7 @@ Various decorators for registry different kind of classes with unique keys
 - Register a processor: ``@registry.register_processor``
 - Register a optimizer: ``@registry.register_optimizer``
 - Register a scheduler: ``@registry.register_scheduler``
+- Register a encoder: ``@registry.register_encoder``
 - Register a decoder: ``@registry.register_decoder``
 - Register a transformer backend: ``@registry.register_transformer_backend``
 """
@@ -47,6 +48,7 @@ class Registry:
         "optimizer_name_mapping": {},
         "scheduler_name_mapping": {},
         "processor_name_mapping": {},
+        "encoder_name_mapping": {},
         "decoder_name_mapping": {},
         "transformer_backend_name_mapping": {},
         "state": {},
@@ -306,6 +308,36 @@ class Registry:
         return wrap
 
     @classmethod
+    def register_encoder(cls, name):
+        r"""Register a encoder to registry with key 'name'
+
+        Args:
+            name: Key with which the encoder will be registered.
+
+        Usage::
+
+            from mmf.common.registry import registry
+            from mmf.modules.encoders import Encoder
+
+
+            @registry.register_encoder("transformer")
+            class TransformerEncoder(Encoder):
+                ...
+
+        """
+
+        def wrap(encoder_cls):
+            from mmf.modules.encoders import Encoder
+
+            assert issubclass(
+                encoder_cls, Encoder
+            ), "All encoders must inherit Encoder class"
+            cls.mapping["encoder_name_mapping"][name] = encoder_cls
+            return encoder_cls
+
+        return wrap
+
+    @classmethod
     def register(cls, name, obj):
         r"""Register an item to registry with key 'name'
 
@@ -363,6 +395,10 @@ class Registry:
     @classmethod
     def get_decoder_class(cls, name):
         return cls.mapping["decoder_name_mapping"].get(name, None)
+
+    @classmethod
+    def get_encoder_class(cls, name):
+        return cls.mapping["encoder_name_mapping"].get(name, None)
 
     @classmethod
     def get_transformer_backend_class(cls, name):

--- a/mmf/models/mmbt.py
+++ b/mmf/models/mmbt.py
@@ -15,12 +15,12 @@ from mmf.common.registry import registry
 from mmf.models.base_model import BaseModel
 from mmf.models.interfaces.mmbt import MMBTGridHMInterface
 from mmf.modules.encoders import (
-    Encoder,
-    ImageEncoder,
+    EncoderFactory,
+    ImageEncoderFactory,
     ImageEncoderTypes,
     MultiModalEncoderBase,
     ResNet152ImageEncoder,
-    TextEncoder,
+    TextEncoderFactory,
     TextEncoderTypes,
     TransformerEncoder,
 )
@@ -544,10 +544,10 @@ class MMBT(BaseModel):
         text_hidden_size: int = 768
         num_labels: int = 2
         # This actually is Union[ImageEncoderConfig, ImageFeatureEncoderConfig]
-        modal_encoder: Encoder.Config = ImageEncoder.Config(
+        modal_encoder: EncoderFactory.Config = ImageEncoderFactory.Config(
             type=ImageEncoderTypes.resnet152, params=ResNet152ImageEncoder.Config()
         )
-        text_encoder: Encoder.Config = TextEncoder.Config(
+        text_encoder: EncoderFactory.Config = TextEncoderFactory.Config(
             type=TextEncoderTypes.transformer,
             params=TransformerEncoder.Config(bert_model_name=II("bert_model_name")),
         )

--- a/tests/models/test_mmbt.py
+++ b/tests/models/test_mmbt.py
@@ -9,10 +9,10 @@ from mmf.common.registry import registry
 from mmf.common.sample import Sample, SampleList
 from mmf.models.mmbt import MMBT
 from mmf.modules.encoders import (
-    ImageEncoder,
+    ImageEncoderFactory,
     ImageEncoderTypes,
     ResNet152ImageEncoder,
-    TextEncoder,
+    TextEncoderFactory,
     TextEncoderTypes,
 )
 from mmf.utils.configuration import Configuration
@@ -67,20 +67,20 @@ class TestMMBTConfig(unittest.TestCase):
     def test_mmbt_from_params(self):
         # default init
         mmbt = MMBT.from_params(
-            modal_encoder=ImageEncoder.Config(
+            modal_encoder=ImageEncoderFactory.Config(
                 type=ImageEncoderTypes.resnet152,
                 params=ResNet152ImageEncoder.Config(pretrained=False),
             ),
-            text_encoder=TextEncoder.Config(type=TextEncoderTypes.identity),
+            text_encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
         )
 
         config = OmegaConf.structured(
             MMBT.Config(
-                modal_encoder=ImageEncoder.Config(
+                modal_encoder=ImageEncoderFactory.Config(
                     type=ImageEncoderTypes.resnet152,
                     params=ResNet152ImageEncoder.Config(pretrained=False),
                 ),
-                text_encoder=TextEncoder.Config(type=TextEncoderTypes.identity),
+                text_encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
             )
         )
         self.assertIsNotNone(mmbt)
@@ -95,11 +95,11 @@ class TestMMBTConfig(unittest.TestCase):
     def test_mmbt_directly_from_config(self):
         config = OmegaConf.structured(
             MMBT.Config(
-                modal_encoder=ImageEncoder.Config(
+                modal_encoder=ImageEncoderFactory.Config(
                     type=ImageEncoderTypes.resnet152,
                     params=ResNet152ImageEncoder.Config(pretrained=False),
                 ),
-                text_encoder=TextEncoder.Config(type=TextEncoderTypes.identity),
+                text_encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
             )
         )
         mmbt = MMBT(config)


### PR DESCRIPTION
Summary:
This diff aims to smoothen the process of adding new encoders to MMF. This is also specifically needed for FB internal encoders which are hard to registry while not being part of OSS without registry. This will also help with keeping sanity in MMFTransformer and generic modalities diff.

This diff also converts the older feature encoders to the factory which is what they technically are. This backwards compatible change as the build api still looks same. Though if someone is directly importing the encoder, this will break their code. But this refactor is much needed at this time.

We also add `build_encoder` function which handles both structured config and normal config patterns. We hope to make it more streamlined in future when we make efforts towards Hydra integration.

Differential Revision: D24300517

