### PR TITLE
[feat] Make top level loss classes torchscriptable

### DIFF
--- a/tests/models/test_mmbt.py
+++ b/tests/models/test_mmbt.py
@@ -3,7 +3,6 @@
 import unittest
 
 import tests.test_utils as test_utils
-from mmf.common.registry import registry
 from mmf.models.mmbt import MMBT
 from mmf.modules.encoders import (
     ImageEncoderFactory,
@@ -12,6 +11,7 @@ from mmf.modules.encoders import (
     TextEncoderFactory,
     TextEncoderTypes,
 )
+from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 from omegaconf import OmegaConf
@@ -28,11 +28,11 @@ class TestMMBTTorchscript(unittest.TestCase):
         args = test_utils.dummy_args(model=model_name)
         configuration = Configuration(args)
         config = configuration.get_config()
-        model_class = registry.get_model_class(model_name)
-        config.model_config[model_name]["training_head_type"] = "classification"
-        config.model_config[model_name]["num_labels"] = 2
-        self.finetune_model = model_class(config.model_config[model_name])
-        self.finetune_model.build()
+        model_config = config.model_config[model_name]
+        model_config["training_head_type"] = "classification"
+        model_config["num_labels"] = 2
+        model_config.model = model_name
+        self.finetune_model = build_model(model_config)
 
     def test_load_save_finetune_model(self):
         self.assertTrue(test_utils.verify_torchscript_models(self.finetune_model))

--- a/tests/models/test_mmf_transformer.py
+++ b/tests/models/test_mmf_transformer.py
@@ -3,7 +3,7 @@
 import unittest
 
 import tests.test_utils as test_utils
-from mmf.common.registry import registry
+from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 
@@ -21,11 +21,8 @@ class TestMMFTransformerTorchscript(unittest.TestCase):
         args = test_utils.dummy_args(model=self.model_name)
         configuration = Configuration(args)
         self.config = configuration.get_config()
-        self.model_class = registry.get_model_class(self.model_name)
-        self.finetune_model = self.model_class(
-            self.config.model_config[self.model_name]
-        )
-        self.finetune_model.build()
+        self.config.model_config[self.model_name].model = self.model_name
+        self.finetune_model = build_model(self.config.model_config[self.model_name])
 
     def test_load_save_finetune_model(self):
         self.assertTrue(test_utils.verify_torchscript_models(self.finetune_model))
@@ -40,8 +37,7 @@ class TestMMFTransformerTorchscript(unittest.TestCase):
 
     def test_finetune_roberta_base(self):
         self.config.model_config[self.model_name]["transformer_base"] = "roberta-base"
-        model = self.model_class(self.config.model_config[self.model_name])
-        model.build()
+        model = build_model(self.config.model_config[self.model_name])
         model.eval()
         self.assertTrue(
             test_utils.compare_torchscript_transformer_models(
@@ -54,8 +50,7 @@ class TestMMFTransformerTorchscript(unittest.TestCase):
         self.config.model_config[self.model_name][
             "transformer_base"
         ] = "xlm-roberta-base"
-        model = self.model_class(self.config.model_config[self.model_name])
-        model.build()
+        model = build_model(self.config.model_config[self.model_name])
         model.eval()
         self.assertTrue(
             test_utils.compare_torchscript_transformer_models(

--- a/tests/models/test_vilbert.py
+++ b/tests/models/test_vilbert.py
@@ -4,7 +4,7 @@ import unittest
 
 import tests.test_utils as test_utils
 import torch
-from mmf.common.registry import registry
+from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 
@@ -20,22 +20,20 @@ class TestViLBertTorchscript(unittest.TestCase):
         args = test_utils.dummy_args(model=model_name)
         configuration = Configuration(args)
         config = configuration.get_config()
-        model_class = registry.get_model_class(model_name)
         self.vision_feature_size = 1024
         self.vision_target_size = 1279
-        config.model_config[model_name]["training_head_type"] = "pretraining"
-        config.model_config[model_name][
-            "visual_embedding_dim"
-        ] = self.vision_feature_size
-        config.model_config[model_name]["v_feature_size"] = self.vision_feature_size
-        config.model_config[model_name]["v_target_size"] = self.vision_target_size
-        config.model_config[model_name]["dynamic_attention"] = False
-        self.pretrain_model = model_class(config.model_config[model_name])
-        self.pretrain_model.build()
-        config.model_config[model_name]["training_head_type"] = "classification"
-        config.model_config[model_name]["num_labels"] = 2
-        self.finetune_model = model_class(config.model_config[model_name])
-        self.finetune_model.build()
+        model_config = config.model_config[model_name]
+        model_config["training_head_type"] = "pretraining"
+        model_config["visual_embedding_dim"] = self.vision_feature_size
+        model_config["v_feature_size"] = self.vision_feature_size
+        model_config["v_target_size"] = self.vision_target_size
+        model_config["dynamic_attention"] = False
+        model_config.model = model_name
+        self.pretrain_model = build_model(model_config)
+
+        model_config["training_head_type"] = "classification"
+        model_config["num_labels"] = 2
+        self.finetune_model = build_model(model_config)
 
     # TODO: fix windows unit test with python version of 3.6 and 3.8
     @test_utils.skip_if_windows

--- a/tests/models/test_visual_bert.py
+++ b/tests/models/test_visual_bert.py
@@ -4,9 +4,9 @@ import unittest
 
 import tests.test_utils as test_utils
 import torch
-from mmf.common.registry import registry
 from mmf.common.sample import SampleList
 from mmf.modules.hf_layers import replace_with_jit
+from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
 
@@ -23,11 +23,11 @@ class TestVisualBertTorchscript(unittest.TestCase):
         args = test_utils.dummy_args(model=model_name)
         configuration = Configuration(args)
         config = configuration.get_config()
-        model_class = registry.get_model_class(model_name)
-        config.model_config[model_name]["training_head_type"] = "classification"
-        config.model_config[model_name]["num_labels"] = 2
-        self.finetune_model = model_class(config.model_config[model_name])
-        self.finetune_model.build()
+        model_config = config.model_config[model_name]
+        model_config["training_head_type"] = "classification"
+        model_config["num_labels"] = 2
+        model_config.model = model_name
+        self.finetune_model = build_model(model_config)
 
     def test_load_save_finetune_model(self):
         self.assertTrue(test_utils.verify_torchscript_models(self.finetune_model))
@@ -50,9 +50,9 @@ class TestVisualBertPretraining(unittest.TestCase):
         args = test_utils.dummy_args(model=model_name)
         configuration = Configuration(args)
         config = configuration.get_config()
-        model_class = registry.get_model_class(model_name)
-        self.pretrain_model = model_class(config.model_config[model_name])
-        self.pretrain_model.build()
+        model_config = config.model_config[model_name]
+        model_config.model = model_name
+        self.pretrain_model = build_model(model_config)
 
     def test_pretrained_model(self):
         sample_list = SampleList()


### PR DESCRIPTION
- We weren't doing init_losses in the tests so we didn't notice this
- Changes make top level loss function torchscriptable so that if losses
are empty, this doesn't cause any issues

Test Plan:

Enable init_losses in mmbt tests

