### PR TITLE
[WIP][feat] Per dataset evaluation loop and metric; detection datasets; UniT model

### DIFF
--- a/mmf/common/batch_collator.py
+++ b/mmf/common/batch_collator.py
@@ -21,7 +21,7 @@ class BatchCollator:
         ):
             sample_list = batch[0]
         elif not isinstance(batch, SampleList):
-            sample_list = SampleList(batch)
+            sample_list = _build_sample_list_with_detr_fields(batch)
 
         if sample_list._get_tensor_field() is None:
             sample_list = SampleList(sample_list.to_dict())
@@ -29,3 +29,22 @@ class BatchCollator:
         sample_list.dataset_name = self._dataset_name
         sample_list.dataset_type = self._dataset_type
         return sample_list
+
+
+def _build_sample_list_with_detr_fields(batch):
+    # handle 'detr_img' and 'detr_target' from detection datasets and
+    # collating images of different sizes into a NestedTensor
+    from mmf.modules.detr.util.misc import NestedTensor
+
+    detr_img_list = None
+    if "detr_img" in batch[0]:
+        detr_img_list = [sample.pop("detr_img") for sample in batch]
+    detr_target = None
+    if "detr_target" in batch[0]:
+        detr_target = [sample.pop("detr_target") for sample in batch]
+    sample_list = SampleList(batch)
+    if detr_img_list is not None:
+        sample_list.detr_img = NestedTensor.from_tensor_list(detr_img_list)
+    if detr_target is not None:
+        sample_list.detr_target = detr_target
+    return sample_list

--- a/mmf/configs/datasets/coco/detection.yaml
+++ b/mmf/configs/datasets/coco/detection.yaml
@@ -1,0 +1,18 @@
+dataset_config:
+  detection_coco:
+    data_dir: ${env.data_dir}/datasets
+    images:
+      train: 
+      - /datasets01/COCO/022719/train2017
+      val:
+      - /datasets01/COCO/022719/val2017
+      test:
+      - /datasets01/COCO/022719/test2017
+    annotations:
+      train:
+      - coco/detection/annotations/instances_train2017.json
+      val:
+      - coco/detection/annotations/instances_val2017.json
+      test:
+      - coco/detection/annotations/image_info_test-dev2017.json
+    load_attributes: false  # COCO has no attribute annotations

--- a/mmf/configs/datasets/visual_genome/detection.yaml
+++ b/mmf/configs/datasets/visual_genome/detection.yaml
@@ -1,0 +1,18 @@
+dataset_config:
+  detection_visual_genome:
+    data_dir: ${env.data_dir}/datasets
+    images:
+      train: 
+      - /datasets01/VisualGenome1.2/061517/VG_100K_all/
+      val:
+      - /datasets01/VisualGenome1.2/061517/VG_100K_all/
+      test:
+      - /datasets01/VisualGenome1.2/061517/VG_100K_all/
+    annotations:
+      train:
+      - visual_genome/detection/annotations/instances_train_split_wrt_coco2017.json
+      val:
+      - visual_genome/detection/annotations/instances_val_split_wrt_coco2017.json
+      test:
+      - visual_genome/detection/annotations/instances_val_split_wrt_coco2017.json
+    load_attributes: true  # Visual Genome has attribute annotations

--- a/mmf/configs/models/unit/defaults.yaml
+++ b/mmf/configs/models/unit/defaults.yaml
@@ -1,0 +1,105 @@
+model_config:
+  unit:
+    detr_ckpt_path: ''  # the initial DETR parameters to start from (this should be a checkpoint file trained w/ DETR package)
+    detr_ckpt_load_backbone_only: false
+    detection_loss_weight: 1.
+
+    keep_only_bert_cls:
+      # whether to keep only the [CLS] token's hidden states in transformer
+      vl:
+        vqa2: false
+        hateful_memes: true
+        visual_entailment: true
+      glue:
+        glue_qnli: true
+        glue_sst2: true
+        glue_mnli_mismatched: true
+        glue_qqp: true
+
+    loss_on_all_hs:
+      vl:
+        vqa2: false
+        hateful_memes: false
+        visual_entailment: false
+      glue:
+        glue_qnli: false
+        glue_sst2: false
+        glue_mnli_mismatched: false
+        glue_qqp: false
+
+    detr_args:
+      lr_backbone: 1e-5
+      backbone: resnet50
+      dilation: false
+      position_embedding: sine
+      enc_layers: 6
+      dec_layers: 6
+      dim_feedforward: 2048
+      encoder_hidden_dim: 256
+      dropout: 0.1
+      nheads: 8
+      # Override the config
+      pre_norm: false
+      pass_pos_and_query: true
+      # detection losses
+      mask_model: none
+      masks: false
+      aux_loss: true
+      set_loss: hungarian
+      use_bcl: false
+      set_cost_class: 1.
+      set_cost_bbox: 5.
+      set_cost_giou: 2.
+      mask_loss_coef: 1.
+      dice_loss_coef: 1.
+      bbox_loss_coef: 5.
+      giou_loss_coef: 2.
+      attr_loss_coef: 1.
+      eos_coef: 0.1
+      # separate dimensionality for decoder
+      decoder_hidden_dim: 256
+      num_queries: {}
+      share_decoders: false
+      residual_in_encoder: true
+      use_task_embedding_in_encoder: false
+      use_task_embedding_in_decoder: false
+      use_task_embedding_in_lang_encoder: false
+
+    datasets:
+      detection:
+        detection_coco:
+          task_idx: 0
+          num_classes: 91
+          use_attr: false
+        detection_visual_genome:
+          task_idx: 1
+          num_classes: 1601
+          use_attr: true
+        detection_lvis:
+          task_idx: 2
+          num_classes: 1235
+          use_attr: false
+      vl:
+        vqa2:
+          task_idx: 3
+          num_labels: 3129
+        hateful_memes:
+          task_idx: 4
+          num_labels: 2
+        visual_entailment:
+          task_idx: 9
+          num_labels: 3
+      glue:
+        glue_qnli:
+          task_idx: 5
+          num_labels: 2
+        glue_mnli_mismatched:
+          task_idx: 6
+          num_labels: 3
+        glue_sst2:
+          task_idx: 7
+          num_labels: 2
+        glue_qqp:
+          task_idx: 8
+          num_labels: 2
+    max_task_num: 256

--- a/mmf/datasets/builders/coco/detection_builder.py
+++ b/mmf/datasets/builders/coco/detection_builder.py
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+from .detection_dataset import DetectionCOCODataset
+
+
+@registry.register_builder("detection_coco")
+class DetectionCOCOBuilder(MMFDatasetBuilder):
+    def __init__(self):
+        super().__init__(
+            dataset_name="detection_coco", dataset_class=DetectionCOCODataset
+        )
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/coco/detection.yaml"
+
+    def update_registry_for_model(self, config):
+        pass

--- a/mmf/datasets/builders/coco/detection_dataset.py
+++ b/mmf/datasets/builders/coco/detection_dataset.py
@@ -1,13 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
+
 import torch
 import torch.nn.functional as F
-from torch import nn
 import torchvision
-
 from mmf.common.sample import Sample
 from mmf.datasets.base_dataset import BaseDataset
 from mmf.modules.detr.datasets.coco import ConvertCocoPolysToMask, make_coco_transforms
+from torch import nn
 
 
 class DetectionCOCODataset(BaseDataset):

--- a/mmf/datasets/builders/coco/detection_dataset.py
+++ b/mmf/datasets/builders/coco/detection_dataset.py
@@ -1,0 +1,147 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import os
+import torch
+import torch.nn.functional as F
+from torch import nn
+import torchvision
+
+from mmf.common.sample import Sample
+from mmf.datasets.base_dataset import BaseDataset
+from mmf.modules.detr.datasets.coco import ConvertCocoPolysToMask, make_coco_transforms
+
+
+class DetectionCOCODataset(BaseDataset):
+    def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
+        name = "detection_coco"
+        super().__init__(name, config, dataset_type, *args, **kwargs)
+        self.dataset_name = name
+
+        self.image_dir = self.config.images[self._dataset_type][imdb_file_index]
+        coco_json = self.config.annotations[self._dataset_type][imdb_file_index]
+        self.coco_json = os.path.join(self.config.data_dir, coco_json)
+
+        self.coco_dataset = torchvision.datasets.CocoDetection(
+            self.image_dir, self.coco_json
+        )
+
+        self.prepare = ConvertCocoPolysToMask()
+        # for the test set, use the same transform as val
+        self.transform = make_coco_transforms(
+            "train" if self._dataset_type == "train" else "val"
+        )
+        self.load_attributes = self.config.load_attributes
+        self.postprocessors = {"bbox": PostProcess()}
+
+    def __getitem__(self, idx):
+        img, target = self.coco_dataset[idx]
+        image_id = self.coco_dataset.ids[idx]
+        target = {"image_id": image_id, "annotations": target}
+        img, target = self.prepare(img, target, load_attributes=self.load_attributes)
+        img, target = self.transform(img, target)
+
+        current_sample = Sample()
+        current_sample.image_id = torch.tensor(image_id, dtype=torch.long)
+        current_sample.detr_img = img
+        current_sample.detr_target = target
+        current_sample.orig_size = target["orig_size"].clone().detach()
+
+        return current_sample
+
+    def __len__(self):
+        return len(self.coco_dataset)
+
+    def prepare_batch(self, batch):
+        batch = super().prepare_batch(batch)
+        # batch.detr_target is a list and won't be sent to GPU automatically
+        # so we manually send it to GPU here
+        batch.detr_target = [
+            {k: v.to(self._device) for k, v in t.items()} for t in batch.detr_target
+        ]
+        return batch
+
+    def format_for_prediction(self, report):
+        outputs = {"pred_logits": report.pred_logits, "pred_boxes": report.pred_boxes}
+
+        image_ids = report.image_id.tolist()
+        results = self.postprocessors["bbox"](outputs, report.orig_size)
+
+        predictions = []
+        for image_id, r in zip(image_ids, results):
+            scores = r["scores"].tolist()
+            labels = r["labels"].tolist()
+            boxes_xywh = convert_to_xywh(r["boxes"]).tolist()
+
+            # group the boxes by image_id for image-level de-duplication
+            # (duplication is introduced by DistributedSampler)
+            predictions.append(
+                (
+                    image_id,
+                    [
+                        {
+                            "image_id": image_id,
+                            "category_id": labels[k],
+                            "bbox": box_xywh,
+                            "score": scores[k],
+                        }
+                        for k, box_xywh in enumerate(boxes_xywh)
+                    ],
+                )
+            )
+
+        return predictions
+
+    def on_prediction_end(self, predictions):
+        # de-duplicate the predictions (duplication is introduced by DistributedSampler)
+        prediction_dict = {image_id: entries for image_id, entries in predictions}
+
+        unique_entries = []
+        for image_id in sorted(prediction_dict):
+            unique_entries.extend(prediction_dict[image_id])
+
+        return unique_entries
+
+
+class PostProcess(nn.Module):
+    """This module converts the model's output into the format expected by the
+    coco api
+    """
+
+    @torch.no_grad()
+    def forward(self, outputs, target_sizes):
+        """ Perform the computation
+        Parameters:
+            outputs: raw outputs of the model
+            target_sizes: tensor of dimension [batch_size x 2] containing the size of
+                          each images of the batch For evaluation, this must be the
+                          original image size (before any data augmentation). For
+                          visualization, this should be the image size after data
+                          augment, but before padding.
+        """
+        out_logits, out_bbox = outputs["pred_logits"], outputs["pred_boxes"]
+
+        assert len(out_logits) == len(target_sizes)
+        assert target_sizes.shape[1] == 2
+
+        prob = F.softmax(out_logits, -1)
+        scores, labels = prob[..., :-1].max(-1)
+
+        # convert to [x0, y0, x1, y1] format
+        from mmf.modules.detr.util.box_ops import box_cxcywh_to_xyxy
+
+        boxes = box_cxcywh_to_xyxy(out_bbox)
+        # and from relative [0, 1] to absolute [0, height] coordinates
+        img_h, img_w = target_sizes.unbind(1)
+        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)
+        boxes = boxes * scale_fct[:, None, :]
+
+        results = [
+            {"scores": s, "labels": l, "boxes": b}
+            for s, l, b in zip(scores, labels, boxes)
+        ]
+
+        return results
+
+
+def convert_to_xywh(boxes):
+    xmin, ymin, xmax, ymax = boxes.unbind(1)
+    return torch.stack((xmin, ymin, xmax - xmin, ymax - ymin), dim=1)

--- a/mmf/datasets/builders/visual_genome/detection_builder.py
+++ b/mmf/datasets/builders/visual_genome/detection_builder.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+from .detection_dataset import DetectionVisualGenomeDataset
+
+
+@registry.register_builder("detection_visual_genome")
+class DetectionVisualGenomeBuilder(MMFDatasetBuilder):
+    def __init__(self):
+        super().__init__(
+            dataset_name="detection_visual_genome",
+            dataset_class=DetectionVisualGenomeDataset,
+        )
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/visual_genome/detection.yaml"
+
+    def update_registry_for_model(self, config):
+        pass

--- a/mmf/datasets/builders/visual_genome/detection_dataset.py
+++ b/mmf/datasets/builders/visual_genome/detection_dataset.py
@@ -1,0 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.datasets.builders.coco.detection_dataset import DetectionCOCODataset
+
+
+class DetectionVisualGenomeDataset(DetectionCOCODataset):
+    def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
+        super().__init__(config, dataset_type, imdb_file_index, *args, **kwargs)
+        self.dataset_name = "detection_visual_genome"

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -463,9 +463,8 @@ class FastTextProcessor(VocabProcessor):
             return model_file_path
 
         import requests
-        from tqdm import tqdm
-
         from mmf.common.constants import FASTTEXT_WIKI_URL
+        from tqdm import tqdm
 
         PathManager.mkdirs(os.path.dirname(model_file_path))
         response = requests.get(FASTTEXT_WIKI_URL, stream=True)

--- a/mmf/models/unit.py
+++ b/mmf/models/unit.py
@@ -6,18 +6,18 @@ import logging
 from copy import deepcopy
 
 import torch
-from torch import nn
-
-from transformers.modeling_bert import BertPredictionHeadTransform
 from mmf.common.registry import registry
 from mmf.models import BaseModel
-from mmf.modules.encoders import TransformerEncoder
 from mmf.modules.detr.models.detr import (
-    build as build_model,
-    build_detection_loss,
     MLP,
     AttributeHead,
+    build as build_model,
+    build_detection_loss,
 )
+from mmf.modules.encoders import TransformerEncoder
+from torch import nn
+from transformers.modeling_bert import BertPredictionHeadTransform
+
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class UniT(BaseModel):
         token_type_ids = sample_list.segment_ids
         device = input_ids.device
 
-        position_ids = torch.arange(input_ids.size(1), dtype=torch.long, device=device,)
+        position_ids = torch.arange(input_ids.size(1), dtype=torch.long, device=device)
 
         input_shape = input_ids.size()
 

--- a/mmf/models/unit.py
+++ b/mmf/models/unit.py
@@ -1,0 +1,335 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# Initial version was taken from https://github.com/uclanlp/visualbert
+# which was cleaned up and adapted for MMF.
+
+import logging
+from copy import deepcopy
+
+import torch
+from torch import nn
+
+from transformers.modeling_bert import BertPredictionHeadTransform
+from mmf.common.registry import registry
+from mmf.models import BaseModel
+from mmf.modules.encoders import TransformerEncoder
+from mmf.modules.detr.models.detr import (
+    build as build_model,
+    build_detection_loss,
+    MLP,
+    AttributeHead,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@registry.register_model("unit")
+class UniT(BaseModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.config = config
+
+    @classmethod
+    def config_path(cls):
+        return "configs/models/unit/defaults.yaml"
+
+    def build(self):
+        # build the image encoder (DETR)
+        self.detr_model = build_model(self.config.detr_args)
+
+        def keep_only_backbone_params(model_state_dict):
+            keys = list(model_state_dict.keys())
+            for k in keys:
+                if "backbone" not in k:
+                    model_state_dict.pop(k)
+
+        ckpt_path = self.config.detr_ckpt_path
+        if ckpt_path != "":
+            logger.info("initializing DETR from {}".format(ckpt_path))
+            if ckpt_path.startswith("https"):
+                detr_checkpoint = torch.hub.load_state_dict_from_url(
+                    ckpt_path, check_hash=True
+                )
+            else:
+                detr_checkpoint = torch.load(ckpt_path)
+            if self.config.detr_ckpt_load_backbone_only:
+                keep_only_backbone_params(detr_checkpoint["model"])
+                self.detr_model.load_state_dict(detr_checkpoint["model"], strict=False)
+            else:
+                self.detr_model.load_state_dict(detr_checkpoint["model"], strict=True)
+        else:
+            logger.info("initializing DETR from scratch")
+
+        # build the text encoder (BERT)
+        self.bert_model = TransformerEncoder(self.config.bert_config)
+        detr_hidden_dim = self.config.detr_args.decoder_hidden_dim
+        bert_config = deepcopy(self.bert_model.config)
+        self.bert_projection = nn.Linear(bert_config.hidden_size, detr_hidden_dim)
+        self.bert_pos_projection = nn.Linear(bert_config.hidden_size, detr_hidden_dim)
+
+        self.classifiers = nn.ModuleDict()
+
+        self.task_embeddings_lang = nn.Identity()
+        if self.config.detr_args.use_task_embedding_in_lang_encoder:
+            self.task_embeddings_lang = nn.Embedding(
+                self.config.max_task_num, bert_config.hidden_size
+            )
+
+        bert_config.hidden_size = detr_hidden_dim
+
+        # build the task-specific output heads
+        self.class_embeds = nn.ModuleDict()
+        self.bbox_embeds = nn.ModuleDict()
+        self.det_losses = nn.ModuleDict()
+        for dataset_name in self.config.detr_args.num_queries.get("detection", []):
+            num_cls = self.config.datasets["detection"][dataset_name]["num_classes"]
+            self.class_embeds[dataset_name] = nn.Linear(detr_hidden_dim, num_cls + 1)
+            self.bbox_embeds[dataset_name] = MLP(detr_hidden_dim, detr_hidden_dim, 4, 3)
+            attr_head = None
+            if self.config.datasets["detection"][dataset_name]["use_attr"]:
+                attr_head = AttributeHead(num_cls, detr_hidden_dim)
+            self.det_losses[dataset_name] = build_detection_loss(
+                self.config.detr_args, num_cls, attr_head
+            )
+
+        vl_classifiers = nn.ModuleDict()
+        for dataset_name in self.config.detr_args.num_queries.get("vl", []):
+            vl_classifiers[dataset_name] = nn.Sequential(
+                BertPredictionHeadTransform(bert_config),
+                nn.Linear(
+                    bert_config.hidden_size,
+                    self.config.datasets["vl"][dataset_name]["num_labels"],
+                ),
+            )
+
+        self.classifiers["vl"] = vl_classifiers
+        self.dropout = nn.Dropout(bert_config.hidden_dropout_prob)
+
+        glue_classifiers = nn.ModuleDict()
+        for dataset_name in self.config.detr_args.num_queries.get("glue", []):
+            glue_classifiers[dataset_name] = nn.Sequential(
+                BertPredictionHeadTransform(bert_config),
+                nn.Linear(
+                    bert_config.hidden_size,
+                    self.config.datasets["glue"][dataset_name]["num_labels"],
+                ),
+            )
+
+        self.classifiers["glue"] = glue_classifiers
+
+        self.loss_calculation_fn = {}
+        self.loss_calculation_fn["detection"] = self.detection_loss_calculation
+        self.loss_calculation_fn["vl"] = self.classifier_loss_calculation
+        self.loss_calculation_fn["glue"] = self.classifier_loss_calculation
+
+        self.losses_dict = {
+            "vl": {
+                "vqa2": nn.BCEWithLogitsLoss(reduction="mean"),
+                "hateful_memes": nn.functional.cross_entropy,
+                "visual_entailment": nn.functional.cross_entropy,
+            },
+            "glue": {
+                "glue_qnli": nn.functional.cross_entropy,
+                "glue_qqp": nn.functional.cross_entropy,
+                "glue_mnli_mismatched": nn.functional.cross_entropy,
+                "glue_sst2": nn.functional.cross_entropy,
+            },
+        }
+
+    def forward_bert_with_task_idx(self, sample_list):
+        bert = self.bert_model.module
+        input_ids = sample_list.input_ids
+        attention_mask = sample_list.input_mask
+        token_type_ids = sample_list.segment_ids
+        device = input_ids.device
+
+        position_ids = torch.arange(input_ids.size(1), dtype=torch.long, device=device,)
+
+        input_shape = input_ids.size()
+
+        if attention_mask is None:
+            attention_mask = torch.ones(input_shape, device=device)
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+        embedding_output = bert.embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+        )
+
+        start_idx = 0
+        if self.config.detr_args.use_task_embedding_in_lang_encoder:
+            bs = input_ids.size(0)
+            task_idx = self.get_task_idx(sample_list.dataset_name)
+            task_embed = self.task_embeddings_lang.weight[task_idx]
+            task_embed = task_embed.unsqueeze(0).unsqueeze(0).repeat(bs, 1, 1)
+            embedding_output = torch.cat([task_embed, embedding_output], dim=1)
+            task_attention_mask = embedding_output.new_ones((bs, 1))
+            attention_mask = torch.cat([task_attention_mask, attention_mask], dim=1)
+            start_idx = 1
+
+        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_attention_mask = extended_attention_mask.to(
+            dtype=next(self.parameters()).dtype
+        )  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+        head_mask = [None for _ in range(bert.config.num_hidden_layers)]
+        encoder_outputs = bert.encoder(
+            embedding_output,
+            attention_mask=extended_attention_mask,
+            head_mask=head_mask,
+        )
+        sequence_output = encoder_outputs[0][:, start_idx:, :]
+        pos_embeddings = self.bert_model.embeddings.position_embeddings(position_ids)
+
+        return sequence_output, pos_embeddings
+
+    def forward(self, sample_list):
+        detr_outputs = {}
+        task_type = self.get_task_type(sample_list.dataset_name)
+        text_src = None
+        text_mask = None
+        text_pos = None
+        img_src = None
+        if task_type == "vl" or task_type == "glue":
+            if task_type == "vl":
+                img_src = sample_list.detr_img
+            text_src, pos_embeddings = self.forward_bert_with_task_idx(sample_list)
+            # 768 -> 256
+            text_src = self.bert_projection(text_src)
+            text_pos = self.bert_pos_projection(pos_embeddings)
+
+            text_mask = sample_list.input_mask
+            if self.config.keep_only_bert_cls[task_type][sample_list.dataset_name]:
+                # take only the [CLS] token's hidden state
+                text_src = text_src[:, 0:1, :]
+                text_pos = text_pos[0:1, :]
+                text_mask = text_mask[:, 0:1]
+        elif task_type == "detection":
+            img_src = sample_list.detr_img
+
+        detr_outputs = self.detr_model(
+            img_src=img_src,
+            text_src=text_src,
+            text_mask=text_mask,
+            text_pos=text_pos,
+            task_type=task_type,
+            dataset_name=sample_list.dataset_name,
+            task_idx=self.get_task_idx(sample_list.dataset_name),
+        )
+
+        output = self.loss_calculation_fn[task_type](detr_outputs, sample_list)
+        return output
+
+    def detection_loss_calculation(self, detr_outputs, sample_list):
+        hs = detr_outputs["hidden_states"]
+
+        outputs_class = self.class_embeds[sample_list.dataset_name](hs)
+        outputs_coord = self.bbox_embeds[sample_list.dataset_name](hs).sigmoid()
+        detr_outputs.update(
+            {
+                "pred_logits": outputs_class[-1],
+                "pred_boxes": outputs_coord[-1],
+                "hs_for_attr": hs[-1],
+            }
+        )
+        if self.config.detr_args.aux_loss:
+            detr_outputs["aux_outputs"] = [
+                {"pred_logits": a, "pred_boxes": b, "hs_for_attr": c}
+                for a, b, c in zip(outputs_class[:-1], outputs_coord[:-1], hs[:-1])
+            ]
+
+        criterion = self.det_losses[sample_list.dataset_name]
+        loss_dict = criterion(detr_outputs, sample_list.detr_target)
+        weight_dict = criterion.weight_dict
+        losses = {
+            f"{sample_list.dataset_type}/{sample_list.dataset_name}/{k}": loss_dict[k]
+            * weight_dict[k]
+            * self.config.detection_loss_weight
+            for k in loss_dict.keys()
+            if k in weight_dict
+        }
+        detr_outputs["losses"] = losses
+        # detr_outputs["targets"] = []  # dummy output for VQA accuracy gathering
+        # detr_outputs["scores"] = []  # dummy output for VQA accuracy gathering
+        return detr_outputs
+
+    def classifier_loss_calculation(self, detr_outputs, sample_list):
+        task_type = self.get_task_type(sample_list.dataset_name)
+        hs = detr_outputs["hidden_states"]
+        if not self.config.loss_on_all_hs[task_type][sample_list.dataset_name]:
+            hs = detr_outputs["hidden_states"][-1:]
+        num_queries = self.config.detr_args.num_queries[task_type][
+            sample_list.dataset_name
+        ]
+        assert hs[0].size(1) == num_queries
+        losses = {}
+        scores = None
+        detr_outputs = {}
+        num_labels = self.config.datasets[task_type][sample_list.dataset_name][
+            "num_labels"
+        ]
+
+        for idx, current_hs in enumerate(hs):
+            pooled_output = hs[idx][:, -num_queries, :]
+            pooled_output = self.dropout(pooled_output)
+            logits = self.classifiers[task_type][sample_list.dataset_name](
+                pooled_output
+            )
+            reshaped_logits = logits.contiguous().view(-1, num_labels)
+            scores = reshaped_logits
+            key = f"{sample_list.dataset_type}/{sample_list.dataset_name}/loss_{idx}"
+            loss = self.losses_dict[task_type][sample_list.dataset_name](
+                scores, sample_list.targets
+            )
+            if sample_list.dataset_name == "vqa2":
+                loss *= sample_list.targets.size(1)
+            losses[key] = loss
+
+        detr_outputs["scores"] = scores
+        detr_outputs["losses"] = losses
+        return detr_outputs
+
+    def get_optimizer_parameters(self, config):
+        detr_params = [
+            {
+                "params": [
+                    p
+                    for n, p in self.detr_model.named_parameters()
+                    if "backbone" not in n and p.requires_grad
+                ]
+            },
+            {
+                "params": [
+                    p
+                    for n, p in self.detr_model.named_parameters()
+                    if "backbone" in n and p.requires_grad
+                ],
+                "lr": self.config.detr_args.lr_backbone,
+            },
+        ]
+
+        vqa_params = [
+            {"params": self.bert_model.parameters()},
+            {"params": self.bert_projection.parameters()},
+            {"params": self.task_embeddings_lang.parameters()},
+            {"params": self.bert_pos_projection.parameters()},
+            {"params": self.classifiers.parameters()},
+            {"params": self.class_embeds.parameters()},
+            {"params": self.bbox_embeds.parameters()},
+            {"params": self.det_losses.parameters()},
+        ]
+        return vqa_params + detr_params
+
+    def get_task_idx(self, dataset_name):
+        task_type = self.get_task_type(dataset_name)
+        assert task_type in self.config.datasets
+        return self.config.datasets[task_type][dataset_name]["task_idx"]
+
+    def get_task_type(self, dataset_name):
+        task_type = "detection"
+        if dataset_name in self.config.datasets["vl"]:
+            task_type = "vl"
+        elif dataset_name in self.config.datasets["glue"]:
+            task_type = "glue"
+        return task_type

--- a/mmf/modules/detr/__init__.py
+++ b/mmf/modules/detr/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/mmf/modules/detr/datasets/__init__.py
+++ b/mmf/modules/detr/datasets/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/mmf/modules/detr/datasets/coco.py
+++ b/mmf/modules/detr/datasets/coco.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import torch
 import torch.utils.data
 import torchvision
+
 from pycocotools import mask as coco_mask
 
 from . import transforms as T
@@ -165,7 +166,7 @@ def make_coco_transforms(image_set):
         )
 
     if image_set == "val":
-        return T.Compose([T.RandomResize([800], max_size=1333), normalize,])
+        return T.Compose([T.RandomResize([800], max_size=1333), normalize])
 
     raise ValueError(f"unknown {image_set}")
 

--- a/mmf/modules/detr/datasets/coco.py
+++ b/mmf/modules/detr/datasets/coco.py
@@ -1,0 +1,189 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/datasets/coco.py
+from pathlib import Path
+
+import torch
+import torch.utils.data
+import torchvision
+from pycocotools import mask as coco_mask
+
+from . import transforms as T
+
+
+class CocoDetection(torchvision.datasets.CocoDetection):
+    def __init__(self, img_folder, ann_file, transforms, return_masks):
+        super(CocoDetection, self).__init__(img_folder, ann_file)
+        self._transforms = transforms
+        self.prepare = ConvertCocoPolysToMask(return_masks)
+
+    def __getitem__(self, idx):
+        img, target = super(CocoDetection, self).__getitem__(idx)
+        image_id = self.ids[idx]
+        target = {"image_id": image_id, "annotations": target}
+        img, target = self.prepare(img, target)
+        if self._transforms is not None:
+            img, target = self._transforms(img, target)
+        return img, target
+
+
+def convert_coco_poly_to_mask(segmentations, height, width):
+    masks = []
+    for polygons in segmentations:
+        rles = coco_mask.frPyObjects(polygons, height, width)
+        mask = coco_mask.decode(rles)
+        if len(mask.shape) < 3:
+            mask = mask[..., None]
+        mask = torch.as_tensor(mask, dtype=torch.uint8)
+        mask = mask.any(dim=2)
+        masks.append(mask)
+    if masks:
+        masks = torch.stack(masks, dim=0)
+    else:
+        masks = torch.zeros((0, height, width), dtype=torch.uint8)
+    return masks
+
+
+class ConvertCocoPolysToMask(object):
+    def __init__(self, return_masks=False):
+        self.return_masks = return_masks
+
+    def __call__(self, image, target, load_attributes=False):
+        w, h = image.size
+
+        image_id = target["image_id"]
+        image_id = torch.tensor([image_id])
+
+        anno = target["annotations"]
+
+        anno = [obj for obj in anno if "iscrowd" not in obj or obj["iscrowd"] == 0]
+
+        boxes = [obj["bbox"] for obj in anno]
+        # guard against no boxes via resizing
+        boxes = torch.as_tensor(boxes, dtype=torch.float32).reshape(-1, 4)
+        boxes[:, 2:] += boxes[:, :2]
+        boxes[:, 0::2].clamp_(min=0, max=w)
+        boxes[:, 1::2].clamp_(min=0, max=h)
+
+        classes = [obj["category_id"] for obj in anno]
+        classes = torch.tensor(classes, dtype=torch.int64)
+
+        attributes = None
+        if load_attributes:
+            MAX_ATTR_NUM = 16
+            # -1 will be used as ignore label
+            attributes = -torch.ones(len(classes), MAX_ATTR_NUM, dtype=torch.int64)
+            for n_obj, obj in enumerate(anno):
+                if "attribute_ids_max16" in obj:
+                    attributes[n_obj] = torch.as_tensor(
+                        obj["attribute_ids_max16"], dtype=torch.int64
+                    )
+                elif "attributes" in obj:
+                    attr_ids = obj["attributes"]
+                    if "attribute_names" not in obj:
+                        # merged attributes, flatten the list
+                        attr_ids = [a for attr_list in attr_ids for a in attr_list]
+                    attr_ids = attr_ids[:MAX_ATTR_NUM]
+                    attributes[n_obj, : len(attr_ids)] = torch.as_tensor(
+                        attr_ids, dtype=torch.int64
+                    )
+
+        if self.return_masks:
+            segmentations = [obj["segmentation"] for obj in anno]
+            masks = convert_coco_poly_to_mask(segmentations, h, w)
+
+        keypoints = None
+        if anno and "keypoints" in anno[0]:
+            keypoints = [obj["keypoints"] for obj in anno]
+            keypoints = torch.as_tensor(keypoints, dtype=torch.float32)
+            num_keypoints = keypoints.shape[0]
+            if num_keypoints:
+                keypoints = keypoints.view(num_keypoints, -1, 3)
+
+        keep = (boxes[:, 3] > boxes[:, 1]) & (boxes[:, 2] > boxes[:, 0])
+        boxes = boxes[keep]
+        classes = classes[keep]
+        if attributes is not None:
+            attributes = attributes[keep]
+        if self.return_masks:
+            masks = masks[keep]
+        if keypoints is not None:
+            keypoints = keypoints[keep]
+
+        target = {}
+        target["boxes"] = boxes
+        target["orig_boxes"] = boxes
+        target["labels"] = classes
+        if attributes is not None:
+            target["attributes"] = attributes
+        if self.return_masks:
+            target["masks"] = masks
+        target["image_id"] = image_id
+        if keypoints is not None:
+            target["keypoints"] = keypoints
+
+        # for conversion to coco api
+        area = torch.tensor([obj["area"] for obj in anno])
+        iscrowd = torch.tensor(
+            [obj["iscrowd"] if "iscrowd" in obj else 0 for obj in anno]
+        )
+        target["area"] = area[keep]
+        target["orig_area"] = target["area"]
+        target["iscrowd"] = iscrowd[keep]
+
+        target["orig_size"] = torch.as_tensor([int(h), int(w)])
+        target["size"] = torch.as_tensor([int(h), int(w)])
+
+        return image, target
+
+
+def make_coco_transforms(image_set):
+
+    normalize = T.Compose(
+        [T.ToTensor(), T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])]
+    )
+
+    scales = [480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800]
+
+    if image_set == "train":
+        return T.Compose(
+            [
+                T.RandomHorizontalFlip(),
+                T.RandomSelect(
+                    T.RandomResize(scales, max_size=1333),
+                    T.Compose(
+                        [
+                            T.RandomResize([400, 500, 600]),
+                            T.RandomSizeCrop(384, 600),
+                            T.RandomResize(scales, max_size=1333),
+                        ]
+                    ),
+                ),
+                normalize,
+            ]
+        )
+
+    if image_set == "val":
+        return T.Compose([T.RandomResize([800], max_size=1333), normalize,])
+
+    raise ValueError(f"unknown {image_set}")
+
+
+def build(image_set, args):
+    root = Path(args.coco_path)
+    assert root.exists(), f"provided COCO path {root} does not exist"
+    mode = "instances"
+    PATHS = {
+        "train": (root / "train2017", root / "annotations" / f"{mode}_train2017.json"),
+        "val": (root / "val2017", root / "annotations" / f"{mode}_val2017.json"),
+    }
+
+    img_folder, ann_file = PATHS[image_set]
+    dataset = CocoDetection(
+        img_folder,
+        ann_file,
+        transforms=make_coco_transforms(image_set),
+        return_masks=args.masks,
+    )
+    return dataset

--- a/mmf/modules/detr/datasets/transforms.py
+++ b/mmf/modules/detr/datasets/transforms.py
@@ -1,0 +1,306 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/datasets/transforms.py
+import random
+
+import PIL
+import torch
+import torchvision.transforms as T
+import torchvision.transforms.functional as F
+
+from ..util.box_ops import box_xyxy_to_cxcywh
+
+
+def crop(image, target, region):
+    cropped_image = F.crop(image, *region)
+
+    target = target.copy()
+    i, j, h, w = region
+
+    # should we do something wrt the original size?
+    target["size"] = torch.tensor([h, w])
+
+    fields = ["labels", "area", "iscrowd"]
+
+    if "boxes" in target:
+        boxes = target["boxes"]
+        max_size = torch.as_tensor([w, h], dtype=torch.float32)
+        cropped_boxes = boxes - torch.as_tensor([j, i, j, i])
+        cropped_boxes = torch.min(cropped_boxes.reshape(-1, 2, 2), max_size)
+        cropped_boxes = cropped_boxes.clamp(min=0)
+        area = (cropped_boxes[:, 1, :] - cropped_boxes[:, 0, :]).prod(dim=1)
+        target["boxes"] = cropped_boxes.reshape(-1, 4)
+        target["area"] = area
+        fields.append("boxes")
+
+    if "masks" in target:
+        # FIXME should we update the area here if there are no boxes?
+        target["masks"] = target["masks"][:, i : i + h, j : j + w]
+        fields.append("masks")
+
+    if "attributes" in target:
+        fields.append("attributes")
+
+    # remove elements for which the boxes or masks that have zero area
+    if "boxes" in target or "masks" in target:
+        # favor boxes selection when defining which elements to keep
+        # this is compatible with previous implementation
+        if "boxes" in target:
+            cropped_boxes = target["boxes"].reshape(-1, 2, 2)
+            keep = torch.all(cropped_boxes[:, 1, :] > cropped_boxes[:, 0, :], dim=1)
+        else:
+            keep = target["masks"].flatten(1).any(1)
+
+        for field in fields:
+            target[field] = target[field][keep]
+
+    return cropped_image, target
+
+
+def hflip(image, target):
+    flipped_image = F.hflip(image)
+
+    w, h = image.size
+
+    target = target.copy()
+    if "boxes" in target:
+        boxes = target["boxes"]
+        boxes = boxes[:, [2, 1, 0, 3]] * torch.as_tensor(
+            [-1, 1, -1, 1]
+        ) + torch.as_tensor([w, 0, w, 0])
+        target["boxes"] = boxes
+
+    if "masks" in target:
+        target["masks"] = target["masks"].flip(-1)
+
+    return flipped_image, target
+
+
+def resize(image, target, size, max_size=None):
+    # size can be min_size (scalar) or (w, h) tuple
+
+    def get_size_with_aspect_ratio(image_size, size, max_size=None):
+        w, h = image_size
+        if max_size is not None:
+            min_original_size = float(min((w, h)))
+            max_original_size = float(max((w, h)))
+            if max_original_size / min_original_size * size > max_size:
+                size = int(round(max_size * min_original_size / max_original_size))
+
+        if (w <= h and w == size) or (h <= w and h == size):
+            return (h, w)
+
+        if w < h:
+            ow = size
+            oh = int(size * h / w)
+        else:
+            oh = size
+            ow = int(size * w / h)
+
+        return (oh, ow)
+
+    def get_size(image_size, size, max_size=None):
+        if isinstance(size, (list, tuple)):
+            return size[::-1]
+        else:
+            return get_size_with_aspect_ratio(image_size, size, max_size)
+
+    size = get_size(image.size, size, max_size)
+    rescaled_image = F.resize(image, size)
+
+    if target is None:
+        return rescaled_image, None
+
+    ratios = tuple(
+        float(s) / float(s_orig) for s, s_orig in zip(rescaled_image.size, image.size)
+    )
+    ratio_width, ratio_height = ratios
+
+    target = target.copy()
+    if "boxes" in target:
+        boxes = target["boxes"]
+        scaled_boxes = boxes * torch.as_tensor(
+            [ratio_width, ratio_height, ratio_width, ratio_height]
+        )
+        target["boxes"] = scaled_boxes
+
+    if "area" in target:
+        area = target["area"]
+        scaled_area = area * (ratio_width * ratio_height)
+        target["area"] = scaled_area
+
+    h, w = size
+    target["size"] = torch.tensor([h, w])
+
+    if "masks" in target:
+        from ..util.misc import interpolate
+
+        target["masks"] = (
+            interpolate(target["masks"][:, None].float(), size, mode="nearest")[:, 0]
+            > 0.5
+        )
+
+    return rescaled_image, target
+
+
+def pad(image, target, padding):
+    # assumes that we only pad on the bottom right corners
+    padded_image = F.pad(image, (0, 0, padding[0], padding[1]))
+    if target is None:
+        return padded_image, None
+    target = target.copy()
+    # should we do something wrt the original size?
+    target["size"] = torch.tensor(padded_image[::-1])
+    if "masks" in target:
+        target["masks"] = torch.nn.functional.pad(
+            target["masks"], (0, padding[0], 0, padding[1])
+        )
+    return padded_image, target
+
+
+class RandomCrop(object):
+    def __init__(self, size):
+        self.size = size
+
+    def __call__(self, img, target):
+        region = T.RandomCrop.get_params(img, self.size)
+        return crop(img, target, region)
+
+
+class RandomSizeCrop(object):
+    def __init__(self, min_size: int, max_size: int):
+        self.min_size = min_size
+        self.max_size = max_size
+
+    def __call__(self, img: PIL.Image.Image, target: dict):
+        w = random.randint(self.min_size, min(img.width, self.max_size))
+        h = random.randint(self.min_size, min(img.height, self.max_size))
+        region = T.RandomCrop.get_params(img, [h, w])
+        return crop(img, target, region)
+
+
+class CenterCrop(object):
+    def __init__(self, size):
+        self.size = size
+
+    def __call__(self, img, target):
+        image_width, image_height = img.size
+        crop_height, crop_width = self.size
+        crop_top = int(round((image_height - crop_height) / 2.0))
+        crop_left = int(round((image_width - crop_width) / 2.0))
+        return crop(img, target, (crop_top, crop_left, crop_height, crop_width))
+
+
+class RandomHorizontalFlip(object):
+    def __init__(self, p=0.5):
+        self.p = p
+
+    def __call__(self, img, target):
+        if random.random() < self.p:
+            return hflip(img, target)
+        return img, target
+
+
+class RandomResize(object):
+    def __init__(self, sizes, max_size=None):
+        assert isinstance(sizes, (list, tuple))
+        self.sizes = sizes
+        self.max_size = max_size
+
+    def __call__(self, img, target=None):
+        size = random.choice(self.sizes)
+        return resize(img, target, size, self.max_size)
+
+
+class RandomPad(object):
+    def __init__(self, max_pad):
+        self.max_pad = max_pad
+
+    def __call__(self, img, target):
+        pad_x = random.randint(0, self.max_pad)
+        pad_y = random.randint(0, self.max_pad)
+        return pad(img, target, (pad_x, pad_y))
+
+
+class RandomSelect(object):
+    """
+    Randomly selects between transforms1 and transforms2,
+    with probability p for transforms1 and (1 - p) for transforms2
+    """
+
+    def __init__(self, transforms1, transforms2, p=0.5):
+        self.transforms1 = transforms1
+        self.transforms2 = transforms2
+        self.p = p
+
+    def __call__(self, img, target):
+        if random.random() < self.p:
+            return self.transforms1(img, target)
+        return self.transforms2(img, target)
+
+
+class ToTensor(object):
+    def __call__(self, img, target):
+        return F.to_tensor(img), target
+
+
+class RandomErasing(object):
+    def __init__(self, *args, **kwargs):
+        self.eraser = T.RandomErasing(*args, **kwargs)
+
+    def __call__(self, img, target):
+        return self.eraser(img), target
+
+
+class Normalize(object):
+    def __init__(self, mean, std):
+        self.mean = mean
+        self.std = std
+
+    def __call__(self, image, target=None):
+        image = F.normalize(image, mean=self.mean, std=self.std)
+        if target is None:
+            return image, None
+        target = target.copy()
+        h, w = image.shape[-2:]
+        if "boxes" in target:
+            boxes = target["boxes"]
+            boxes = box_xyxy_to_cxcywh(boxes)
+            boxes = boxes / torch.tensor([w, h, w, h], dtype=torch.float32)
+            target["boxes"] = boxes
+        return image, target
+
+
+class RemoveDifficult(object):
+    def __init__(self, enabled=False):
+        self.remove_difficult = enabled
+
+    def __call__(self, image, target=None):
+        if target is None:
+            return image, None
+        target = target.copy()
+        keep = ~target["iscrowd"].to(torch.bool) | (not self.remove_difficult)
+        if "boxes" in target:
+            target["boxes"] = target["boxes"][keep]
+        target["labels"] = target["labels"][keep]
+        target["iscrowd"] = target["iscrowd"][keep]
+        return image, target
+
+
+class Compose(object):
+    def __init__(self, transforms):
+        self.transforms = transforms
+
+    def __call__(self, image, target):
+        for t in self.transforms:
+            image, target = t(image, target)
+        return image, target
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + "("
+        for t in self.transforms:
+            format_string += "\n"
+            format_string += "    {0}".format(t)
+        format_string += "\n)"
+        return format_string

--- a/mmf/modules/detr/models/__init__.py
+++ b/mmf/modules/detr/models/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/mmf/modules/detr/models/backbone.py
+++ b/mmf/modules/detr/models/backbone.py
@@ -1,0 +1,152 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/backbone.py
+"""
+Backbone modules.
+"""
+from collections import OrderedDict
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch import nn
+from torchvision.models._utils import IntermediateLayerGetter
+
+from ..util.misc import NestedTensor
+from .position_encoding import build_position_encoding
+
+
+class FrozenBatchNorm2d(torch.nn.Module):
+    """
+    BatchNorm2d where the batch statistics and the affine parameters are fixed.
+
+    Copy-paste from torchvision.misc.ops with added eps before rqsrt,
+    without which any other models than torchvision.models.resnet[18,34,50,101]
+    produce nans.
+    """
+
+    def __init__(self, n):
+        super(FrozenBatchNorm2d, self).__init__()
+        self.register_buffer("weight", torch.ones(n))
+        self.register_buffer("bias", torch.zeros(n))
+        self.register_buffer("running_mean", torch.zeros(n))
+        self.register_buffer("running_var", torch.ones(n))
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        num_batches_tracked_key = prefix + "num_batches_tracked"
+        if num_batches_tracked_key in state_dict:
+            del state_dict[num_batches_tracked_key]
+
+        super(FrozenBatchNorm2d, self)._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+    def forward(self, x):
+        # move reshapes to the beginning
+        # to make it fuser-friendly
+        w = self.weight.reshape(1, -1, 1, 1)
+        b = self.bias.reshape(1, -1, 1, 1)
+        rv = self.running_var.reshape(1, -1, 1, 1)
+        rm = self.running_mean.reshape(1, -1, 1, 1)
+        eps = 1e-5
+        scale = w * (rv + eps).rsqrt()
+        bias = b - rm * scale
+        return x * scale + bias
+
+
+class BackboneBase(nn.Module):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        train_backbone: bool,
+        num_channels: int,
+        return_interm_layers: bool,
+    ):
+        super().__init__()
+        for name, parameter in backbone.named_parameters():
+            if (
+                not train_backbone
+                or "layer2" not in name
+                and "layer3" not in name
+                and "layer4" not in name
+            ):
+                parameter.requires_grad_(False)
+        if return_interm_layers:
+            return_layers = {"layer1": "0", "layer2": "1", "layer3": "2", "layer4": "3"}
+        else:
+            return_layers = {"layer4": 0}
+        self.body = IntermediateLayerGetter(backbone, return_layers=return_layers)
+        self.num_channels = num_channels
+
+    def forward(self, tensor_list):
+        xs = self.body(tensor_list.tensors)
+        out = OrderedDict()
+        for name, x in xs.items():
+            mask = F.interpolate(
+                tensor_list.mask[None].float(), size=x.shape[-2:]
+            ).bool()[0]
+            out[name] = NestedTensor(x, mask)
+        return out
+
+
+class Backbone(BackboneBase):
+    """ResNet backbone with frozen BatchNorm."""
+
+    def __init__(
+        self,
+        name: str,
+        train_backbone: bool,
+        return_interm_layers: bool,
+        dilation: bool,
+    ):
+        backbone = getattr(torchvision.models, name)(
+            replace_stride_with_dilation=[False, False, dilation],
+            pretrained=True,
+            norm_layer=FrozenBatchNorm2d,
+        )
+        num_channels = 512 if name in ("resnet18", "resnet34") else 2048
+        super().__init__(backbone, train_backbone, num_channels, return_interm_layers)
+
+
+class Joiner(nn.Sequential):
+    def __init__(self, backbone, position_embedding):
+        super().__init__(backbone, position_embedding)
+
+    def forward(self, tensor_list):
+        xs = self[0](tensor_list)
+        out = []
+        pos = []
+        for name, x in xs.items():
+            out.append(x)
+            # position encoding
+            pos.append(self[1](x).to(x.tensors.dtype))
+
+        return out, pos
+
+
+def build_backbone(args):
+    position_embedding = build_position_encoding(args)
+    train_backbone = args.lr_backbone > 0
+    return_interm_layers = args.masks
+    backbone = Backbone(
+        args.backbone, train_backbone, return_interm_layers, args.dilation
+    )
+    model = Joiner(backbone, position_embedding)
+    model.num_channels = backbone.num_channels
+    return model

--- a/mmf/modules/detr/models/detr.py
+++ b/mmf/modules/detr/models/detr.py
@@ -1,0 +1,540 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/detr.py
+"""
+DETR model and criterion classes.
+"""
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from ..util import box_ops
+from ..util.misc import (
+    NestedTensor,
+    accuracy,
+    get_world_size,
+    is_dist_avail_and_initialized,
+)
+
+from .backbone import build_backbone
+from .matcher import build_matcher
+from .transformer import build_transformer
+
+
+ATTRIBUTE_CLASS_NUM = 401
+MAX_ATTR_NUM = 16
+
+
+class AttributeHead(nn.Module):
+    def __init__(self, num_classes, representation_size):
+        super().__init__()
+
+        # copy-pasted from
+        # https://github.com/ronghanghu/vqa-maskrcnn-benchmark-m4c/blob/0fbccee2dfed10d652bcf014f9f8bfafd8478f51/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py#L52-L61
+        self.cls_embed = nn.Embedding(num_classes + 1, 256)
+        self.attr_linear1 = nn.Linear(representation_size + 256, 512)
+        self.attr_linear2 = nn.Linear(512, ATTRIBUTE_CLASS_NUM)
+
+        nn.init.normal_(self.cls_embed.weight, std=0.01)
+        nn.init.normal_(self.attr_linear1.weight, std=0.01)
+        nn.init.normal_(self.attr_linear2.weight, std=0.01)
+        nn.init.constant_(self.attr_linear1.bias, 0)
+        nn.init.constant_(self.attr_linear2.bias, 0)
+
+    def forward(self, hidden_states, labels):
+        # copy-pasted from
+        # https://github.com/ronghanghu/vqa-maskrcnn-benchmark-m4c/blob/0fbccee2dfed10d652bcf014f9f8bfafd8478f51/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py#L76-L96
+
+        # get embeddings of indices using gt cls labels
+        cls_embed_out = self.cls_embed(labels)
+
+        # concat with fc7 feats
+        concat_attr = torch.cat([hidden_states, cls_embed_out], dim=-1)
+
+        # pass through attr head layers
+        fc_attr = self.attr_linear1(concat_attr)
+        attr_score = F.relu(self.attr_linear2(fc_attr))
+
+        return attr_score
+
+
+class DETR(nn.Module):
+    """ This is the DETR module that performs object detection """
+
+    def __init__(self, backbone, transformer, num_queries):
+        """ Initializes the model.
+        Parameters:
+            backbone: torch module of the backbone to be used. See backbone.py
+            transformer: torch module of the transformer architecture. See transformer.py
+            num_classes: number of object classes
+            num_queries: number of object queries, ie detection slot. This is the maximal number of objects
+                         DETR can detect in a single image. For COCO, we recommend 100 queries.
+            aux_loss: True if auxiliary decoding losses (loss at each decoder layer) are to be used.
+        """
+        super().__init__()
+        self.num_queries = num_queries
+        self.transformer = transformer
+        encoder_hidden_dim = transformer.d_model_enc
+        decoder_hidden_dim = transformer.d_model_dec
+
+        self.query_embeds = nn.ModuleDict()
+        for task_type in self.num_queries:
+            task_dict = nn.ModuleDict()
+            for dataset in self.num_queries[task_type]:
+                task_dict[dataset] = nn.Embedding(
+                    self.num_queries[task_type][dataset], decoder_hidden_dim
+                )
+            self.query_embeds[task_type] = task_dict
+
+        self.input_proj = nn.Conv2d(
+            backbone.num_channels, encoder_hidden_dim, kernel_size=1
+        )
+        self.backbone = backbone
+
+    def forward(
+        self,
+        img_src: NestedTensor = None,
+        text_src=None,
+        text_mask=None,
+        text_pos=None,
+        output_hidden_states_only=False,
+        task_type="detection",
+        dataset_name="detection_coco",
+        task_idx=None,
+        **kwargs,
+    ):
+        """ The forward expects a NestedTensor, which consists of:
+               - samples.tensor: batched images, of shape [batch_size x 3 x H x W]
+               - samples.mask: a binary mask of shape [batch_size x H x W], containing 1 on padded pixels
+
+            It returns a dict with the following elements:
+               - "pred_logits": the classification logits (including no-object) for all queries.
+                                Shape= [batch_size x num_queries x (num_classes + 1)]
+               - "pred_boxes": The normalized boxes coordinates for all queries, represented as
+                               (center_x, center_y, height, width). These values are normalized in [0, 1],
+                               relative to the size of each individual image (disregarding possible padding).
+                               See PostProcess for information on how to retrieve the unnormalized bounding box.
+               - "aux_outputs": Optional, only returned when auxilary losses are activated. It is a list of
+                                dictionnaries containing the two above keys for each decoder layer.
+        """
+        img_mask = None
+        img_pos = [None]
+        if img_src is not None:
+            if not isinstance(img_src, NestedTensor):
+                img_src = NestedTensor.from_tensor_list(img_src)
+            features, img_pos = self.backbone(img_src)
+
+            img_src, img_mask = features[-1].decompose()
+            img_src = self.input_proj(img_src)
+
+        query_embed = self.query_embeds[task_type][dataset_name]
+        hs, _ = self.transformer(
+            img_src=img_src,
+            img_mask=img_mask,
+            img_pos=img_pos[-1],
+            text_src=text_src,
+            text_mask=text_mask,
+            text_pos=text_pos,
+            query_embed=query_embed.weight,
+            task_type=task_type,
+            dataset_name=dataset_name,
+            task_idx=task_idx,
+        )
+
+        if hs is not None:
+            assert hs.size(2) == self.num_queries[task_type][dataset_name]
+
+        return {"hidden_states": hs}
+
+
+def _attribute_loss(attribute_logits, attributes):
+    _N, _B, _C = attribute_logits.size()
+    assert _C == ATTRIBUTE_CLASS_NUM
+    attribute_logits = attribute_logits.view(_N * _B, _C)
+
+    assert attributes.size(0) == _N
+    assert attributes.size(1) == _B
+    assert attributes.size(2) == MAX_ATTR_NUM
+    attributes = attributes.view(_N * _B, MAX_ATTR_NUM)
+
+    # https://github.com/ronghanghu/vqa-maskrcnn-benchmark-m4c/blob/0fbccee2dfed10d652bcf014f9f8bfafd8478f51/maskrcnn_benchmark/modeling/roi_heads/box_head/loss.py#L185-L222
+    n_boxes = attribute_logits.shape[0]
+
+    # N_BOXES, N_ATTR -> N_BOXES, 1, N_ATTR
+    attribute_logits = attribute_logits.unsqueeze(1)
+
+    # N_BOXES, 1, N_ATTR -> N_BOXES, MAX_ATTR_PER_INST, N_ATTR -> N_BOXES * MAX_ATTR_PER_INST, N_ATTR
+    attribute_logits = (
+        attribute_logits.expand(n_boxes, 16, ATTRIBUTE_CLASS_NUM)
+        .contiguous()
+        .view(-1, ATTRIBUTE_CLASS_NUM)
+    )
+
+    # Normalize each box loss by # of valid GT attributes (ie attr != -1)
+    # Repeat number of valid attributes per box along the rows and take transpose
+    inv_per_box_weights = (
+        (attributes >= 0).sum(dim=1).repeat(16, 1).transpose(0, 1).flatten()
+    )
+    per_box_weights = inv_per_box_weights.float().reciprocal()
+    per_box_weights[per_box_weights > 1] = 0.0
+
+    attributes = attributes.view(-1)
+    attribute_loss = 0.5 * F.cross_entropy(
+        attribute_logits, attributes, reduction="none", ignore_index=-1
+    )
+
+    attribute_loss = (attribute_loss * per_box_weights).view(n_boxes, -1).sum(dim=1)
+
+    # Find number of boxes with atleast valid attribute
+    n_valid_boxes = len(attribute_loss.nonzero())
+
+    if n_valid_boxes > 0:
+        attribute_loss = (attribute_loss / n_valid_boxes).sum()
+    else:
+        attribute_loss = (attribute_loss * 0.0).sum()
+
+    return attribute_loss
+
+
+class SetCriterion(nn.Module):
+    """ This class computes the loss for DETR.
+    The process happens in two steps:
+        1) we compute hungarian assignment between ground truth boxes and the outputs of the model
+        2) we supervise each pair of matched ground-truth / prediction (supervise class and box)
+    """
+
+    def __init__(
+        self, num_classes, matcher, weight_dict, eos_coef, losses, attribute_head=None
+    ):
+        """ Create the criterion.
+        Parameters:
+            num_classes: number of object categories, omitting the special no-object category
+            matcher: module able to compute a matching between targets and proposals
+            weight_dict: dict containing as key the names of the losses and as values their relative weight.
+            eos_coef: relative classification weight applied to the no-object category
+            losses: list of all the losses to be applied. See get_loss for list of available losses.
+        """
+        super().__init__()
+        self.num_classes = num_classes
+        self.matcher = matcher
+        self.weight_dict = weight_dict
+        self.eos_coef = eos_coef
+        self.losses = losses
+        empty_weight = torch.ones(self.num_classes + 1)
+        empty_weight[-1] = self.eos_coef
+        self.register_buffer("empty_weight", empty_weight)
+        self.attribute_head = attribute_head
+
+    def loss_labels(self, outputs, targets, indices, num_boxes, log=True):
+        """Classification loss (NLL)
+        targets dicts must contain the key "labels" containing a tensor of dim [nb_target_boxes]
+        """
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"]
+
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+
+        loss_ce = F.cross_entropy(
+            src_logits.transpose(1, 2), target_classes, self.empty_weight
+        )
+        losses = {"loss_ce": loss_ce}
+
+        if self.attribute_head is not None and "attributes" in targets[0]:
+            attribute_logits = self.attribute_head(
+                outputs["hs_for_attr"], target_classes
+            )
+            target_attributes_o = torch.cat(
+                [t["attributes"][J] for t, (_, J) in zip(targets, indices)]
+            )
+            target_attributes = -torch.ones(
+                *src_logits.shape[:2], 16, dtype=torch.int64, device=src_logits.device
+            )
+            target_attributes[idx] = target_attributes_o
+            losses["loss_attr"] = _attribute_loss(attribute_logits, target_attributes)
+
+        if log:
+            # TODO this should probably be a separate loss, not hacked in this one here
+            losses["class_error"] = 100 - accuracy(src_logits[idx], target_classes_o)[0]
+        return losses
+
+    def loss_labels_balanced(self, outputs, targets, indices, num_boxes, log=True):
+        """Classification loss (NLL)
+        targets dicts must contain the key "labels" containing a tensor of dim [nb_target_boxes]
+        """
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"]
+
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+
+        sl = src_logits.flatten(0, 1)
+        tc = target_classes.flatten(0, 1)
+        pos = tc != self.num_classes
+        loss_pos = F.cross_entropy(sl[pos], tc[pos], reduction="none").sum() / num_boxes
+        loss_neg = F.cross_entropy(sl[~pos], tc[~pos], reduction="none").sum() / (
+            sl.shape[0] - num_boxes
+        )
+
+        loss_ce = (1 - self.eos_coef) * loss_pos + self.eos_coef * loss_neg
+        losses = {"loss_ce": loss_ce}
+
+        if self.attribute_head is not None:
+            raise NotImplementedError()
+
+        if log:
+            # TODO this should probably be a separate loss, not hacked in this one here
+            losses["class_error"] = 100 - accuracy(src_logits[idx], target_classes_o)[0]
+        return losses
+
+    @torch.no_grad()
+    def loss_cardinality(self, outputs, targets, indices, num_boxes):
+        """ Compute the cardinality error, ie the absolute error in the number of predicted non-empty boxes
+        This is not really a loss, it is intended for logging purposes only. It doesn't propagate gradients
+        """
+        pred_logits = outputs["pred_logits"]
+        device = pred_logits.device
+        tgt_lengths = torch.as_tensor(
+            [len(v["labels"]) for v in targets], device=device
+        )
+        # Count the number of predictions that are NOT "no-object" (which is the last class)
+        card_pred = (pred_logits.argmax(-1) != pred_logits.shape[-1] - 1).sum(1)
+        card_err = F.l1_loss(card_pred.float(), tgt_lengths.float())
+        losses = {"cardinality_error": card_err}
+        return losses
+
+    def loss_boxes(self, outputs, targets, indices, num_boxes):
+        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
+           targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
+           The target boxes are expected in format (center_x, center_y, h, w), normalized by the image size.
+        """
+        assert "pred_boxes" in outputs
+        idx = self._get_src_permutation_idx(indices)
+        src_boxes = outputs["pred_boxes"][idx]
+        target_boxes = torch.cat(
+            [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+        )
+
+        loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction="none")
+
+        losses = {}
+        losses["loss_bbox"] = loss_bbox.sum() / num_boxes
+
+        loss_giou = 1 - torch.diag(
+            box_ops.generalized_box_iou(
+                box_ops.box_cxcywh_to_xyxy(src_boxes).float(),
+                box_ops.box_cxcywh_to_xyxy(target_boxes),
+            )
+        )
+        losses["loss_giou"] = loss_giou.sum() / num_boxes
+        return losses
+
+    def loss_masks(self, outputs, targets, indices, num_boxes):
+        """Compute the losses related to the masks: the focal loss and the dice loss.
+           targets dicts must contain the key "masks" containing a tensor of dim [nb_target_boxes, h, w]
+        """
+        from ..util.misc import interpolate
+        from .segmentation import dice_loss, sigmoid_focal_loss
+
+        assert "pred_masks" in outputs
+
+        src_idx = self._get_src_permutation_idx(indices)
+        tgt_idx = self._get_tgt_permutation_idx(indices)
+
+        src_masks = outputs["pred_masks"]
+
+        # TODO use valid to mask invalid areas due to padding in loss
+        target_masks, valid = NestedTensor.from_tensor_list(
+            [t["masks"] for t in targets]
+        ).decompose()
+        target_masks = target_masks.to(src_masks)
+
+        src_masks = src_masks[src_idx]
+        # upsample predictions to the target size
+        src_masks = interpolate(
+            src_masks[:, None],
+            size=target_masks.shape[-2:],
+            mode="bilinear",
+            align_corners=False,
+        )
+        src_masks = src_masks[:, 0].flatten(1)
+
+        target_masks = target_masks[tgt_idx].flatten(1)
+
+        losses = {
+            "loss_mask": sigmoid_focal_loss(src_masks, target_masks, num_boxes),
+            "loss_dice": dice_loss(src_masks, target_masks, num_boxes),
+        }
+        return losses
+
+    def _get_src_permutation_idx(self, indices):
+        # permute predictions following indices
+        batch_idx = torch.cat(
+            [torch.full_like(src, i) for i, (src, _) in enumerate(indices)]
+        )
+        src_idx = torch.cat([src for (src, _) in indices])
+        return batch_idx, src_idx
+
+    def _get_tgt_permutation_idx(self, indices):
+        # permute targets following indices
+        batch_idx = torch.cat(
+            [torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)]
+        )
+        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
+        return batch_idx, tgt_idx
+
+    def get_loss(self, loss, outputs, targets, indices, num_boxes, **kwargs):
+        loss_map = {
+            "labels": self.loss_labels,
+            "labels_balanced": self.loss_labels_balanced,
+            "cardinality": self.loss_cardinality,
+            "boxes": self.loss_boxes,
+            "masks": self.loss_masks,
+        }
+        assert loss in loss_map, f"do you really want to compute {loss} loss?"
+        return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
+
+    def forward(self, outputs, targets):
+        """ This performs the loss computation.
+        Parameters:
+             outputs: dict of tensors, see the output specification of the model for the format
+             targets: list of dicts, such that len(targets) == batch_size.
+                      The expected keys in each dict depends on the losses applied, see each loss' doc
+        """
+        outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
+
+        # Retrieve the matching between the outputs of the last layer and the targets
+        indices = self.matcher(outputs_without_aux, targets)
+
+        # Compute the average number of target boxes accross all nodes, for normalization purposes
+        num_boxes = sum(len(t["labels"]) for t in targets)
+        num_boxes = torch.as_tensor(
+            [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
+        )
+        if is_dist_avail_and_initialized():
+            torch.distributed.all_reduce(num_boxes)
+        num_boxes = torch.clamp(num_boxes / get_world_size(), min=1).item()
+
+        # Compute all the requested losses
+        losses = {}
+        for loss in self.losses:
+            losses.update(self.get_loss(loss, outputs, targets, indices, num_boxes))
+
+        # In case of auxiliary losses, we repeat this process with the output of each intermediate layer.
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                indices = self.matcher(aux_outputs, targets)
+                for loss in self.losses:
+                    if loss == "masks":
+                        # Intermediate masks losses are too costly to compute, we ignore them.
+                        continue
+                    kwargs = {}
+                    if loss in ("labels", "labels_balanced"):
+                        # Logging is enabled only for the last layer
+                        kwargs = {"log": False}
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices, num_boxes, **kwargs
+                    )
+                    l_dict = {k + f"_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        return losses
+
+
+class MLP(nn.Module):
+    """ Very simple multi-layer perceptron (also called FFN)"""
+
+    def __init__(self, input_dim, hidden_dim, output_dim, num_layers):
+        super().__init__()
+        self.num_layers = num_layers
+        h = [hidden_dim] * (num_layers - 1)
+        self.layers = nn.ModuleList(
+            nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim])
+        )
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers):
+            x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
+        return x
+
+
+def build(args):
+    # num_classes = 20 if args.dataset_file != 'coco' else 91
+    # if args.dataset_file == "lvis":
+    #     num_classes = 1235
+    # if args.dataset_file == "coco_panoptic":
+    #     num_classes = 250
+    # if args.dataset_file == "visualgenome":
+    #     num_classes = 1601
+    assert not args.masks or args.mask_model != "none"
+
+    backbone = build_backbone(args)
+
+    transformer = build_transformer(args)
+
+    model = DETR(backbone, transformer, num_queries=args.num_queries,)
+    if args.mask_model != "none":
+        from .segmentation import DETRsegm
+
+        model = DETRsegm(
+            model,
+            mask_head=args.mask_model,
+            freeze_detr=(args.frozen_weights is not None),
+        )
+
+    return model
+
+
+def build_detection_loss(args, num_classes, attribute_head):
+    matcher = build_matcher(args)
+    weight_dict = {"loss_ce": 1, "loss_bbox": args.bbox_loss_coef}
+    weight_dict["loss_giou"] = args.giou_loss_coef
+    if args.masks:
+        weight_dict["loss_mask"] = args.mask_loss_coef
+        weight_dict["loss_dice"] = args.dice_loss_coef
+    weight_dict["loss_attr"] = args.attr_loss_coef
+    # TODO this is a hack
+    if args.aux_loss:
+        aux_weight_dict = {}
+        for i in range(args.dec_layers - 1):
+            aux_weight_dict.update({k + f"_{i}": v for k, v in weight_dict.items()})
+        weight_dict.update(aux_weight_dict)
+
+    losses = []
+    if args.use_bcl:
+        losses.append("labels_balanced")
+    else:
+        losses.append("labels")
+    losses.extend(["boxes", "cardinality"])
+    if args.masks:
+        losses += ["masks"]
+
+    criterion = SetCriterion(
+        num_classes,
+        matcher=matcher,
+        weight_dict=weight_dict,
+        eos_coef=args.eos_coef,
+        losses=losses,
+        attribute_head=attribute_head,
+    )
+
+    return criterion

--- a/mmf/modules/detr/models/detr.py
+++ b/mmf/modules/detr/models/detr.py
@@ -16,7 +16,6 @@ from ..util.misc import (
     get_world_size,
     is_dist_avail_and_initialized,
 )
-
 from .backbone import build_backbone
 from .matcher import build_matcher
 from .transformer import build_transformer
@@ -491,7 +490,7 @@ def build(args):
 
     transformer = build_transformer(args)
 
-    model = DETR(backbone, transformer, num_queries=args.num_queries,)
+    model = DETR(backbone, transformer, num_queries=args.num_queries)
     if args.mask_model != "none":
         from .segmentation import DETRsegm
 

--- a/mmf/modules/detr/models/matcher.py
+++ b/mmf/modules/detr/models/matcher.py
@@ -1,0 +1,166 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/matcher.py
+"""
+Modules to compute the matching cost and solve the corresponding LSAP.
+"""
+import torch
+from scipy.optimize import linear_sum_assignment
+from torch import nn
+
+from ..util.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+
+
+class HungarianMatcher(nn.Module):
+    """This class computes an assignment between the targets and the predictions of the network
+
+    For efficiency reasons, the targets don't include the no_object. Because of this, in general,
+    there are more predictions than targets. In this case, we do a 1-to-1 matching of the best predictions,
+    while the others are un-matched (and thus treated as non-objects).
+    """
+
+    def __init__(
+        self,
+        cost_class: float = 1,
+        cost_bbox: float = 1,
+        cost_giou: float = 1,
+        logsoftmax: bool = False,
+    ):
+        """Creates the matcher
+
+        Params:
+            cost_class: This is the relative weight of the classification error in the matching cost
+            cost_bbox: This is the relative weight of the L1 error of the bounding box coordinates in the matching cost
+            cost_giou: This is the relative weight of the giou loss of the bounding box in the matching cost
+        """
+        super().__init__()
+        self.cost_class = cost_class
+        self.cost_bbox = cost_bbox
+        self.cost_giou = cost_giou
+        self.norm = nn.LogSoftmax(-1) if logsoftmax else nn.Softmax(-1)
+        assert (
+            cost_class != 0 or cost_bbox != 0 or cost_giou != 0
+        ), "all costs cant be 0"
+
+    @torch.no_grad()
+    def forward(self, outputs, targets):
+        """ Performs the matching
+
+        Params:
+            outputs: This is a dict that contains at least these entries:
+                 "pred_logits": Tensor of dim [batch_size, num_queries, num_classes] with the classification logits
+                 "pred_boxes": Tensor of dim [batch_size, num_queries, 4] with the predicted box coordinates
+
+            targets: This is a list of targets (len(targets) = batch_size), where each target is a dict containing:
+                 "labels": Tensor of dim [num_target_boxes] (where num_target_boxes is the number of ground-truth
+                           objects in the target) containing the class labels
+                 "boxes": Tensor of dim [num_target_boxes, 4] containing the target box coordinates
+
+        Returns:
+            A list of size batch_size, containing tuples of (index_i, index_j) where:
+                - index_i is the indices of the selected predictions (in order)
+                - index_j is the indices of the corresponding selected targets (in order)
+            For each batch element, it holds:
+                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+        """
+        bs, num_queries = outputs["pred_logits"].shape[:2]
+
+        # We flatten to compute the cost matrices in a batch
+        out_prob = self.norm(
+            outputs["pred_logits"].flatten(0, 1)
+        )  # [batch_size * num_queries, num_classes]
+        out_bbox = outputs["pred_boxes"].flatten(0, 1)  # [batch_size * num_queries, 4]
+
+        # Also concat the target labels and boxes
+        tgt_ids = torch.cat([v["labels"] for v in targets])
+        tgt_bbox = torch.cat([v["boxes"] for v in targets])
+
+        # Compute the classification cost. Contrary to the loss, we don't use the NLL,
+        # but approximate it in 1 - proba[target class].
+        # The 1 is a constant that doesn't change the matching, it can be ommitted.
+        cost_class = -out_prob[:, tgt_ids]
+
+        # Compute the L1 cost between boxes
+        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+
+        # Compute the giou cost betwen boxes
+        cost_giou = -generalized_box_iou(
+            box_cxcywh_to_xyxy(out_bbox).float(), box_cxcywh_to_xyxy(tgt_bbox)
+        )
+
+        # Final cost matrix
+        C = (
+            self.cost_bbox * cost_bbox
+            + self.cost_class * cost_class
+            + self.cost_giou * cost_giou
+        )
+        C = C.view(bs, num_queries, -1).cpu()
+
+        sizes = [len(v["boxes"]) for v in targets]
+        indices = [
+            linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))
+        ]
+        return [
+            (
+                torch.as_tensor(i, dtype=torch.int64),
+                torch.as_tensor(j, dtype=torch.int64),
+            )
+            for i, j in indices
+        ]
+
+
+class SequentialMatcher(nn.Module):
+    def forward(self, outputs, targets):
+        return [(torch.arange(len(tgt["labels"])),) * 2 for tgt in targets]
+
+
+class LexicographicalMatcher(nn.Module):
+    def __init__(self, lexic="acb"):
+        super().__init__()
+        self.lexic = lexic
+
+    def forward(self, outputs, targets):
+        indices = []
+        for tgt in targets:
+            tgt_cls, tgt_box = tgt["labels"], tgt["boxes"]
+            area = tgt_box[:, 2] * tgt_box[:, 3]
+            if self.lexic == "acb":
+                search_list = [
+                    (-a, cl, b)
+                    for cl, a, b in zip(
+                        tgt_cls.tolist(), area.tolist(), tgt_box.tolist()
+                    )
+                ]
+            else:
+                search_list = [
+                    (cl, -a, b)
+                    for cl, a, b in zip(
+                        tgt_cls.tolist(), area.tolist(), tgt_box.tolist()
+                    )
+                ]
+            # argsort from https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
+            j = sorted(range(len(search_list)), key=search_list.__getitem__)
+            j = torch.as_tensor(j, dtype=torch.int64)
+            i = torch.arange(len(j), dtype=j.dtype)
+            indices.append((i, j))
+        return indices
+
+
+def build_matcher(args):
+    if args.set_loss == "sequential":
+        matcher = SequentialMatcher()
+    elif args.set_loss == "hungarian":
+        matcher = HungarianMatcher(
+            cost_class=args.set_cost_class,
+            cost_bbox=args.set_cost_bbox,
+            cost_giou=args.set_cost_giou,
+            logsoftmax=args.use_bcl,
+        )
+    elif args.set_loss == "lexicographical":
+        matcher = LexicographicalMatcher()
+    else:
+        raise ValueError(
+            f"Only sequential, lexicographical and hungarian accepted, got {args.set_loss}"
+        )
+    return matcher

--- a/mmf/modules/detr/models/matcher.py
+++ b/mmf/modules/detr/models/matcher.py
@@ -6,8 +6,9 @@
 Modules to compute the matching cost and solve the corresponding LSAP.
 """
 import torch
-from scipy.optimize import linear_sum_assignment
 from torch import nn
+
+from scipy.optimize import linear_sum_assignment
 
 from ..util.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
 

--- a/mmf/modules/detr/models/position_encoding.py
+++ b/mmf/modules/detr/models/position_encoding.py
@@ -6,6 +6,7 @@
 Various positional encodings for the transformer.
 """
 import math
+
 import torch
 from torch import nn
 

--- a/mmf/modules/detr/models/position_encoding.py
+++ b/mmf/modules/detr/models/position_encoding.py
@@ -1,0 +1,105 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/position_encoding.py
+"""
+Various positional encodings for the transformer.
+"""
+import math
+import torch
+from torch import nn
+
+
+class PositionEmbeddingSine(nn.Module):
+    """
+    This is a more standard version of the position embedding, very similar to the one
+    used by the Attention is all you need paper, generalized to work on images.
+    """
+
+    def __init__(
+        self, num_pos_feats=64, temperature=10000, normalize=False, scale=None
+    ):
+        super().__init__()
+        self.num_pos_feats = num_pos_feats
+        self.temperature = temperature
+        self.normalize = normalize
+        if scale is not None and normalize is False:
+            raise ValueError("normalize should be True if scale is passed")
+        if scale is None:
+            scale = 2 * math.pi
+        self.scale = scale
+
+    def forward(self, tensor_list):
+        x = tensor_list.tensors
+        mask = tensor_list.mask
+        not_mask = ~mask
+        y_embed = not_mask.cumsum(1, dtype=torch.float32)
+        x_embed = not_mask.cumsum(2, dtype=torch.float32)
+        if self.normalize:
+            eps = 1e-6
+            y_embed = y_embed / (y_embed[:, -1:, :] + eps) * self.scale
+            x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
+
+        dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=x.device)
+        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)
+
+        pos_x = x_embed[:, :, :, None] / dim_t
+        pos_y = y_embed[:, :, :, None] / dim_t
+        pos_x = torch.stack(
+            (pos_x[:, :, :, 0::2].sin(), pos_x[:, :, :, 1::2].cos()), dim=4
+        ).flatten(3)
+        pos_y = torch.stack(
+            (pos_y[:, :, :, 0::2].sin(), pos_y[:, :, :, 1::2].cos()), dim=4
+        ).flatten(3)
+        pos = torch.cat((pos_y, pos_x), dim=3).permute(0, 3, 1, 2)
+        return pos
+
+
+class PositionEmbeddingLearned(nn.Module):
+    """
+    Absolute pos embedding, learned.
+    """
+
+    def __init__(self, num_pos_feats=256):
+        super().__init__()
+        self.row_embed = nn.Embedding(50, num_pos_feats)
+        self.col_embed = nn.Embedding(50, num_pos_feats)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.init.uniform_(self.row_embed.weight)
+        nn.init.uniform_(self.col_embed.weight)
+
+    def forward(self, tensor_list):
+        x = tensor_list.tensors
+        h, w = x.shape[-2:]
+        i = torch.arange(w, device=x.device)
+        j = torch.arange(h, device=x.device)
+        x_emb = self.col_embed(i)
+        y_emb = self.row_embed(j)
+        pos = (
+            torch.cat(
+                [
+                    x_emb.unsqueeze(0).repeat(h, 1, 1),
+                    y_emb.unsqueeze(1).repeat(1, w, 1),
+                ],
+                dim=-1,
+            )
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .repeat(x.shape[0], 1, 1, 1)
+        )
+        return pos
+
+
+def build_position_encoding(args):
+    N_steps = args.encoder_hidden_dim // 2
+    if args.position_embedding in ("v2", "sine"):
+        # TODO find a better way of exposing other arguments
+        position_embedding = PositionEmbeddingSine(N_steps, normalize=True)
+    elif args.position_embedding in ("v3", "learned"):
+        position_embedding = PositionEmbeddingLearned(N_steps)
+    else:
+        raise ValueError(f"not supported {args.position_embedding}")
+
+    return position_embedding

--- a/mmf/modules/detr/models/transformer.py
+++ b/mmf/modules/detr/models/transformer.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 import torch
 import torch.nn.functional as F
-from torch import nn, Tensor
+from torch import Tensor, nn
 
 
 class Transformer(nn.Module):

--- a/mmf/modules/detr/models/transformer.py
+++ b/mmf/modules/detr/models/transformer.py
@@ -1,0 +1,638 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/transformer.py
+"""
+DETR Transformer class.
+
+Copy-paste from torch.nn.Transformer with modifications:
+    * positional encodings are passed in MHattention
+    * extra LN at the end of encoder is removed
+    * decoder returns a stack of activations from all decoding layers
+"""
+import copy
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn, Tensor
+
+
+class Transformer(nn.Module):
+    def __init__(
+        self,
+        args,
+        d_model_enc=512,
+        d_model_dec=512,
+        nhead=8,
+        num_encoder_layers=6,
+        num_decoder_layers=6,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        pass_pos_and_query=True,
+        share_decoders=False,
+    ):
+        super().__init__()
+
+        self.args = args
+
+        self.pass_pos_and_query = pass_pos_and_query
+        encoder_layer = TransformerEncoderLayer(
+            d_model_enc, nhead, dim_feedforward, dropout, activation, normalize_before
+        )
+        encoder_norm = nn.LayerNorm(d_model_enc) if normalize_before else None
+        self.encoder = TransformerEncoder(
+            encoder_layer, num_encoder_layers, encoder_norm
+        )
+
+        if d_model_dec != d_model_enc:
+            self.enc2dec_proj = nn.Linear(d_model_enc, d_model_dec)
+            self.pos_embed_proj = nn.Linear(d_model_enc, d_model_dec)
+        else:
+            self.enc2dec_proj = nn.Identity()
+            self.pos_embed_proj = nn.Identity()
+
+        decoder_layer = TransformerDecoderLayer(
+            d_model_dec, nhead, dim_feedforward, dropout, activation, normalize_before
+        )
+        decoder_norm = nn.LayerNorm(d_model_dec)
+        self.decoder = TransformerDecoder(
+            decoder_layer,
+            num_decoder_layers,
+            decoder_norm,
+            return_intermediate=return_intermediate_dec,
+        )
+
+        self._reset_parameters()
+
+        self.d_model_enc = d_model_enc
+        self.d_model_dec = d_model_dec
+        self.nhead = nhead
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(
+        self, src, mask, query_embed, pos_embed, query_embed_vqa=None, task_idx=None
+    ):
+        # flatten NxCxHxW to HWxNxC
+        bs, c, h, w = src.shape
+        src = src.flatten(2).permute(2, 0, 1)
+        pos_embed = pos_embed.flatten(2).permute(2, 0, 1)
+        query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)
+        mask = mask.flatten(1)
+
+        if self.pass_pos_and_query:
+            tgt = torch.zeros_like(query_embed)
+        else:
+            src, tgt, query_embed, pos_embed = (
+                src + 0.1 * pos_embed,
+                query_embed,
+                None,
+                None,
+            )
+        memory = self.encoder(src, src_key_padding_mask=mask, pos=pos_embed)
+        if self.args.residual_in_encoder:
+            memory = src + memory
+        memory = self.enc2dec_proj(memory)
+        pos_embed = self.pos_embed_proj(pos_embed)
+        hs = self.decoder(
+            tgt,
+            memory,
+            memory_key_padding_mask=mask,
+            pos=pos_embed,
+            query_pos=query_embed,
+        )
+        return hs.transpose(1, 2), memory.permute(1, 2, 0).view(bs, c, h, w), None
+
+
+class MTTransformer(Transformer):
+    def __init__(
+        self,
+        args,
+        d_model_enc=512,
+        d_model_dec=512,
+        nhead=8,
+        num_encoder_layers=6,
+        num_decoder_layers=6,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        pass_pos_and_query=True,
+        share_decoders=False,
+    ):
+        super().__init__(
+            args=args,
+            d_model_enc=d_model_enc,
+            d_model_dec=d_model_dec,
+            nhead=nhead,
+            num_encoder_layers=num_encoder_layers,
+            num_decoder_layers=num_decoder_layers,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            activation=activation,
+            normalize_before=normalize_before,
+            return_intermediate_dec=return_intermediate_dec,
+            pass_pos_and_query=pass_pos_and_query,
+        )
+        # text_src is already projected from nn.Linear, so we don't need to add an extra
+        # segment embedding (the bias term in nn.Linear can learn this embedding)
+        # self.segment_projection = nn.Linear(d_model_dec, d_model_dec)
+        self.share_decoders = share_decoders
+        num_queries = self.args.num_queries
+
+        self.decoders = nn.ModuleDict()
+        for task in num_queries:
+            task_dict = nn.ModuleDict()
+            for dataset in num_queries[task]:
+                if share_decoders:
+                    task_dict[dataset] = self.decoder
+                else:
+                    self.decoder = None
+                    task_dict[dataset] = self.build_decoder_layer(
+                        d_model_dec=d_model_dec,
+                        nhead=nhead,
+                        dim_feedforward=dim_feedforward,
+                        dropout=dropout,
+                        activation=activation,
+                        normalize_before=normalize_before,
+                        num_decoder_layers=num_decoder_layers,
+                        return_intermediate_dec=return_intermediate_dec,
+                    )
+            self.decoders[task] = task_dict
+            # A separate decoder for VQA
+
+        MAX_TASK_NUM = 256
+        if args.use_task_embedding_in_encoder:
+            self.task_embeddings_enc = nn.Embedding(MAX_TASK_NUM, d_model_enc)
+        if args.use_task_embedding_in_decoder:
+            self.task_embeddings_dec = nn.Embedding(MAX_TASK_NUM, d_model_dec)
+        # when adding the task embedding to the beginning of the decoder, we'll strip
+        # it from the hidden state outputs to make it compatible with previous models
+        self.mem_out_begin_idx = 1 if args.use_task_embedding_in_encoder else 0
+        self.hs_out_begin_idx = 1 if args.use_task_embedding_in_decoder else 0
+
+    def build_decoder_layer(
+        self,
+        d_model_dec=512,
+        nhead=8,
+        num_decoder_layers=6,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+    ):
+        decoder_layer = TransformerDecoderLayer(
+            d_model_dec, nhead, dim_feedforward, dropout, activation, normalize_before
+        )
+        decoder_norm = nn.LayerNorm(d_model_dec)
+        return TransformerDecoder(
+            decoder_layer,
+            num_decoder_layers,
+            decoder_norm,
+            return_intermediate=return_intermediate_dec,
+        )
+
+    def forward(
+        self,
+        img_src=None,
+        img_mask=None,
+        img_pos=None,
+        text_src=None,
+        text_mask=None,
+        text_pos=None,
+        query_embed=None,
+        task_type=None,
+        dataset_name=None,
+        task_idx=None,
+    ):
+        # flatten NxCxHxW to HWxNxC
+        memories = []
+        pos_embeds = []
+        masks = []
+
+        if img_src is not None:
+            bs, c, h, w = img_src.shape
+            img_src = img_src.flatten(2).permute(2, 0, 1)
+            img_pos = img_pos.flatten(2).permute(2, 0, 1)
+            img_mask = img_mask.flatten(1)
+            if text_src is None:
+                query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)
+                query_embed = self._prefix_task_embedding_to_query_embed(
+                    query_embed, task_idx
+                )
+                if self.pass_pos_and_query:
+                    tgt = torch.zeros_like(query_embed)
+                else:
+                    img_src, tgt, query_embed, img_pos = (
+                        img_src + 0.1 * img_pos,
+                        query_embed,
+                        None,
+                        None,
+                    )
+            img_src, img_mask, img_pos = self._prefix_task_embedding_to_encoder_inputs(
+                img_src, img_mask, img_pos, task_idx
+            )
+            memory = self.encoder(img_src, src_key_padding_mask=img_mask, pos=img_pos)
+
+            if self.mem_out_begin_idx != 0:
+                img_src = img_src[self.mem_out_begin_idx :]
+                img_pos = img_pos[self.mem_out_begin_idx :]
+                img_mask = img_mask[:, self.mem_out_begin_idx :]
+                memory = memory[self.mem_out_begin_idx :]
+
+            if self.args.residual_in_encoder:
+                memory = img_src + memory
+
+            memory = self.enc2dec_proj(memory)
+            img_pos = self.pos_embed_proj(img_pos)
+            memories.append(memory)
+            pos_embeds.append(img_pos)
+            masks.append(img_mask)
+
+        if text_src is not None:
+            text_src = text_src.permute(1, 0, 2)
+            memories.append(text_src)
+            text_pos = text_pos.unsqueeze(1).repeat(1, text_src.size(1), 1)
+            pos_embeds.append(text_pos)
+            masks.append(text_mask != 1)
+
+            query_embed = query_embed.unsqueeze(1).repeat(1, text_src.size(1), 1)
+            query_embed = self._prefix_task_embedding_to_query_embed(
+                query_embed, task_idx
+            )
+            if self.pass_pos_and_query:
+                tgt = torch.zeros_like(query_embed)
+            else:
+                raise NotImplementedError()
+
+        decoder = self.decoders[task_type][dataset_name]
+
+        memories = torch.cat(memories)
+        masks = torch.cat(masks, dim=-1)
+        pos_embeds = torch.cat(pos_embeds)
+
+        hs = decoder(
+            tgt,
+            memories,
+            memory_key_padding_mask=masks,
+            pos=pos_embeds,
+            query_pos=query_embed,
+        )
+        hs = hs.transpose(1, 2)
+        # hs is num_layer x batch_size x seq_length x hidden_dim
+        hs = hs[:, :, self.hs_out_begin_idx :, :]
+
+        return hs, memories.permute(1, 2, 0)
+
+    def _prefix_task_embedding_to_query_embed(self, query_embed, task_idx):
+        if not self.args.use_task_embedding_in_decoder:
+            return query_embed
+
+        bs = query_embed.size(1)
+        task_embed = self.task_embeddings_dec.weight[task_idx]
+        task_embed = task_embed.unsqueeze(0).unsqueeze(0).repeat(1, bs, 1)
+        query_embed = torch.cat([task_embed, query_embed], dim=0)
+        return query_embed
+
+    def _prefix_task_embedding_to_encoder_inputs(
+        self, img_src, img_mask, img_pos, task_idx
+    ):
+        if not self.args.use_task_embedding_in_encoder:
+            return img_src, img_mask, img_pos
+
+        bs = img_src.size(1)
+        task_embed = self.task_embeddings_enc.weight[task_idx]
+        task_embed = task_embed.unsqueeze(0).unsqueeze(0).repeat(1, bs, 1)
+        img_src = torch.cat([task_embed, img_src], dim=0)
+
+        # 0 for non-padding in img_mask
+        img_mask_pad = torch.zeros_like(img_mask[:, :1])
+        img_mask = torch.cat([img_mask_pad, img_mask], dim=1)
+        img_pos_pad = torch.zeros_like(img_pos[:1])
+        img_pos = torch.cat([img_pos_pad, img_pos], dim=0)
+
+        return img_src, img_mask, img_pos
+
+
+class TransformerEncoder(nn.Module):
+    def __init__(self, encoder_layer, num_layers, norm=None):
+        super().__init__()
+        self.layers = _get_clones(encoder_layer, num_layers)
+        self.num_layers = num_layers
+        self.norm = norm
+
+    def forward(
+        self,
+        src,
+        mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        output = src
+
+        for layer in self.layers:
+            output = layer(
+                output,
+                src_mask=mask,
+                src_key_padding_mask=src_key_padding_mask,
+                pos=pos,
+            )
+
+        if self.norm is not None:
+            output = self.norm(output)
+
+        return output
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, decoder_layer, num_layers, norm=None, return_intermediate=False):
+        super().__init__()
+        self.layers = _get_clones(decoder_layer, num_layers)
+        self.num_layers = num_layers
+        self.norm = norm
+        self.return_intermediate = return_intermediate
+
+    def forward(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        output = tgt
+
+        intermediate = []
+
+        for layer in self.layers:
+            output = layer(
+                output,
+                memory,
+                tgt_mask=tgt_mask,
+                memory_mask=memory_mask,
+                tgt_key_padding_mask=tgt_key_padding_mask,
+                memory_key_padding_mask=memory_key_padding_mask,
+                pos=pos,
+                query_pos=query_pos,
+            )
+            if self.return_intermediate:
+                intermediate.append(self.norm(output))
+
+        if self.norm is not None:
+            output = self.norm(output)
+            if self.return_intermediate:
+                intermediate.pop()
+                intermediate.append(output)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate)
+
+        return output
+
+
+class TransformerEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+    ):
+        super().__init__()
+        self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        # Implementation of Feedforward model
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+
+        self.activation = _get_activation_fn(activation)
+        self.normalize_before = normalize_before
+
+    def with_pos_embed(self, tensor, pos: Optional[Tensor]):
+        return tensor if pos is None else tensor + pos
+
+    def forward_post(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        q = k = self.with_pos_embed(src, pos)
+        src2 = self.self_attn(
+            q, k, value=src, attn_mask=src_mask, key_padding_mask=src_key_padding_mask
+        )[0]
+        src = src + self.dropout1(src2)
+        src = self.norm1(src)
+        src2 = self.linear2(self.dropout(self.activation(self.linear1(src))))
+        src = src + self.dropout2(src2)
+        src = self.norm2(src)
+        return src
+
+    def forward_pre(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        src2 = self.norm1(src)
+        q = k = self.with_pos_embed(src2, pos)
+        src2 = self.self_attn(
+            q, k, value=src2, attn_mask=src_mask, key_padding_mask=src_key_padding_mask
+        )[0]
+        src = src + self.dropout1(src2)
+        src2 = self.norm2(src)
+        src2 = self.linear2(self.dropout(self.activation(self.linear1(src2))))
+        src = src + self.dropout2(src2)
+        return src
+
+    def forward(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        if self.normalize_before:
+            return self.forward_pre(src, src_mask, src_key_padding_mask, pos)
+        return self.forward_post(src, src_mask, src_key_padding_mask, pos)
+
+
+class TransformerDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+    ):
+        super().__init__()
+        self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        self.multihead_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        # Implementation of Feedforward model
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.norm3 = nn.LayerNorm(d_model)
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+        self.dropout3 = nn.Dropout(dropout)
+
+        self.activation = _get_activation_fn(activation)
+        self.normalize_before = normalize_before
+
+    def with_pos_embed(self, tensor, pos: Optional[Tensor]):
+        return tensor if pos is None else tensor + pos
+
+    def forward_post(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        q = k = self.with_pos_embed(tgt, query_pos)
+        tgt2 = self.self_attn(
+            q, k, value=tgt, attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask
+        )[0]
+        tgt = tgt + self.dropout1(tgt2)
+        tgt = self.norm1(tgt)
+        tgt2 = self.multihead_attn(
+            query=self.with_pos_embed(tgt, query_pos),
+            key=self.with_pos_embed(memory, pos),
+            value=memory,
+            attn_mask=memory_mask,
+            key_padding_mask=memory_key_padding_mask,
+        )[0]
+        tgt = tgt + self.dropout2(tgt2)
+        tgt = self.norm2(tgt)
+        tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt))))
+        tgt = tgt + self.dropout3(tgt2)
+        tgt = self.norm3(tgt)
+        return tgt
+
+    def forward_pre(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        tgt2 = self.norm1(tgt)
+        q = k = self.with_pos_embed(tgt2, query_pos)
+        tgt2 = self.self_attn(
+            q, k, value=tgt2, attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask
+        )[0]
+        tgt = tgt + self.dropout1(tgt2)
+        tgt2 = self.norm2(tgt)
+        tgt2 = self.multihead_attn(
+            query=self.with_pos_embed(tgt2, query_pos),
+            key=self.with_pos_embed(memory, pos),
+            value=memory,
+            attn_mask=memory_mask,
+            key_padding_mask=memory_key_padding_mask,
+        )[0]
+        tgt = tgt + self.dropout2(tgt2)
+        tgt2 = self.norm3(tgt)
+        tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt2))))
+        tgt = tgt + self.dropout3(tgt2)
+        return tgt
+
+    def forward(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        if self.normalize_before:
+            return self.forward_pre(
+                tgt,
+                memory,
+                tgt_mask,
+                memory_mask,
+                tgt_key_padding_mask,
+                memory_key_padding_mask,
+                pos,
+                query_pos,
+            )
+        return self.forward_post(
+            tgt,
+            memory,
+            tgt_mask,
+            memory_mask,
+            tgt_key_padding_mask,
+            memory_key_padding_mask,
+            pos,
+            query_pos,
+        )
+
+
+def _get_clones(module, N):
+    return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+
+def build_transformer(args):
+    # TODO(ronghanghu): remove all other parameters and use args only
+    return MTTransformer(
+        args=args,
+        d_model_enc=args.encoder_hidden_dim,
+        d_model_dec=args.decoder_hidden_dim,
+        dropout=args.dropout,
+        nhead=args.nheads,
+        dim_feedforward=args.dim_feedforward,
+        num_encoder_layers=args.enc_layers,
+        num_decoder_layers=args.dec_layers,
+        normalize_before=args.pre_norm,
+        return_intermediate_dec=True,
+        pass_pos_and_query=args.pass_pos_and_query,
+        share_decoders=args.share_decoders,
+    )
+
+
+def _get_activation_fn(activation):
+    """Return an activation function given a string"""
+    if activation == "relu":
+        return F.relu
+    if activation == "gelu":
+        return F.gelu
+    if activation == "glu":
+        return F.glu
+    raise RuntimeError(f"activation should be relu/gelu, not {activation}.")

--- a/mmf/modules/detr/util/__init__.py
+++ b/mmf/modules/detr/util/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/mmf/modules/detr/util/box_ops.py
+++ b/mmf/modules/detr/util/box_ops.py
@@ -1,0 +1,83 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/util/box_ops.py
+import torch
+from torchvision.ops.boxes import box_area
+
+
+def box_cxcywh_to_xyxy(x):
+    x_c, y_c, w, h = x.unbind(-1)
+    b = [(x_c - 0.5 * w), (y_c - 0.5 * h), (x_c + 0.5 * w), (y_c + 0.5 * h)]
+    return torch.stack(b, dim=-1)
+
+
+def box_xyxy_to_cxcywh(x):
+    x0, y0, x1, y1 = x.unbind(-1)
+    b = [(x0 + x1) / 2, (y0 + y1) / 2, (x1 - x0), (y1 - y0)]
+    return torch.stack(b, dim=-1)
+
+
+# modified from torchvision to also return the union
+def box_iou(boxes1, boxes2):
+    area1 = box_area(boxes1)
+    area2 = box_area(boxes2)
+
+    lt = torch.max(boxes1[:, None, :2], boxes2[:, :2])  # [N,M,2]
+    rb = torch.min(boxes1[:, None, 2:], boxes2[:, 2:])  # [N,M,2]
+
+    wh = (rb - lt).clamp(min=0)  # [N,M,2]
+    inter = wh[:, :, 0] * wh[:, :, 1]  # [N,M]
+
+    union = area1[:, None] + area2 - inter
+
+    iou = inter / union
+    return iou, union
+
+
+def generalized_box_iou(boxes1, boxes2):
+    """
+    Generalized IoU from https://giou.stanford.edu/
+    The boxes should be in [x0, y0, x1, y1] format
+    Returns a [N, M] pairwise matrix, where N = len(boxes1)
+    and M = len(boxes2)
+    """
+    # degenerate boxes gives inf / nan results
+    # so do an early check
+    assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
+    assert (boxes2[:, 2:] >= boxes2[:, :2]).all()
+    iou, union = box_iou(boxes1, boxes2)
+
+    lt = torch.min(boxes1[:, None, :2], boxes2[:, :2])
+    rb = torch.max(boxes1[:, None, 2:], boxes2[:, 2:])
+
+    wh = (rb - lt).clamp(min=0)  # [N,M,2]
+    area = wh[:, :, 0] * wh[:, :, 1]
+
+    return iou - (area - union) / area
+
+
+def masks_to_boxes(masks):
+    """Compute the bounding boxes around the provided masks
+    The masks should be in format [N, H, W] where N is the number of masks,
+    (H, W) are the spatial dimensions.
+    Returns a [N, 4] tensors, with the boxes in xyxy format
+    """
+    if masks.numel() == 0:
+        return torch.zeros((0, 4), device=masks.device)
+
+    h, w = masks.shape[-2:]
+
+    y = torch.arange(0, h, dtype=torch.float)
+    x = torch.arange(0, w, dtype=torch.float)
+    y, x = torch.meshgrid(y, x)
+
+    x_mask = masks * x.unsqueeze(0)
+    x_max = x_mask.flatten(1).max(-1)[0]
+    x_min = x_mask.masked_fill(~(masks.bool()), 1e8).flatten(1).min(-1)[0]
+
+    y_mask = masks * y.unsqueeze(0)
+    y_max = y_mask.flatten(1).max(-1)[0]
+    y_min = y_mask.masked_fill(~(masks.bool()), 1e8).flatten(1).min(-1)[0]
+
+    return torch.stack([x_min, y_min, x_max, y_max], 1)

--- a/mmf/modules/detr/util/misc.py
+++ b/mmf/modules/detr/util/misc.py
@@ -1,0 +1,107 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/util/misc.py
+import torch
+import torch.distributed as dist
+
+
+class NestedTensor(object):
+    def __init__(self, tensors, mask):
+        self.tensors = tensors
+        self.mask = mask
+
+    def to(self, *args, **kwargs):
+        cast_tensor = self.tensors.to(*args, **kwargs)
+        cast_mask = self.mask.to(*args, **kwargs) if self.mask is not None else None
+        return type(self)(cast_tensor, cast_mask)
+
+    def decompose(self):
+        return self.tensors, self.mask
+
+    @classmethod
+    def from_tensor_list(cls, tensor_list):
+        # TODO make this more general
+        if tensor_list[0].ndim == 3:
+            # TODO make it support different-sized images
+            max_size = tuple(max(s) for s in zip(*[img.shape for img in tensor_list]))
+            # min_size = tuple(min(s) for s in zip(*[img.shape for img in tensor_list]))
+            batch_shape = (len(tensor_list),) + max_size
+            b, c, h, w = batch_shape
+            dtype = tensor_list[0].dtype
+            device = tensor_list[0].device
+            tensor = torch.zeros(batch_shape, dtype=dtype, device=device)
+            mask = torch.ones((b, h, w), dtype=torch.bool, device=device)
+            for img, pad_img, m in zip(tensor_list, tensor, mask):
+                pad_img[: img.shape[0], : img.shape[1], : img.shape[2]].copy_(img)
+                m[: img.shape[1], : img.shape[2]] = False
+        else:
+            raise ValueError("not supported")
+        return cls(tensor, mask)
+
+    def __repr__(self):
+        return repr(self.tensors)
+
+
+def setup_for_distributed(is_master):
+    """
+    This function disables printing when not in master process
+    """
+    import builtins as __builtin__
+
+    builtin_print = __builtin__.print
+
+    def print(*args, **kwargs):
+        force = kwargs.pop("force", False)
+        if is_master or force:
+            builtin_print(*args, **kwargs)
+
+    __builtin__.print = print
+
+
+def is_dist_avail_and_initialized():
+    if not dist.is_available():
+        return False
+    if not dist.is_initialized():
+        return False
+    return True
+
+
+def get_world_size():
+    if not is_dist_avail_and_initialized():
+        return 1
+    return dist.get_world_size()
+
+
+def get_rank():
+    if not is_dist_avail_and_initialized():
+        return 0
+    return dist.get_rank()
+
+
+def is_main_process():
+    return get_rank() == 0
+
+
+def save_on_master(*args, **kwargs):
+    if is_main_process():
+        torch.save(*args, **kwargs)
+
+
+@torch.no_grad()
+def accuracy(output, target, topk=(1,)):
+    """Computes the precision@k for the specified values of k"""
+    if target.numel() == 0:
+        return [torch.zeros([], device=output.device)]
+    maxk = max(topk)
+    batch_size = target.size(0)
+
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    res = []
+    for k in topk:
+        correct_k = correct[:k].view(-1).float().sum(0)
+        res.append(correct_k.mul_(100.0 / batch_size))
+    return res

--- a/mmf/modules/optimizers.py
+++ b/mmf/modules/optimizers.py
@@ -1,7 +1,83 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import math
+from typing import Callable
 
+import torch
 from mmf.common.registry import registry
 from transformers.optimization import AdamW
 
 
+class AdamWSkipParamsWithZeroGrad(AdamW):
+    def step(self, closure: Callable = None):
+        """
+        Performs a single optimization step.
+        Arguments:
+            closure (:obj:`Callable`, `optional`): A closure that reevaluates the model and returns the loss.
+
+        modified from https://github.com/huggingface/transformers/blob/d2f9cb838ec1ed7f62ddfb850dccd223e19441ad/src/transformers/optimization.py#L259-L318
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if p.grad.abs().sum().item() == 0:
+                    continue
+                grad = p.grad.data
+                if grad.is_sparse:
+                    raise RuntimeError(
+                        "Adam does not support sparse gradients, please consider SparseAdam instead"
+                    )
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state["step"] = 0
+                    # Exponential moving average of gradient values
+                    state["exp_avg"] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state["exp_avg_sq"] = torch.zeros_like(p.data)
+
+                exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
+                beta1, beta2 = group["betas"]
+
+                state["step"] += 1
+
+                # Decay the first and second moment running average coefficient
+                # In-place operations to update the averages at the same time
+                exp_avg.mul_(beta1).add_(grad, alpha=1.0 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
+                denom = exp_avg_sq.sqrt().add_(group["eps"])
+
+                step_size = group["lr"]
+                if group["correct_bias"]:  # No bias correction for Bert
+                    bias_correction1 = 1.0 - beta1 ** state["step"]
+                    bias_correction2 = 1.0 - beta2 ** state["step"]
+                    step_size = (
+                        step_size * math.sqrt(bias_correction2) / bias_correction1
+                    )
+
+                p.data.addcdiv_(exp_avg, denom, value=-step_size)
+
+                # Just adding the square of the weights to the loss function is *not*
+                # the correct way of using L2 regularization/weight decay with Adam,
+                # since that will interact with the m and v parameters in strange ways.
+                #
+                # Instead we want to decay the weights in a manner that doesn't interact
+                # with the m/v parameters. This is equivalent to adding the square
+                # of the weights to the loss with plain (non-momentum) SGD.
+                # Add weight decay at the end (fixed version)
+                if group["weight_decay"] > 0.0:
+                    p.data.add_(p.data, alpha=-group["lr"] * group["weight_decay"])
+
+        return loss
+
+
 registry.register_optimizer("adam_w")(AdamW)
+registry.register_optimizer("adam_w_skip_params_with_zero_grad")(
+    AdamWSkipParamsWithZeroGrad
+)

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -42,7 +42,7 @@ class TrainerTrainingLoopMixin(ABC):
             and self.num_updates % self.training_config.evaluation_interval != 0
         ):
             # Create a new meter for this case
-            report, meter = self.evaluation_loop(self.val_loader)
+            report, meter = self.evaluation_loop("val")
 
             # Validation end callbacks
             self.on_validation_end(report=report, meter=meter)
@@ -132,7 +132,7 @@ class TrainerTrainingLoopMixin(ABC):
                     logger.info("Evaluation time. Running on full validation set...")
                     # Validation and Early stopping
                     # Create a new meter for this case
-                    report, meter = self.evaluation_loop(self.val_loader)
+                    report, meter = self.evaluation_loop("val")
 
                     # Validation end callbacks
                     stop = self.early_stop_callback.on_validation_end(

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -140,7 +140,5 @@ class MMFTrainer(
             else:
                 self.on_test_start()
                 logger.info(f"Starting inference on {dataset} set")
-                report, meter = self.evaluation_loop(
-                    getattr(self, f"{dataset}_loader"), use_tqdm=True
-                )
+                report, meter = self.evaluation_loop(dataset, use_tqdm=True)
                 self.on_test_end(report=report, meter=meter)

--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -110,6 +110,23 @@ def gather_tensor(tensor):
     return tensor_list
 
 
+def gather_tensor_along_batch(tensor, dim=0):
+    world_size = get_world_size()
+
+    if world_size < 2:
+        return tensor
+
+    with torch.no_grad():
+        tensor_list = []
+
+        for _ in range(world_size):
+            tensor_list.append(torch.zeros_like(tensor))
+
+        dist.all_gather(tensor_list, tensor)
+        tensor_list = torch.cat(tensor_list, dim=dim)
+    return tensor_list
+
+
 def reduce_dict(dictionary):
     world_size = get_world_size()
     if world_size < 2:

--- a/projects/unit/configs/coco/single_task.yaml
+++ b/projects/unit/configs/coco/single_task.yaml
@@ -1,0 +1,62 @@
+model_config:
+  unit:
+    detr_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+      share_decoders: false
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    bert_config:
+      bert_model_name: bert-base-uncased
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    detr_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    detr_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection/annotations/instances_val2017.json
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 150000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: detection_coco/detection_mean_ap
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true

--- a/projects/unit/configs/coco_vg_vqa2/separate_dec.yaml
+++ b/projects/unit/configs/coco_vg_vqa2/separate_dec.yaml
@@ -1,0 +1,10 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    detr_args:
+      share_decoders: false
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW

--- a/projects/unit/configs/coco_vg_vqa2/separate_dec_no_attr_loss.yaml
+++ b/projects/unit/configs/coco_vg_vqa2/separate_dec_no_attr_loss.yaml
@@ -1,0 +1,9 @@
+includes:
+- ./separate_dec.yaml
+
+model_config:
+  unit:
+    datasets:
+      detection:
+        detection_visual_genome:
+          use_attr: false

--- a/projects/unit/configs/coco_vg_vqa2/shared_dec.yaml
+++ b/projects/unit/configs/coco_vg_vqa2/shared_dec.yaml
@@ -1,0 +1,110 @@
+model_config:
+  unit:
+    detr_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+          detection_visual_genome: 100
+        vl:
+          vqa2: 25
+      share_decoders: true
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    bert_config:
+      bert_model_name: bert-base-uncased
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    detr_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    detr_ckpt_load_backbone_only: true
+
+dataset_config:
+  vqa2:
+    return_features_info: true
+    use_features: false
+    use_images: true
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 25
+      detr_image_processor:
+        type: detr_image
+        params:
+          image_size: 800
+          max_size: 1333
+    images:
+      train:
+      - coco/defaults/images/trainval2014
+      - coco/defaults/images/trainval2014
+      - coco/defaults/images/trainval2014
+      val:
+      - coco/defaults/images/trainval2014
+      test:
+      - coco/defaults/images/test2015
+    annotations:
+      train:
+      - vqa2/defaults/annotations/imdb_train2017.npy
+      - vqa2/defaults/annotations/imdb_vg_karpathytrain_not_in_val2017.npy
+      - vqa2/defaults/annotations/imdb_vg_karpathytest_not_in_val2017.npy
+      val:
+      - vqa2/defaults/annotations/imdb_val2017.npy
+      test:
+      - vqa2/defaults/annotations/imdb_test2015.npy
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    - detection_visual_genome
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection/annotations/instances_val2017.json
+        detection_visual_genome:
+          val: ${env.data_dir}/datasets/visual_genome/detection/annotations/instances_val_split_wrt_coco2017.json
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad  # skip update on unused params in a batch
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 450000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true

--- a/projects/unit/configs/coco_vg_vqa2/shared_dec_no_attr_loss.yaml
+++ b/projects/unit/configs/coco_vg_vqa2/shared_dec_no_attr_loss.yaml
@@ -1,0 +1,9 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    datasets:
+      detection:
+        detection_visual_genome:
+          use_attr: false

--- a/projects/unit/configs/coco_vqa2/separate_dec.yaml
+++ b/projects/unit/configs/coco_vqa2/separate_dec.yaml
@@ -1,0 +1,10 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    detr_args:
+      share_decoders: false
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW

--- a/projects/unit/configs/coco_vqa2/shared_dec.yaml
+++ b/projects/unit/configs/coco_vqa2/shared_dec.yaml
@@ -1,0 +1,106 @@
+model_config:
+  unit:
+    detr_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+        vl:
+          vqa2: 25
+      share_decoders: true
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    bert_config:
+      bert_model_name: bert-base-uncased
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    detr_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    detr_ckpt_load_backbone_only: true
+
+dataset_config:
+  vqa2:
+    return_features_info: true
+    use_features: false
+    use_images: true
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 25
+      detr_image_processor:
+        type: detr_image
+        params:
+          image_size: 800
+          max_size: 1333
+    images:
+      train:
+      - coco/defaults/images/trainval2014
+      - coco/defaults/images/trainval2014
+      - coco/defaults/images/trainval2014
+      val:
+      - coco/defaults/images/trainval2014
+      test:
+      - coco/defaults/images/test2015
+    annotations:
+      train:
+      - vqa2/defaults/annotations/imdb_train2017.npy
+      - vqa2/defaults/annotations/imdb_vg_karpathytrain_not_in_val2017.npy
+      - vqa2/defaults/annotations/imdb_vg_karpathytest_not_in_val2017.npy
+      val:
+      - vqa2/defaults/annotations/imdb_val2017.npy
+      test:
+      - vqa2/defaults/annotations/imdb_test2015.npy
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection/annotations/instances_val2017.json
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad  # skip update on unused params in a batch
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 300000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true

--- a/projects/unit/configs/vg/single_task.yaml
+++ b/projects/unit/configs/vg/single_task.yaml
@@ -1,0 +1,62 @@
+model_config:
+  unit:
+    detr_args:
+      num_queries:
+        detection:
+          detection_visual_genome: 100
+      share_decoders: false
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    bert_config:
+      bert_model_name: bert-base-uncased
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    detr_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    detr_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_visual_genome
+    params:
+      dataset_json_files:
+        detection_visual_genome:
+          val: ${env.data_dir}/datasets/visual_genome/detection/annotations/instances_val_split_wrt_coco2017.json
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 150000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: detection_visual_genome/detection_mean_ap
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true

--- a/projects/unit/configs/vg/single_task_no_attr_loss.yaml
+++ b/projects/unit/configs/vg/single_task_no_attr_loss.yaml
@@ -1,0 +1,9 @@
+includes:
+- ./single_task.yaml
+
+model_config:
+  unit:
+    datasets:
+      detection:
+        detection_visual_genome:
+          use_attr: false

--- a/projects/unit/configs/vqa2/single_task.yaml
+++ b/projects/unit/configs/vqa2/single_task.yaml
@@ -1,0 +1,96 @@
+model_config:
+  unit:
+    detr_args:
+      num_queries:
+        vl:
+          vqa2: 25
+      share_decoders: false
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    bert_config:
+      bert_model_name: bert-base-uncased
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    detr_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    detr_ckpt_load_backbone_only: true
+
+dataset_config:
+  vqa2:
+    return_features_info: true
+    use_features: false
+    use_images: true
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 25
+      detr_image_processor:
+        type: detr_image
+        params:
+          image_size: 800
+          max_size: 1333
+    images:
+      train:
+      - coco/defaults/images/trainval2014
+      - coco/defaults/images/trainval2014
+      - coco/defaults/images/trainval2014
+      val:
+      - coco/defaults/images/trainval2014
+      test:
+      - coco/defaults/images/test2015
+    annotations:
+      train:
+      - vqa2/defaults/annotations/imdb_train2017.npy
+      - vqa2/defaults/annotations/imdb_vg_karpathytrain_not_in_val2017.npy
+      - vqa2/defaults/annotations/imdb_vg_karpathytest_not_in_val2017.npy
+      val:
+      - vqa2/defaults/annotations/imdb_val2017.npy
+      test:
+      - vqa2/defaults/annotations/imdb_test2015.npy
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 150000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ sklearn==0.0
 omegaconf==2.0.1rc4
 lmdb==0.98
 termcolor==1.1.0
+datasets==1.1.2
+pycocotools==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch==1.6.0
 torchvision==0.7.0
 numpy>=1.16.6
-tqdm>=4.43.0
+tqdm>=4.43.0,<4.50.0
 demjson==2.2.4
 torchtext==0.5.0
 GitPython==3.1.0
@@ -14,5 +14,5 @@ sklearn==0.0
 omegaconf==2.0.1rc4
 lmdb==0.98
 termcolor==1.1.0
-datasets==1.1.2
+datasets==1.2.1
 pycocotools==2.0.2


### PR DESCRIPTION
Summary
- Per dataset evaluation loop and metric
  - change the current evaluation loop (that runs on the union of all datasets) to per-dataset evaluation.
  - allow running metrics only on a subset with `datasets` config field (see example below)
  - generate prediction JSON object during evaluation loop, which can be consumed by metrics that evaluate the entire dataset (e.g. mAP for object detection or CIDEr for image captioning) and cannot be expressed as averaging over per-batch metrics
 - detection dataset support
   - COCO detection dataset
   - Visual Genome detection (object and attribute) dataset
   - relevant parts (e.g. package dependencies, test reporter, batch collator, etc.)
 - UniT model
   - (moved several hard-coded components into config, such as MT_DATASETS)
   - tested w/ previous snapshots -- results match the paper on COCO, VG and VQAv2

Example on specifying per-dataset metric with `datasets` (here `vqa_accuracy` will only run on vqa2 while `detection_mean_ap` will only run on detection_coco and detection_visual_genome). If `datasets` is not specified, the default behavior is to run on all dataset:
```
evaluation:
  metrics:
  - type: vqa_accuracy
    datasets:
    - vqa2
  - type: detection_mean_ap
    datasets:
    - detection_coco
    - detection_visual_genome
 ```