### PR TITLE
[docs] update the terms and concepts doc

### DIFF
--- a/website/docs/notes/concepts.md
+++ b/website/docs/notes/concepts.md
@@ -4,44 +4,35 @@ title: Terminology and Concepts
 sidebar_label: Terminology and Concepts
 ---
 
-**[Outdated]** A new version of this will be uploaded soon
-
 To develop on top of MMF, it is necessary to understand concepts and terminology used in MMF codebase. MMF has been very carefully designed from ground-up to be a multi-tasking framework. This means using MMF you can train on multiple datasets/datasets together.
 
 To achieve this, MMF has few opinions about architecture of your research project. But, being generic means MMF abstracts a lot of concepts in its modules and it would be easy to develop on top of MMF once a developer understands these simple concepts. Major concepts and terminology in MMF that one needs to know in order to develop over MMF are as follows:
 
-- [Tasks and Datasets](#tasks-and-datasets)
+- [Datasets](#datasets)
 - [Models](#models)
 - [Registry](#registry)
 - [Configuration](#configuration)
 - [Processors](#processors)
 - [Sample List](#sample-list)
 
-## Tasks and Datasets
+## Datasets
 
-In MMF, we have divided datasets into a set category of tasks. Thus, a task corresponds to a collection of datasets that belong to it. For example, VQA 2.0, VizWiz and TextVQA all belong VQA task. Each task and dataset has been assigned a unique key which is used to refer it in the command line arguments.
+You can find all the latest datasets [here](https://github.com/facebookresearch/mmf/tree/master/mmf/configs/datasets).
 
-Following table shows the tasks and their datasets:
+The dataset's key is available under the particular dataset's config, ie., for vizwiz's key, you can look in vizwiz's config available [here](https://github.com/facebookresearch/mmf/blob/master/mmf/configs/datasets/vizwiz/defaults.yaml)
 
-|         |            |                                              |
-| ------- | ---------- | -------------------------------------------- |
-| Task    | Key        | Datasets                                     |
-| VQA     | vqa        | VQA2.0, VizWiz, TextVQA, VisualGenome, CLEVR |
-| Dialog  | dialog     | VisualDialog                                 |
-| Caption | captioning | MS COCO                                      |
-
-Following table shows the inverse of the above table, datasets along with their tasks and keys:
-
-|              |               |            |              |
-| ------------ | ------------- | ---------- | ------------ |
-| Datasets     | Key           | Task       | Notes        |
-| VQA 2.0      | vqa2          | vqa        |              |
-| TextVQA      | textvqa       | vqa        |              |
-| VizWiz       | vizwiz        | vqa        |              |
-| VisualDialog | visdial       | dialog     | Coming soon! |
-| VisualGenome | visual_genome | vqa        |              |
-| CLEVR        | clevr         | vqa        |              |
-| MS COCO      | coco          | captioning |              |
+```yaml
+dataset_config:
+  vizwiz: # dataset key
+      data_dir: ${env.data_dir}/datasets
+      depth_first: false
+      fast_read: false
+      use_images: false
+      use_features: true
+      zoo_requirements:
+      - vizwiz.v2019
+      ...
+```
 
 ## Models
 
@@ -49,24 +40,24 @@ Reference implementations for state-of-the-art models have been included to act 
 
 - [Towards VQA Models That Can Read (LoRRA model)](https://arxiv.org/abs/1904.08920)
 - [VQA 2018 Challenge winner](https://arxiv.org/abs/1807.09956)
-- VizWiz 2018 Challenge winner
+- [VizWiz 2018 Challenge winner](https://vizwiz.org/wp-content/uploads/2019/06/workshop2018_slides_FAIR_A-STAR.pdf)
+- [VQA 2020 Challenge winner](https://github.com/facebookresearch/mmf/tree/master/projects/movie_mcan)
 
-Similar to tasks and datasets, each model has been registered with a unique key for easy reference in configuration and command line arguments. Following table shows each model's key name and datasets it can be run on.
+Similar to datasets, each model has been registered with a unique key for easy reference in configuration and command line arguments. For a more complete list of models, please see [here](https://github.com/facebookresearch/mmf/tree/master/mmf/configs/models)
 
-|          |          |                                      |
-| -------- | -------- | ------------------------------------ |
-| Model    | Key      | Datasets                             |
-| LoRRA    | lorra    | vqa2, textvqa, vizwiz                |
-| Pythia   | pythia   | textvqa, vizwiz, vqa2, visual_genome |
-| BAN      | ban      | textvqa, vizwiz, vqa2                |
-| BUTD     | butd     | coco                                 |
-| CNN LSTM | cnn_lstm | clevr                                |
+The model's key is available under the particular model's config, ie., for mmf_transformer, the model's config file is available under [here](https://github.com/facebookresearch/mmf/blob/master/mmf/configs/models/mmf_transformer/defaults.yaml)
 
-:::note
-
-BAN support is preliminary and hasn't been properly fine-tuned yet.
-
-:::
+```yaml
+model_config:
+  mmf_transformer: # model key
+    transformer_base: bert-base-uncased
+    training_head_type: classification
+    backend:
+      type: huggingface
+      freeze: false
+      params: {}
+    ...
+```
 
 ## Registry
 
@@ -85,22 +76,23 @@ Find more details about Registry class in its documentation [common/registry](ht
 
 ## Configuration
 
-As is necessary with research, most of the parameters/settings in MMF are configurable. MMF specific default values (`training`) are present in [mmf/common/defaults/configs/base.yaml](https://github.com/facebookresearch/mmf/blob/v0.3/mmf/common/defaults/configs/base.yaml) with detailed comments delineating the usage of each parameter.
+As is necessary with research, most of the parameters/settings in MMF are configurable. MMF specific default values (`training`) are present in [mmf/configs/defaults.yaml](https://github.com/facebookresearch/mmf/blob/master/mmf/configs/defaults.yaml) with detailed comments delineating the usage of each parameter.
 
-For ease of usage and modularity, configuration for each dataset is kept separately in `mmf/common/defaults/configs/datasets/[task]/[dataset].yaml` where you can get `[task]` value for the dataset from the tables in [Tasks and Datasets](#tasks-and-datasets) section.
+For ease of usage and modularity, configuration for each dataset is kept separately in `mmf/configs/datasets/[dataset]/[variants].yaml` where you can get `[dataset]` value for the dataset from the tables in [Datasets](#datasets) section.
 
-The most dynamic part, model configuration are also kept separate and are the one which need to be defined by the user if they are creating their own models. We include configurations for the models included in the model zoo of MMF. For each model, there is a separate configuration for each dataset it can work on. See an example in [configs/vqa/vqa2/pythia.yaml](https://github.com/facebookresearch/mmf/blob/v0.3/configs/vqa/vqa2/pythia.yaml). The configuration in the configs folder are divided using the scheme `configs/[task]/[dataset]/[model].yaml`.
+The most dynamic part, model configurations are also kept separate and are the ones which need to be defined by the user if they are creating their own models. We include configurations for the models included in the model zoo of MMF. You can find the model configurations [here](https://github.com/facebookresearch/mmf/tree/master/mmf/configs/models)
 
-It is possible to include other configs into your config using `includes` directive. Thus, in MMF config above you can include `vqa2`'s config like this:
 
-```
+It is possible to include other configs into your config using `includes` directive. Thus, in MMF config above you can include `lxmert`'s config like this:
+
+```yaml
 includes:
-- common/defaults/configs/datasets/vqa/vqa2.yaml
+- configs/models/lxmert/defaults.yaml
 ```
 
 Now, due to separate config per dataset this concept can be extended to do multi-tasking and include multiple dataset configs here.
 
-`base.yaml` file mentioned above is always included and provides sane defaults for most of the training parameters. You can then specify the config of the model that you want to train using `--config [config_path]` option. The final config can be retrieved using `registry.get('config')` anywhere in your codebase. You can access the attributes from these configs by using `dot` notation. For e.g. if you want to get the value of maximum iterations, you can get that by `registry.get('config').training.max_updates`.
+`defaults.yaml` file mentioned above is always included and provides sane defaults for most of the training parameters. You can then specify the config of the model that you want to train using `--config [config_path]` option. The final config can be retrieved using `registry.get('config')` anywhere in your codebase. You can access the attributes from these configs by using `dot` notation. For e.g. if you want to get the value of maximum iterations, you can get that by `registry.get('config').training.max_updates`.
 
 The values in the configuration can be overriden using two formats:
 
@@ -119,4 +111,10 @@ The main aim of processors is to keep data processing pipelines as similar as po
 
 ## Sample List
 
-[SampleList](https://mmf.sh/api/lib/common/sample.html#mmf.common.sample.SampleList) has been inspired from BBoxList in maskrcnn-benchmark, but is more generic. All datasets integrated with MMF need to return a [Sample](https://mmf.sh/api/lib/common/sample.html#mmf.common.sample.Sample) which will be collated into `SampleList`. Now, `SampleList` comes with a lot of handy functions which enable easy batching and access of things. For e.g. `Sample` is a dict with some keys. In `SampleList`, values for these keys will be smartly clubbed based on whether it is a tensor or a list and assigned back to that dict. So, end user gets these keys clubbed nicely together and can use them in their model. Models integrated with Pythia receive a `SampleList` as an argument which again makes the trainer unopinionated about the models as well as the datasets. Learn more about `Sample` and `SampleList` in their [documentation](https://mmf.sh/api/lib/common/sample.html).
+[SampleList](https://mmf.sh/api/lib/common/sample.html#mmf.common.sample.SampleList) has been inspired from BBoxList in maskrcnn-benchmark, but is more generic. All datasets integrated with MMF need to return a [Sample](https://mmf.sh/api/lib/common/sample.html#mmf.common.sample.Sample) which will be collated into `SampleList`. Now, `SampleList` comes with a lot of handy functions which enable easy batching and access of things. For e.g. `Sample` is a dict with some keys. In `SampleList`, values for these keys will be smartly clubbed based on whether it is a tensor or a list and assigned back to that dict. So, end user gets these keys clubbed nicely together and can use them in their model. Models integrated with MMF receive a `SampleList` as an argument which again makes the trainer unopinionated about the models as well as the datasets. Learn more about `Sample` and `SampleList` in their [documentation](https://mmf.sh/api/lib/common/sample.html).
+
+:::tip
+
+SampleList is a dict that works as a collator
+
+:::

--- a/website/docs/notes/dataset_zoo.md
+++ b/website/docs/notes/dataset_zoo.md
@@ -4,20 +4,31 @@ title: Dataset Zoo
 sidebar_label: Dataset Zoo
 ---
 
-Here is the current list of datasets currently supported in MMF:
+Here is the list of datasets currently supported in MMF:
 
-- **CLEVR** [Paper : CLEVR A Diagnostic Dataset for Compositional Language and Elementary Visual Reasoning][arxiv](https://arxiv.org/abs/1612.06890)]
-- **COCO Captions** [Paper : Microsoft COCO Captions: Data Collection and Evaluation Server][arxiv](https://arxiv.org/abs/1504.00325)]
-- **Conceptual Captions** [Paper : Conceptual Captions: A Cleaned, Hypernymed, Image Alt-text Dataset For Automatic Image Captioning][website](https://ai.google.com/research/ConceptualCaptions)]
-- **Hateful Memes** [Paper : The Hateful Memes Challenge: Detecting Hate Speech in Multimodal Memes][arxiv](https://arxiv.org/abs/2005.04790)]
-- **MM IMDB** [Paper : Gated Multimodal Units for Information Fusion][arxiv](https://arxiv.org/abs/1702.01992)] [[website](http://lisi1.unal.edu.co/mmimdb)]
-- **NLVR2** [Paper : A Corpus for Reasoning About Natural Language Grounded in Photographs][arxiv](https://arxiv.org/abs/1811.00491)] [[website](http://lil.nlp.cornell.edu/nlvr/)]
-- **OCRVQA** [Paper : OCR-VQA: Visual Question Answering by Reading Text in Images][website](https://ocr-vqa.github.io/)]
-- **STVQA** [Paper : Scene Text Visual Question Answering][arxiv](https://arxiv.org/abs/1905.13648)]
-- **TextVQA** [Paper : Towards VQA Models That Can Read][arxiv](https://arxiv.org/abs/1904.08920)] [[website](https://textvqa.org/)]
-- **TextCaps** [Paper : TextCaps: a Dataset for Image Captioning with Reading Comprehension][arxiv](https://arxiv.org/abs/2003.12462)]
-- **Visual Dialog** [Paper : Visual Dialog][website](https://visualdialog.org/)]
-- **SNLI-VE** [Paper : Visual Entailment: A Novel Task for Fine-Grained Image Understanding][arxiv](https://arxiv.org/abs/1901.06706)] [[website](https://github.com/necla-ml/SNLI-VE)]
-- **Visual Genome** [Paper : Visual Genome: Connecting Language and Vision Using Crowdsourced Dense Image Annotations][arxiv](https://arxiv.org/abs/1602.07332)] [[website](https://visualgenome.org/)]
-- **VizWiZ** [Paper : VizWiz Grand Challenge: Answering Visual Questions from Blind People][arxiv](https://arxiv.org/abs/1802.08218)] [[website](https://vizwiz.org/)]
-- **VQA2.0** [Paper : VQA: Visual Question Answering][arxiv](https://arxiv.org/abs/1505.00468)] [[website](https://visualqa.org/)]
+| Datasets             | Key                  | Notes                                                                                                             |
+| -------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| CLEVR                | clevr                | [website](https://cs.stanford.edu/people/jcjohns/clevr/), [paper](https://arxiv.org/abs/1612.06890)                                                          |
+| MS COCO 2014         | coco                 | coco has other types of data available (ie, detection), mmf only has coco caption dataset implemented, [website](https://cocodataset.org/), [paper](https://arxiv.org/abs/1504.00325)|
+| MS COCO 2017         | coco17               | coco has other types of data available (ie, detection), mmf only has coco caption dataset implemented, [website](https://cocodataset.org/), [paper](https://arxiv.org/abs/1504.00325)|
+| Conceptual Captions  | conceptual_captions  | [github](https://github.com/google-research-datasets/conceptual-captions), [website](https://ai.google.com/research/ConceptualCaptions) |
+| Flickr30k            | flickr30k            | [github](https://github.com/BryanPlummer/flickr30k_entities)                                                     |
+| GQA                  | gqa                  | [website](https://cs.stanford.edu/people/dorarad/gqa/about.html)                                                 |
+| Hateful Memes        | hateful_memes        | [paper](https://arxiv.org/abs/2005.04790)                                                                         |
+| Localized Narratives | localized_narratives | [website](https://google.github.io/localized-narratives/)                                                         |
+| MM IMDB              | mmimdb               | [website](http://lisi1.unal.edu.co/mmimdb/), [paper](https://arxiv.org/abs/1702.01992) |
+| NLVR2                | nlvr2                | [website](http://lil.nlp.cornell.edu/nlvr/), [paper](https://arxiv.org/abs/1811.00491) |
+| OCRVQA               | ocrvqa               | [website](https://ocr-vqa.github.io/)                                                                             |
+| OKVQA                | okvqa                | [website](https://okvqa.allenai.org/)                                                                             |
+| SBU Captions         | masked_sbu           | [website](http://www.cs.virginia.edu/~vicente/sbucaptions/)                                                       |
+| Scene Text VQA       | stvqa                | [paper](https://arxiv.org/abs/1905.13648)                                   |
+| Text Caps            | text_caps            | [website](https://textvqa.org/textcaps)                                                                           |
+| TextVQA              | textvqa              | [website](https://textvqa.org/)                                                                                   |
+| VisualDialog         | visdial              | [website](https://visualdialog.org/)                                                                              |
+| Visual Genome        | visual_genome        | [website](https://visualgenome.org/), [paper](https://arxiv.org/abs/1602.07332) |
+| SNLI-VE              | visual_entailment    | [github](https://github.com/necla-ml/SNLI-VE), [paper](https://arxiv.org/abs/1901.06706) |
+| VizWiz               | vizwiz               | [website](https://vizwiz.org/), [paper](https://arxiv.org/abs/1802.08218) |
+| VQA 2.0              | vqa2                 | [website](https://visualqa.org/), [paper](https://arxiv.org/abs/1505.00468)        |
+| VQA CP V2            | vqacp_v2             | [paper](https://arxiv.org/pdf/1712.00377.pdf)|
+
+We are adding many more new datasets which will be available soon.

--- a/website/docs/notes/model_zoo.md
+++ b/website/docs/notes/model_zoo.md
@@ -4,18 +4,24 @@ title: Model Zoo
 sidebar_label: Model Zoo
 ---
 
-Here is the current list of models currently implemented in MMF:
+Here is the list of models currently implemented in MMF:
 
-- **M4C** Iterative Answer Prediction with Pointer-Augmented Multimodal Transformers for TextVQA [[arXiv](https://arxiv.org/abs/1911.06258)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/m4c)]
-- **ViLBERT** ViLBERT: Pretraining Task-Agnostic Visiolinguistic Representations for Vision-and-Language Tasks [[arXiv](https://arxiv.org/abs/1908.02265)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/vilbert)]
-- **VisualBert** Visualbert: A simple and performant baseline for vision and language [[arXiv](https://arxiv.org/abs/1908.03557)] [[project](https://arxiv.org/abs/1908.03557)]
-- **LoRRA** Towards VQA Models That Can Read [[arXiv](https://arxiv.org/abs/1904.08920)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/lorra)]
-- **M4C Captioner** TextCaps: a Dataset for Image Captioning with Reading Comprehension [[arXiv](https://arxiv.org/abs/2003.12462)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/m4c_captioner)]
-- **LXMERT** LXMERT: Learning Cross-Modality Encoder Representations from Transformers [[arXiv](https://arxiv.org/abs/1908.07490)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/lxmert)]
-- **Pythia** Pythia v0. 1: the winning entry to the vqa challenge 2018 [[arXiv](https://arxiv.org/abs/1807.09956)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/pythia)]
-- **BUTD** Bottom-up and top-down attention for image captioning and visual question answering [[arXiv](https://arxiv.org/abs/1707.07998)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/butd)]
-- **MMBT** Supervised Multimodal Bitransformers for Classifying Images and Text [[arXiv](https://arxiv.org/abs/1909.02950)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/mmbt)]
-- **MoViE** Revisiting Modulated Convolutions for Visual Counting and Beyond [[arXiv](https://arxiv.org/abs/2004.11883)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/movie_mcan)]
-- **BAN** Bilinear Attention Networks [[arXiv](https://arxiv.org/abs/1805.07932)] [[project](https://github.com/facebookresearch/mmf/tree/master/projects/ban)]
+| Model           | Key                                  | Datasets                                 | Notes
+| --------------- | ------------------------------------ | ---------------------------------------- | ----------------------------------------------------------- |
+| BAN             | ban                                  | textvqa, vizwiz, vqa2                    | [BAN](https://arxiv.org/abs/1805.07932) support is preliminary and hasn't been properly fine-tuned yet. |
+| BUTD            | butd                                 | coco                                     | [paper](https://arxiv.org/abs/1707.07998)                   |
+| CNN LSTM        | cnn_lstm                             | clevr                                    |                                                             |
+| FUSIONS         | concat_bert, late_fusion, concat_bow | hateful_memes                            |                                                             |
+| LoRRA           | lorra                                | vqa2, textvqa, vizwiz                    | [paper](https://arxiv.org/abs/1904.08920)                   |
+| LXMERT          | lxmert                               | coco, gqa, visual_genome, vqa2           | [paper](https://arxiv.org/abs/1908.07490)                   |
+| M4C             | m4c                                  | ocrvqa, stvqa, textvqa                   | [paper](https://arxiv.org/pdf/1911.06258.pdf)               |
+| M4C Captioner   | m4c_captioner                        | coco, textcaps                           | [paper](https://arxiv.org/pdf/2003.12462.pdf)               |
+| MMBT            | mmbt                                 | hateful_memes, coco, mmimdb, okvqa, vqa2 | [paper](https://arxiv.org/abs/1909.02950)                   |
+| MMF Transformer | mmf_transformer                      | hateful_memes, okvqa, vqa2               |                                                             |
+| Movie MCAN      | movie_mcan                           | vqa2                                     | [paper](https://arxiv.org/abs/2004.11883)                   |
+| Pythia          | pythia                               | textvqa, vizwiz, vqa2, visual_genome     | [paper](https://arxiv.org/abs/1904.08920)                   |
+| Unimodal        | unimodal                             | hateful_memes                            |                                                             |
+| VilBERT         | vilbert                              | hateful_memes, coco, conceptual_captions, vqa2, mmimdb, nlvr2, visual_entailment, vizwiz, vqa2 |[paper](https://arxiv.org/abs/1908.02265)|
+| Visual BERT     | visual_bert                          | gqa, hateful_memes, localized_narratives, coco, conceptual_captions, sbu, vqa2, mmimdb, nlvr2, visual_entailment, vizwiz|[paper](https://arxiv.org/abs/1908.03557)|
 
-In addition to the above MMF also has implementations of models ConcatBERT, ConcatBOW, LateFusion, Unimodal Text, Unimodal Image, VisDial, MMFBERT etc. We are adding many more new models which will be available soon.
+We are adding many more new models which will be available soon.


### PR DESCRIPTION
* Updated the terms of concepts to include the latest models and datasets
* Fixed the links in this page
* Renamed pythia to mmf
* Added links to those models/datasets