### PR TITLE
[fix] Upgrade actions workflows to use miniconda@v2

### DIFF
--- a/.github/workflows/cpu_test.yaml
+++ b/.github/workflows/cpu_test.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Conda Environment
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: mmf
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -20,7 +20,7 @@ jobs:
         path: mmf_master
 
     - name: Setup Miniconda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: mmf
         python-version: 3.7

--- a/.github/workflows/linter_test.yaml
+++ b/.github/workflows/linter_test.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Conda Environment
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: mmf
         python-version: 3.7


### PR DESCRIPTION
Github Actions workflows are broken due to deprecation of `set-env` and `add-path` commands. We need to upgrade to newer version of miniconda. 

Test Plan:

Example broken tests : https://github.com/facebookresearch/mmf/actions/runs/368665121

Fixed in this PR.