### PR TITLE
[chores] Upgrade transformers dependency for mmf

### DIFF
--- a/mmf/models/m4c.py
+++ b/mmf/models/m4c.py
@@ -15,7 +15,6 @@ from transformers.modeling_bert import (
     BertConfig,
     BertEmbeddings,
     BertEncoder,
-    BertLayerNorm,
     BertPreTrainedModel,
 )
 
@@ -111,8 +110,8 @@ class M4C(BaseModel):
         # object location feature: relative bounding box coordinates (4-dim)
         self.linear_obj_bbox_to_mmt_in = nn.Linear(4, self.mmt_config.hidden_size)
 
-        self.obj_feat_layer_norm = BertLayerNorm(self.mmt_config.hidden_size)
-        self.obj_bbox_layer_norm = BertLayerNorm(self.mmt_config.hidden_size)
+        self.obj_feat_layer_norm = nn.LayerNorm(self.mmt_config.hidden_size)
+        self.obj_bbox_layer_norm = nn.LayerNorm(self.mmt_config.hidden_size)
         self.obj_drop = nn.Dropout(self.config.obj.dropout_prob)
 
     def _build_ocr_encoding(self):
@@ -141,8 +140,8 @@ class M4C(BaseModel):
         # OCR location feature: relative bounding box coordinates (4-dim)
         self.linear_ocr_bbox_to_mmt_in = nn.Linear(4, self.mmt_config.hidden_size)
 
-        self.ocr_feat_layer_norm = BertLayerNorm(self.mmt_config.hidden_size)
-        self.ocr_bbox_layer_norm = BertLayerNorm(self.mmt_config.hidden_size)
+        self.ocr_feat_layer_norm = nn.LayerNorm(self.mmt_config.hidden_size)
+        self.ocr_bbox_layer_norm = nn.LayerNorm(self.mmt_config.hidden_size)
         self.ocr_drop = nn.Dropout(self.config.ocr.dropout_prob)
 
     def _build_mmt(self):
@@ -505,9 +504,9 @@ class PrevPredEmbeddings(nn.Module):
         self.position_embeddings = nn.Embedding(MAX_DEC_LENGTH, hidden_size)
         self.token_type_embeddings = nn.Embedding(MAX_TYPE_NUM, hidden_size)
 
-        self.ans_layer_norm = BertLayerNorm(hidden_size, eps=ln_eps)
-        self.ocr_layer_norm = BertLayerNorm(hidden_size, eps=ln_eps)
-        self.emb_layer_norm = BertLayerNorm(hidden_size, eps=ln_eps)
+        self.ans_layer_norm = nn.LayerNorm(hidden_size, eps=ln_eps)
+        self.ocr_layer_norm = nn.LayerNorm(hidden_size, eps=ln_eps)
+        self.emb_layer_norm = nn.LayerNorm(hidden_size, eps=ln_eps)
         self.emb_dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(self, ans_emb, ocr_emb, prev_inds):

--- a/mmf/models/mmf_bert.py
+++ b/mmf/models/mmf_bert.py
@@ -10,7 +10,6 @@ from transformers.modeling_bert import (
     BertConfig,
     BertEmbeddings,
     BertForPreTraining,
-    BertLayerNorm,
     BertPooler,
     BertPredictionHeadTransform,
     BertPreTrainingHeads,
@@ -81,7 +80,7 @@ class MMFBert(Pythia):
         self.text_embedding = nn.MultiheadAttention(**self.config.text_embeddings[0])
 
     def _tie_or_clone_weights(self, first_module, second_module):
-        """ Tie or clone module weights depending of weither we are using
+        """Tie or clone module weights depending of weither we are using
         TorchScript or not
         """
         if self.config.torchscript:
@@ -90,9 +89,9 @@ class MMFBert(Pythia):
             first_module.weight = second_module.weight
 
     def tie_weights(self):
-        """ Make sure we are sharing the input and output embeddings.
-            Export to TorchScript can't handle parameter sharing so we are cloning
-            them instead.
+        """Make sure we are sharing the input and output embeddings.
+        Export to TorchScript can't handle parameter sharing so we are cloning
+        them instead.
         """
         if hasattr(self, "cls"):
             self._tie_or_clone_weights(
@@ -271,14 +270,13 @@ class MMFBert(Pythia):
         return feature_embedding_total, feature_attentions
 
     def init_weights(self, module):
-        """ Initialize the weights.
-        """
+        """Initialize the weights."""
         if isinstance(module, (nn.Linear, nn.Embedding)):
             # Slightly different from the TF version which uses truncated_normal
             # for initialization
             # cf https://github.com/pytorch/pytorch/pull/5617
             module.weight.data.normal_(mean=0.0, std=self.bert_config.initializer_range)
-        elif isinstance(module, BertLayerNorm):
+        elif isinstance(module, nn.LayerNorm):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
         if isinstance(module, nn.Linear) and module.bias is not None:

--- a/mmf/models/vilbert.py
+++ b/mmf/models/vilbert.py
@@ -21,7 +21,6 @@ from transformers.modeling_bert import (
     BertConfig,
     BertEmbeddings,
     BertIntermediate,
-    BertLayerNorm,
     BertLMPredictionHead,
     BertOutput,
     BertPredictionHeadTransform,
@@ -239,7 +238,7 @@ class BertImageSelfOutput(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.dense = nn.Linear(config.v_hidden_size, config.v_hidden_size)
-        self.LayerNorm = BertLayerNorm(config.v_hidden_size, eps=1e-12)
+        self.LayerNorm = nn.LayerNorm(config.v_hidden_size, eps=1e-12)
         self.dropout = nn.Dropout(config.v_hidden_dropout_prob)
 
     def forward(self, hidden_states: Tensor, input_tensor: Tensor) -> Tensor:
@@ -288,7 +287,7 @@ class BertImageOutput(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.dense = nn.Linear(config.v_intermediate_size, config.v_hidden_size)
-        self.LayerNorm = BertLayerNorm(config.v_hidden_size, eps=1e-12)
+        self.LayerNorm = nn.LayerNorm(config.v_hidden_size, eps=1e-12)
         self.dropout = nn.Dropout(config.v_hidden_dropout_prob)
 
     def forward(self, hidden_states: Tensor, input_tensor: Tensor) -> Tensor:
@@ -469,14 +468,14 @@ class BertBiOutput(nn.Module):
         super().__init__()
 
         self.dense1 = nn.Linear(config.bi_hidden_size, config.v_hidden_size)
-        self.LayerNorm1 = BertLayerNorm(config.v_hidden_size, eps=1e-12)
+        self.LayerNorm1 = nn.LayerNorm(config.v_hidden_size, eps=1e-12)
         self.dropout1 = nn.Dropout(config.v_hidden_dropout_prob)
 
         self.q_dense1 = nn.Linear(config.bi_hidden_size, config.v_hidden_size)
         self.q_dropout1 = nn.Dropout(config.v_hidden_dropout_prob)
 
         self.dense2 = nn.Linear(config.bi_hidden_size, config.hidden_size)
-        self.LayerNorm2 = BertLayerNorm(config.hidden_size, eps=1e-12)
+        self.LayerNorm2 = nn.LayerNorm(config.hidden_size, eps=1e-12)
         self.dropout2 = nn.Dropout(config.hidden_dropout_prob)
 
         self.q_dense2 = nn.Linear(config.bi_hidden_size, config.hidden_size)
@@ -827,7 +826,7 @@ class BertImgPredictionHeadTransform(nn.Module):
             self.transform_act_fn = ACT2FN[config.hidden_act]
         else:
             self.transform_act_fn = config.v_hidden_act
-        self.LayerNorm = BertLayerNorm(config.v_hidden_size, eps=1e-12)
+        self.LayerNorm = nn.LayerNorm(config.v_hidden_size, eps=1e-12)
 
     def forward(self, hidden_states: Tensor) -> Tensor:
         hidden_states = self.dense(hidden_states)
@@ -891,7 +890,7 @@ class BertImageFeatureEmbeddings(nn.Module):
 
         self.image_embeddings = nn.Linear(config.v_feature_size, config.v_hidden_size)
         self.image_location_embeddings = nn.Linear(5, config.v_hidden_size)
-        self.LayerNorm = BertLayerNorm(config.v_hidden_size, eps=1e-12)
+        self.LayerNorm = nn.LayerNorm(config.v_hidden_size, eps=1e-12)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(self, image_feature: Tensor, image_location: Tensor) -> Tensor:
@@ -1080,9 +1079,9 @@ class ViLBERTForPretraining(nn.Module):
             self.tie_weights()
 
     def tie_weights(self):
-        """ Make sure we are sharing the input and output embeddings.
-            Export to TorchScript can't handle parameter sharing so we are cloning
-            them instead.
+        """Make sure we are sharing the input and output embeddings.
+        Export to TorchScript can't handle parameter sharing so we are cloning
+        them instead.
         """
         self._tie_or_clone_weights(
             self.cls.predictions.decoder, self.bert.embeddings.word_embeddings

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.23.0
 fasttext==0.9.1
 nltk==3.4.5
 editdistance==0.5.3
-transformers==2.3.0
+transformers==3.4.0
 sklearn==0.0
 omegaconf==2.0.1rc4
 lmdb==0.98


### PR DESCRIPTION
Summary:
- Includes changes for compatibility with transformers 3.4.0
- BertLayerNorm is replaced with LayerNorm from torch.nn
- Roberta classes are replicated in the latest version. So we need to monkey patch all of them.
- BertEmbedding has a new position_id variable, due to which existing checkpoints have to be loaded with strict=False. This doesn't effect the models, instead of generating position ids it is just an added variable. In most of our models its a no-op.
- Additional properties need to be ignored in the `PreTrainedModel` class.

Differential Revision: D24599639

