### PR TITLE
[feat,fix] Stronger checkpoint validation, fix missing keys

### DIFF
--- a/mmf/models/m4c.py
+++ b/mmf/models/m4c.py
@@ -34,6 +34,12 @@ class M4C(BaseModel):
     def config_path(cls):
         return "configs/models/m4c/defaults.yaml"
 
+    @classmethod
+    def format_state_key(cls, key):
+        key = key.replace("obj_faster_rcnn_fc7.module.lc", "obj_faster_rcnn_fc7.lc")
+        key = key.replace("ocr_faster_rcnn_fc7.module.lc", "ocr_faster_rcnn_fc7.lc")
+        return key
+
     def build(self):
         # modules requiring custom learning rates (usually for finetuning)
         self.finetune_modules = []

--- a/mmf/models/movie_mcan.py
+++ b/mmf/models/movie_mcan.py
@@ -30,6 +30,13 @@ class MoVieMcan(BaseModel):
     def config_path(cls):
         return "configs/models/movie_mcan/defaults.yaml"
 
+    @classmethod
+    def format_state_key(cls, key):
+        key = key.replace(
+            "image_feature_encoders.0.module.lc", "image_feature_encoders.0.lc"
+        )
+        return key
+
     def build(self):
         self.image_feature_dim = 2048
         self._build_word_embedding()

--- a/mmf/models/pythia.py
+++ b/mmf/models/pythia.py
@@ -30,7 +30,11 @@ class Pythia(BaseModel):
 
     @classmethod
     def format_state_key(cls, key):
-        return key.replace("fa_history", "fa_context")
+        key = key.replace("fa_history", "fa_context")
+        key = key.replace(
+            "image_feature_encoders.0.module.lc", "image_feature_encoders.0.lc"
+        )
+        return key
 
     def build(self):
         self._build_word_embedding()


### PR DESCRIPTION
- This PR aims to add stronger checkpoint validations to MMF
- It will fail the run if there are missing keys in the checkpoint
- It will log unexpected keys as warnings
- Using this, we fix multiple missing keys in pythia, m4c

Fixes #661 #652 