### PR TITLE
[fix] Typo in LMDBConversion

### DIFF
--- a/tools/scripts/features/lmdb_conversion.py
+++ b/tools/scripts/features/lmdb_conversion.py
@@ -92,7 +92,7 @@ class LMDBConversion:
                 tmp_dict["image_id"] = img_id
                 tmp_dict["bbox"] = item["bbox"]
                 tmp_dict["num_boxes"] = item["num_boxes"]
-                tmp_dict["image_height"] = item["image_width"]
+                tmp_dict["image_height"] = item["image_height"]
                 tmp_dict["image_width"] = item["image_width"]
                 tmp_dict["objects"] = item["objects"]
                 tmp_dict["cls_prob"] = item["cls_prob"]


### PR DESCRIPTION
Fix typo when extracting image features from .mdb file to .npy files.

**Fix:**
In **Line#95** image height is set to be the image width, which is wrong:
https://github.com/facebookresearch/mmf/blob/518a5a675586e4dc1b415a52a8a80c75edfc2960/tools/scripts/features/lmdb_conversion.py#L95-L96
