### PR TITLE
[fix] Fix in_dim for movie_mcan model

### DIFF
--- a/mmf/configs/models/movie_mcan/defaults.yaml
+++ b/mmf/configs/models/movie_mcan/defaults.yaml
@@ -19,6 +19,7 @@ model_config:
       params:
         model_data_dir: ${model_config.movie_mcan.model_data_dir}
         cond_features: 1024
+        in_dim: ${model_config.movie_mcan.image_feature_dim}
     text_embeddings:
       type: mcan
       params:


### PR DESCRIPTION
`in_dim` needs to be added to the config after the change in PR #564. Fixing that.
