### PR TITLE
[fix] Allow struct=True configs for MMFT encoders,pretrained Pythia

### DIFF
--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -39,21 +39,20 @@ class MMFTransformer(BaseTransformer):
         self.encoders = nn.ModuleDict()
 
         for modality in self.config.modalities:
-            # Support "image_encoder" attribute in config if directly provided
-            if (
-                modality.type == "image"
-                and "encoder" not in modality
-                and "image_encoder" in self.config
-            ):
-                modality.encoder = self.config.image_encoder
-
             if "encoder" not in modality:
-                # 100 is a random number added to satisfy identity encoder
-                modality.encoder = OmegaConf.create(
-                    {"type": "identity", "params": {"in_dim": 100}}
-                )
+                # Support "image_encoder" attribute in config if directly provided
+                if modality.type == "image" and "image_encoder" in self.config:
+                    encoder_config = self.config.image_encoder
+                else:
+                    # 100 is a random number added to satisfy identity encoder
+                    # Set encoder to identity
+                    encoder_config = OmegaConf.create(
+                        {"type": "identity", "params": {"in_dim": 100}}
+                    )
+            else:
+                encoder_config = modality.encoder
 
-            encoder = build_encoder(modality.encoder)
+            encoder = build_encoder(encoder_config)
             self.encoders[modality.key] = encoder
 
             if modality.type == "image" and getattr(

--- a/mmf/models/movie_mcan.py
+++ b/mmf/models/movie_mcan.py
@@ -3,6 +3,7 @@
 import copy
 from typing import Any, Dict, List, Optional, Tuple
 
+import omegaconf
 import torch
 from mmf.common.registry import registry
 from mmf.common.typings import DictConfig
@@ -69,8 +70,9 @@ class MoVieMcan(BaseModel):
         setattr(self, attr + "_feature_dim", feature_dim)
 
         feat_encoder_config = copy.deepcopy(feat_encoder)
-        feat_encoder_config.params.model_data_dir = self.config.model_data_dir
-        feat_encoder_config.params.in_dim = feature_dim
+        with omegaconf.open_dict(feat_encoder_config):
+            feat_encoder_config.params.model_data_dir = self.config.model_data_dir
+            feat_encoder_config.params.in_dim = feature_dim
         feat_model = build_image_encoder(feat_encoder_config, direct_features=True)
 
         setattr(self, attr + "_feature_dim", feat_model.out_dim)

--- a/mmf/models/pythia.py
+++ b/mmf/models/pythia.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import copy
 
+import omegaconf
 import torch
 from mmf.common.registry import registry
 from mmf.models.base_model import BaseModel
@@ -81,8 +82,9 @@ class Pythia(BaseModel):
 
         for feat_encoder in feat_encoders_list_config:
             feat_encoder_config = copy.deepcopy(feat_encoder)
-            feat_encoder_config.params.model_data_dir = self.config.model_data_dir
-            feat_encoder_config.params.in_dim = feature_dim
+            with omegaconf.open_dict(feat_encoder_config):
+                feat_encoder_config.params.model_data_dir = self.config.model_data_dir
+                feat_encoder_config.params.in_dim = feature_dim
             feat_model = build_image_encoder(feat_encoder_config, direct_features=True)
             feat_encoders.append(feat_model)
             setattr(self, attr + "_feature_dim", feat_model.out_dim)


### PR DESCRIPTION
- If modality is missing encoder key, MMFT after recent fix won't break
down
- This allows using configs without specifying encoder key and if they
are in struct mode which is what MMF gives when ran from command line

Test Plan:

Tested with audio video MMFT

