### PR TITLE
[feat] Add optimizer state sharding (ZeRO)

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -171,6 +171,9 @@ optimizer:
     # optimizer. Default is false to guard against missing parameters due to
     # implementation errors in a model's get_optimizer_parameters
     allow_unused_parameters: false
+    # Whether to enable optimizer state sharding. It uses ZeRO optimizer state
+    # sharding method as described here https://arxiv.org/abs/1910.02054.
+    enable_state_sharding: false
 
 # Configuration for scheduler, examples can be found in models' configs
 scheduler: {}

--- a/mmf/trainers/callbacks/checkpoint.py
+++ b/mmf/trainers/callbacks/checkpoint.py
@@ -2,7 +2,7 @@
 import logging
 
 from mmf.trainers.callbacks.base import Callback
-from mmf.utils.checkpoint import Checkpoint
+from mmf.utils.checkpoint import Checkpoint, consolidate_optim_state_dict
 
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,8 @@ class CheckpointCallback(Callback):
     def on_update_end(self, **kwargs):
         if self.trainer.num_updates % self.checkpoint_interval == 0:
             logger.info("Checkpoint time. Saving a checkpoint.")
+            # Consolidate the state dict of sharded optimizers
+            consolidate_optim_state_dict(self.trainer.optimizer)
             self._checkpoint.save(
                 self.trainer.num_updates,
                 self.trainer.current_iteration,

--- a/mmf/trainers/callbacks/early_stopping.py
+++ b/mmf/trainers/callbacks/early_stopping.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 from mmf.trainers.callbacks.base import Callback
+from mmf.utils.checkpoint import consolidate_optim_state_dict
 from mmf.utils.distributed import broadcast_scalar
 from mmf.utils.early_stopping import EarlyStopping
 
@@ -32,6 +33,8 @@ class EarlyStoppingCallback(Callback):
         )
 
     def on_validation_end(self, **kwargs):
+        # Consolidate the state dict of sharded optimizers
+        consolidate_optim_state_dict(self.trainer.optimizer)
         stop = self.early_stopping(
             self.trainer.num_updates, self.trainer.current_iteration, kwargs["meter"]
         )

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -80,6 +80,11 @@ def load_pretrained_model(model_name_or_path, *args, **kwargs):
     return {"config": model_config, "checkpoint": ckpt, "full_config": config}
 
 
+def consolidate_optim_state_dict(optimizer):
+    if hasattr(optimizer, "consolidate_state_dict"):
+        optimizer.consolidate_state_dict(recipient_rank=0)
+
+
 class Checkpoint:
     def __init__(self, trainer):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # This is required to make sorting same as fbcode as all absolute imports
 # are considered third party there
 known_third_party = [
-    "PIL", "cv2", "demjson", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "mmf",
+    "PIL", "cv2", "demjson", "fairscale", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "mmf",
     "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
     "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
     "torchtext", "torchvision", "tqdm", "transformers"

--- a/website/docs/notes/training_tricks.md
+++ b/website/docs/notes/training_tricks.md
@@ -4,8 +4,18 @@ title: Training Tricks
 sidebar_label: Training Tricks
 ---
 
-# FP16
+## FP16
 
 MMF supports FP16 training for faster performance with negligible impact on
 the results through `torch.cuda.amp` module. Append `training.fp16=True` to
 the end of your command to enable fp16 training in the trainer.
+
+## Optimizer State Sharding
+
+MMF supports optimizer state sharding for fitting larger models in GPUs. To enable optimizer state sharding append `optimizer.enable_state_sharding=True` to the end of your command. Optimizer state sharding is achieved by using the `OSS` optimizer wrapper from [fairscale](https://github.com/facebookresearch/fairscale) library. `OSS` uses the Zero Redundancy Optimizer [(ZeRO)](https://arxiv.org/abs/1910.02054).
+
+:::note
+
+[fairscale](https://github.com/facebookresearch/fairscale) is not installed along with MMF due to some dependency issues. In order to use optimizer state sharding, install the library following the instructions in the repository.
+
+:::


### PR DESCRIPTION
Summary:
Adding Zero optimizer state sharding to MMF from [fairscale](https://github.com/facebookresearch/fairscale) library.
Added to tutorials

It can used with this option : `optimizer.enable_state_sharding=True`

Differential Revision: D24317858

