### PR TITLE
[fix] Parameter list regression in build_optimizers

### DIFF
--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -143,6 +143,17 @@ def get_optimizer_parameters(model, config):
     if is_parallel and hasattr(model.module, "get_optimizer_parameters"):
         parameters = model.module.get_optimizer_parameters(config)
 
+    # If parameters are a generator, convert to a list first
+    parameters = list(parameters)
+
+    if len(parameters) == 0:
+        raise ValueError("optimizer got an empty parameter list")
+
+    # If parameters are in format of list, instead of grouped params
+    # convert them to grouped params form
+    if not isinstance(parameters[0], dict):
+        parameters = [{"params": parameters}]
+
     for group in parameters:
         group["params"] = list(group["params"])
 

--- a/tests/modules/test_optimizers.py
+++ b/tests/modules/test_optimizers.py
@@ -1,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+
+import torch
+from mmf.models.mmbt import MMBT
+from mmf.utils.build import build_optimizer
+from omegaconf import OmegaConf
+from tests.test_utils import SimpleModel, skip_if_no_network
+
+
+class TestOptimizers(unittest.TestCase):
+    def setUp(self):
+        self.config = OmegaConf.create(
+            {"optimizer": {"type": "adam_w", "params": {"lr": 5e-5}}}
+        )
+
+    def test_build_optimizer_simple_model(self):
+        model = SimpleModel(1)
+
+        optimizer = build_optimizer(model, self.config)
+        self.assertTrue(isinstance(optimizer, torch.optim.Optimizer))
+        self.assertEqual(len(optimizer.param_groups), 1)
+
+    @skip_if_no_network
+    def test_build_optimizer_custom_model(self):
+        model = MMBT.from_params()
+        model.build()
+        self.config.model = model.config.model
+        self.config.model_config = model.config
+
+        optimizer = build_optimizer(model, self.config)
+        self.assertTrue(isinstance(optimizer, torch.optim.Optimizer))
+        self.assertEqual(len(optimizer.param_groups), 2)


### PR DESCRIPTION
- With recent change of #580, there is a regression for models which
don't have `get_optimizer_parameters` or don't return param groups. #580
specifically expects param groups to be present.
- This PR fixes this regression and add tests for optimizers so that
this doesn't happen again

Test Plan:

Tested added for two type of parameter groups returned from the model