### PR TITLE
[fix] Fix text encoder output if the output is tensor

### DIFF
--- a/mmf/models/fusions.py
+++ b/mmf/models/fusions.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import collections
 from copy import deepcopy
 
 import torch
@@ -44,7 +45,7 @@ class FusionBase(MultiModalEncoderBase):
 
         # Case of bert encoder, we only need pooled output. For BertModelJIT encoder
         # pooled output is the 2nd in the tuple(sequence, pooled, encoded_layers)
-        if len(text) >= 2:
+        if isinstance(text, collections.abc.Sequence) and len(text) >= 2:
             text = text[1]
 
         modal = self.modal(modal, *modal_args, **modal_kwargs)

--- a/mmf/models/unimodal.py
+++ b/mmf/models/unimodal.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import collections
 from copy import deepcopy
 
 import torch
@@ -29,7 +30,7 @@ class UnimodalBase(MultiModalEncoderBase):
     def forward(self, x, *args, **kwargs):
         x = self.encoder(x, *args, **kwargs)
         # Case of bert encoder, we only need pooled output
-        if not torch.is_tensor(x) and len(x) == 2:
+        if isinstance(x, collections.abc.Sequence) and len(x) >= 2:
             x = x[1]
 
         x = torch.flatten(x, start_dim=1)


### PR DESCRIPTION
Summary: Some text encoder outputs return a single tensor (say with dimension `batch_size x out_dim`). Additional condition checks are added to make sure this case is not affected.

Differential Revision: D24456401

