### PR TITLE
[WIP][feat] per-dataset evaluation loop w/ dataset-level metrics

### DIFF
--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -56,9 +56,12 @@ class TestReporter(Dataset):
 
         PathManager.mkdirs(self.report_folder)
 
-    def next_dataset(self):
+    def next_dataset(self, flush_report=True):
         if self.current_dataset_idx >= 0:
-            self.flush_report()
+            if flush_report:
+                self.flush_report()
+            else:
+                self.report = []
 
         self.current_dataset_idx += 1
 
@@ -95,6 +98,10 @@ class TestReporter(Dataset):
         logger.info(f"Wrote predictions for {name} to {os.path.abspath(filepath)}")
         self.report = []
 
+    def postprocess_dataset_report(self):
+        if hasattr(self.current_dataset, "on_prediction_end"):
+            self.report = self.current_dataset.on_prediction_end(self.report)
+
     def csv_dump(self, filepath):
         with PathManager.open(filepath, "w") as f:
             title = self.report[0].keys()
@@ -123,12 +130,12 @@ class TestReporter(Dataset):
     def __getitem__(self, idx):
         return self.current_dataset[idx]
 
-    def add_to_report(self, report, model):
+    def add_to_report(self, report, model, master_only=True):
         keys = ["id", "question_id", "image_id", "context_tokens", "captions", "scores"]
         for key in keys:
             report = self.reshape_and_gather(report, key)
 
-        if not is_master():
+        if master_only and not is_master():
             return
 
         results = self.current_dataset.format_for_prediction(report)

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -42,7 +42,7 @@ class TrainerTrainingLoopMixin(ABC):
             and self.num_updates % self.training_config.evaluation_interval != 0
         ):
             # Create a new meter for this case
-            report, meter = self.evaluation_loop(self.val_loader)
+            report, meter = self.evaluation_loop("val")
 
             # Validation end callbacks
             self.on_validation_end(report=report, meter=meter)
@@ -132,7 +132,7 @@ class TrainerTrainingLoopMixin(ABC):
                     logger.info("Evaluation time. Running on full validation set...")
                     # Validation and Early stopping
                     # Create a new meter for this case
-                    report, meter = self.evaluation_loop(self.val_loader)
+                    report, meter = self.evaluation_loop("val")
 
                     # Validation end callbacks
                     stop = self.early_stop_callback.on_validation_end(

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -140,7 +140,5 @@ class MMFTrainer(
             else:
                 self.on_test_start()
                 logger.info(f"Starting inference on {dataset} set")
-                report, meter = self.evaluation_loop(
-                    getattr(self, f"{dataset}_loader"), use_tqdm=True
-                )
+                report, meter = self.evaluation_loop(dataset, use_tqdm=True)
                 self.on_test_end(report=report, meter=meter)


### PR DESCRIPTION
This is the first piece of the PRs for the multimodal multitask transformer merge.

------

Summary
- change the current evaluation loop (that runs on the union of all datasets) to per-dataset evaluation.
- generate prediction JSON object during evaluation loop, which can be consumed by metrics that evaluate the entire dataset (e.g. mAP for object detection or CIDEr for image captioning) and cannot be expressed as averaging over per-batch metrics

Issues
- in the current evaluation, the `total_loss` results will only retain the `total_loss` metric from the last dataset. Shall we give `<dataset_name>/total_loss` instead?