### PR TITLE
[fix] Fix text encoder output for BertModelJIT

### DIFF
--- a/mmf/models/fusions.py
+++ b/mmf/models/fusions.py
@@ -42,8 +42,9 @@ class FusionBase(MultiModalEncoderBase):
             modal_kwargs = {}
         text = self.text(text, *text_args, **text_kwargs)
 
-        # Case of bert encoder, we only need pooled output
-        if len(text) == 2:
+        # Case of bert encoder, we only need pooled output. For BertModelJIT encoder
+        # pooled output is the 2nd in the tuple(sequence, pooled, encoded_layers)
+        if len(text) >= 2:
             text = text[1]
 
         modal = self.modal(modal, *modal_args, **modal_kwargs)


### PR DESCRIPTION
Summary: Output of BertModelJit is a 3 tuple. Fix to pick the pooled output for the fusion models. Behavior changed after we fixed `bert-*` models to use `BertModelJit` in D24038872 (https://github.com/facebookresearch/mmf/commit/5be74f067382272d6f6729156659d7f5a00be187)

Reviewed By: n-zhang

Differential Revision: D24440904

