### PR TITLE
[feat] pytorch lightning integration - training

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -4,6 +4,7 @@ config_version: 1.0
 # Configuration for training
 training:
     # Name of the trainer class used to define the training/evalution loop
+    # `mmf` for default trainer, `lightning` for Pytorch Lightning trainer
     trainer: mmf
     # Seed to be used for training. -1 means random seed between 1 and 100000.
     # Either pass fixed through your config or command line arguments

--- a/mmf/datasets/base_dataset.py
+++ b/mmf/datasets/base_dataset.py
@@ -65,7 +65,7 @@ class BaseDataset(Dataset):
 
     def prepare_batch(self, batch):
         """
-        Can be possibly overridden in your child class
+        Can be possibly overridden in your child class. Deprecated w Pytorch Lightning
 
         Prepare batch for passing to model. Whatever returned from here will
         be directly passed to model's forward function. Currently moves the batch to

--- a/mmf/datasets/lightning_datamodule.py
+++ b/mmf/datasets/lightning_datamodule.py
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Optional
+
+import pytorch_lightning as pl
+from mmf.datasets.multi_dataset_loader import MultiDatasetLoader
+from mmf.utils.general import get_batch_size
+
+
+class LightningDataModule(pl.LightningDataModule):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.batch_size = get_batch_size()
+
+        self.train_loader = MultiDatasetLoader("train")
+        self.val_loader = MultiDatasetLoader("val")
+        self.test_loader = MultiDatasetLoader("test")
+
+        self.train_loader.load(self.config)
+        self.val_loader.load(self.config)
+        self.test_loader.load(self.config)
+
+    def prepare_data(self):
+        pass
+
+    def setup(self, stage: Optional[str] = None):
+        pass
+
+    def train_dataloader(self):
+        return self.train_loader
+
+    def val_dataloader(self):
+        return self.val_loader
+
+    def test_dataloader(self):
+        return self.test_loader

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 """
-Models built on top of Pythia need to inherit ``BaseModel`` class and adhere to
+Models built on top of MMF need to inherit ``BaseModel`` class and adhere to
 some format. To create a model for MMF, follow this quick cheatsheet.
 
 1. Inherit ``BaseModel`` class, make sure to call ``super().__init__()`` in your
@@ -48,19 +48,29 @@ from dataclasses import dataclass
 from typing import Union
 
 from mmf.common.registry import registry
-from mmf.common.sample import to_device
+from mmf.common.sample import SampleList, to_device
 from mmf.modules.losses import Losses
 from mmf.utils.checkpoint import load_pretrained_model
 from mmf.utils.download import download_pretrained_model
 from mmf.utils.file_io import PathManager
 from omegaconf import MISSING, DictConfig, OmegaConf
-from torch import nn
 
+
+try:
+    import pytorch_lightning as pl
+except ImportError:
+    print(
+        "BaseModel requires Pytorch Lightning. "
+        + "Please follow the installation here: "
+        + "https://pytorch-lightning.readthedocs.io/"
+        + "en/latest/introduction_guide.html"
+    )
+    raise
 
 logger = logging.getLogger(__name__)
 
 
-class BaseModel(nn.Module):
+class BaseModel(pl.LightningModule):
     """For integration with MMF's trainer, datasets and other features,
     models needs to inherit this class, call `super`, write a build function,
     write a forward function taking a ``SampleList`` as input and returning a
@@ -82,8 +92,10 @@ class BaseModel(nn.Module):
             config = OmegaConf.structured(config)
 
         self.config = config
+
         self._logged_warning = {"losses_present": False}
         self._is_pretrained = False
+        self._is_pl_enabled = False
 
     @classmethod
     def from_params(cls, **kwargs):
@@ -93,9 +105,17 @@ class BaseModel(nn.Module):
     def is_pretrained(self):
         return self._is_pretrained
 
+    @property
+    def is_pl_enabled(self):
+        return self._is_pl_enabled
+
     @is_pretrained.setter
     def is_pretrained(self, x: bool):
         self._is_pretrained = x
+
+    @is_pl_enabled.setter
+    def is_pl_enabled(self, x: bool):
+        self._is_pl_enabled = x
 
     def build(self):
         """Function to be implemented by the child class, in case they need to
@@ -163,10 +183,73 @@ class BaseModel(nn.Module):
             "Forward of the child model class needs to be implemented."
         )
 
+    def training_step(self, batch, batch_idx, *args, **kwargs):
+        """Member function of PL modules. Used only when PL enabled.
+        To be implemented by child class. Takes in a ``SampleList``,
+        batch_idx and returns back a dict.
+
+        Args:
+            sample_list (SampleList): SampleList returned by the DataLoader for
+            current iteration
+
+        Returns:
+            Dict: Dict containing loss.
+        """
+        batch = self._ensure_sample_list(batch)
+        output = self(batch)
+        loss_dict = output["losses"]
+        output["loss"] = sum([loss.mean() for loss in loss_dict.values()])
+        return output
+
+    def validation_step(self, batch, batch_idx, *args, **kwargs):
+        """Member function of PL modules. Used only when PL enabled.
+        To be implemented by child class. Takes in a ``SampleList``,
+        batch_idx and returns back a dict.
+
+        Args:
+            sample_list (SampleList): SampleList returned by the DataLoader for
+            current iteration
+
+        Returns:
+            Dict
+        """
+        batch = self._ensure_sample_list(batch)
+        output = self(batch)
+        # TODO: @sash Implementation coming soon! (next PR)
+        return output
+
+    def configure_optimizers(self):
+        """ Member function of PL modules. Used only when PL enabled."""
+        assert self._is_pl_enabled, (
+            "configure_optimizers should be only used as a member "
+            "function of LightningModule when pytorch lightning is enabled."
+        )
+
+        from mmf.utils.build import build_optimizer, build_scheduler
+
+        config = registry.get("config")
+        optimizer = build_optimizer(self, config)
+
+        if config.training.lr_scheduler:
+            lr_scheduler = build_scheduler(optimizer, config)
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {"scheduler": lr_scheduler, "interval": "step"},
+            }
+        else:
+            return optimizer
+
+    def _ensure_sample_list(self, batch):
+        if not isinstance(batch, SampleList):
+            # Try converting to SampleList
+            batch = SampleList(batch)
+        return batch
+
     def __call__(self, sample_list, *args, **kwargs):
-        # Move to proper device i.e. same as the model before passing
-        model_device = next(self.parameters()).device
-        sample_list = to_device(sample_list, model_device)
+        if not self._is_pl_enabled:
+            # Move to proper device i.e. same as the model before passing
+            model_device = next(self.parameters()).device
+            sample_list = to_device(sample_list, model_device)
 
         model_output = super().__call__(sample_list, *args, **kwargs)
 
@@ -174,7 +257,7 @@ class BaseModel(nn.Module):
         if self.is_pretrained:
             return model_output
 
-        # Make sure theat the output from the model is a Mapping
+        # Make sure that the output from the model is a Mapping
         assert isinstance(
             model_output, collections.abc.Mapping
         ), "A dict must be returned from the forward of the model."

--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -62,7 +62,7 @@ class Losses(nn.Module):
         mostly doesn't need to use this class.
 
     Attributes:
-        losses: List containing instanttions of each loss
+        losses: List containing instantiations of each loss
                                    passed in config
     """
 
@@ -322,8 +322,7 @@ class CaptionCrossEntropyLoss(nn.Module):
 
 @registry.register_loss("nll_loss")
 class NLLLoss(nn.Module):
-    """Negative log likelikehood loss.
-    """
+    """Negative log likelikehood loss."""
 
     def __init__(self):
         super().__init__()

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -2,7 +2,6 @@
 
 import gc
 import logging
-import warnings
 from abc import ABC
 from typing import Any, Dict
 
@@ -10,7 +9,7 @@ import torch
 from mmf.common.registry import registry
 from mmf.common.report import Report
 from mmf.common.sample import to_device
-from mmf.utils.general import clip_gradients
+from mmf.utils.general import clip_gradients, get_max_updates
 from torch import Tensor
 
 
@@ -217,27 +216,9 @@ class TrainerTrainingLoopMixin(ABC):
         return loss
 
     def _calculate_max_updates(self):
-        max_updates = self.training_config.max_updates
-        max_epochs = self.training_config.max_epochs
-        if max_updates is None and max_epochs is None:
-            raise ValueError("Neither max_updates nor max_epochs is specified.")
-
-        if isinstance(
-            self.train_loader.current_dataset, torch.utils.data.IterableDataset
-        ):
-            warnings.warn(
-                "max_epochs not supported for Iterable datasets. Falling back "
-                + "to max_updates."
-            )
-            return max_updates
-
-        if max_updates is not None and max_epochs is not None:
-            warnings.warn(
-                "Both max_updates and max_epochs are specified. "
-                + f"Favoring max_epochs: {max_epochs}"
-            )
-
-        if max_epochs is not None:
-            max_updates = len(self.train_loader) * max_epochs
-
+        config_max_updates = self.training_config.max_updates
+        config_max_epochs = self.training_config.max_epochs
+        max_updates, _ = get_max_updates(
+            config_max_updates, config_max_epochs, self.train_loader
+        )
         return max_updates

--- a/mmf/trainers/lightning_core/__init__.py
+++ b/mmf/trainers/lightning_core/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -1,0 +1,48 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import logging
+
+from mmf.common.registry import registry
+from mmf.utils.checkpoint import Checkpoint
+from pytorch_lightning.callbacks.base import Callback
+
+
+logger = logging.getLogger(__name__)
+
+
+class LightningLoopCallback(Callback):
+    def __init__(self, lightning_trainer):
+        super().__init__()
+        self.lightning_trainer = lightning_trainer
+
+    def on_init_start(self, trainer):
+        self._checkpoint = Checkpoint(self.lightning_trainer)
+        self._checkpoint_interval = (
+            self.lightning_trainer.config.training.checkpoint_interval
+        )
+
+    def on_train_start(self, trainer, pl_module):
+        registry.register("current_epoch", trainer.current_epoch)
+
+    def on_train_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
+    ):
+        if trainer.global_step % self._checkpoint_interval == 0:
+            self._save_checkpoint(trainer)
+
+        # prepare the next batch
+        self.lightning_trainer.data_module.train_loader.change_dataloader()
+
+    def on_train_end(self, trainer, pl_module):
+        trainer.run_evaluation(test_mode=False)
+
+    def on_validation_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
+    ):
+        # TODO: sash Needs implementation - coming soon
+        self.lightning_trainer.data_module.val_loader.change_dataloader()
+
+    def _save_checkpoint(self, trainer):
+        logger.info("Checkpoint time. Saving a checkpoint.")
+        return
+        # TODO: sash Needs implementation - coming soon

--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -1,0 +1,158 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import logging
+import math
+
+import omegaconf
+import torch
+from mmf.common import typings as mmf_typings
+from mmf.common.registry import registry
+from mmf.datasets.lightning_datamodule import LightningDataModule
+from mmf.modules.metrics import Metrics
+from mmf.trainers.base_trainer import BaseTrainer
+from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
+from mmf.utils.build import build_model
+from mmf.utils.general import get_max_updates, print_model_parameters
+from pytorch_lightning import Trainer
+
+
+logger = logging.getLogger(__name__)
+
+
+@registry.register_trainer("lightning")
+class LightningTrainer(BaseTrainer):
+    def __init__(self, config: mmf_typings.DictConfig):
+        super().__init__(config)
+        self.trainer = None
+
+    def load(self):
+        super().load()
+        self._calculate_max_updates()
+        self._calculate_gradient_clip_val()
+        self._load_trainer()
+
+    def _load_trainer(self):
+        self.trainer = Trainer(
+            logger=False,
+            gpus=self._gpus,
+            num_nodes=self._num_nodes,
+            callbacks=self._callbacks,
+            precision=16 if self.training_config.fp16 else 32,
+            deterministic=self._deterministic,
+            benchmark=self._benchmark,
+            max_steps=self._max_updates,
+            max_epochs=self._max_epochs,
+            gradient_clip_val=self._gradient_clip_val,
+            num_sanity_val_steps=0,
+            automatic_optimization=True,
+            checkpoint_callback=False,
+            accumulate_grad_batches=self.training_config.update_frequency,
+            val_check_interval=self.training_config.evaluation_interval,
+            log_every_n_steps=self.training_config.log_interval,
+        )
+
+    def configure_device(self):
+        # TODO: @sash coming soon!
+        local_rank = self.config.device_id
+        registry.register("global_device", local_rank)
+        if self.config.distributed.init_method is not None:
+            self._distributed = True
+            self._gpus = [local_rank]
+            self.device = torch.device("cuda", local_rank)
+            # TODO: @sash set the corresponding node number
+            assert 0, "Please set the corresponding nodes"
+        elif torch.cuda.is_available():
+            self._gpus = [0]
+            self._num_nodes = 1
+        else:
+            self._gpus = None
+            self._num_nodes = 1
+
+    def configure_seed(self):
+        default_deterministic = False
+        seed = self.config.training.seed
+
+        self._deterministic = default_deterministic
+        if seed is not None:
+            self._deterministic = True
+
+        self._benchmark = False
+
+    def load_datasets(self):
+        logger.info("Loading datasets")
+        data_module = LightningDataModule(self.config)
+        data_module.prepare_data()
+        self.data_module = data_module
+
+    def load_model(self):
+        logger.info("Loading models")
+
+        attributes = self.config.model_config[self.config.model]
+        if isinstance(attributes, str):
+            attributes = self.config.model_config[attributes]
+        with omegaconf.open_dict(attributes):
+            attributes.model = self.config.model
+
+        self.model = build_model(attributes)
+        self.model.is_pl_enabled = True
+
+    def load_optimizer(self):
+        logger.info("Loading optimizer")
+        if self.trainer:
+            pass
+            # TODO: sash, this is a problem, needs fix
+            # at this point the model's configure_optimizer
+            # function isnt called yet, so this will break.
+            # self.optimizer = self.trainer.optimizers[0]
+            # we need an assigned optimizer for checkpoint
+            # to work
+
+    def load_metrics(self) -> None:
+        logger.info("Loading metrics")
+        metrics = self.config.evaluation.get("metrics", [])
+        self.metrics = Metrics(metrics)
+        self.metrics_params = self.metrics.required_params
+
+    def configure_callbacks(self) -> None:
+        self._callbacks = [LightningLoopCallback(self)]
+
+    def train(self):
+        logger.info("===== Model =====")
+        logger.info(self.model)
+        print_model_parameters(self.model)
+
+        logger.info("Starting training...")
+        self.trainer.fit(self.model, self.data_module)
+
+    def inference(self):
+        logger.info("Starting inference...")
+        # TODO: @sash coming soon
+        pass
+
+    def _calculate_max_updates(self):
+        self._max_updates = self.training_config.max_updates
+        self._max_epochs = self.training_config.max_epochs
+        if self._max_updates is None and self._max_epochs is None:
+            raise ValueError("Neither max_updates nor max_epochs is specified.")
+
+        train_loader = self.data_module.train_loader
+        self._max_updates, max_epochs = get_max_updates(
+            self._max_updates, self._max_epochs, train_loader
+        )
+        self._max_epochs = math.ceil(max_epochs)
+        return self._max_updates
+
+    def _calculate_gradient_clip_val(self):
+        if not self.config.training.clip_gradients:
+            self._gradient_clip_val = 0.0
+            return
+
+        max_grad_l2_norm = self.config.training.max_grad_l2_norm
+        clip_norm_mode = self.config.training.clip_norm_mode
+
+        if max_grad_l2_norm is not None:
+            if clip_norm_mode == "all":
+                self._gradient_clip_val = max_grad_l2_norm
+            else:
+                raise NotImplementedError(
+                    "Clip norm mode %s not implemented" % clip_norm_mode
+                )

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -4,6 +4,7 @@ import collections
 import gc
 import logging
 import os
+import warnings
 from bisect import bisect
 
 import torch
@@ -287,6 +288,33 @@ def get_sizes_list(dim, chunks):
         assert sum(sizes_list) == dim
         assert min(sizes_list) > 0
     return sizes_list
+
+
+def get_max_updates(config_max_updates, config_max_epochs, train_loader):
+    if config_max_updates is None and config_max_epochs is None:
+        raise ValueError("Neither max_updates nor max_epochs is specified.")
+
+    if isinstance(train_loader.current_dataset, torch.utils.data.IterableDataset):
+        warnings.warn(
+            "max_epochs not supported for Iterable datasets. Falling back "
+            + "to max_updates."
+        )
+        return config_max_updates, config_max_epochs
+
+    if config_max_updates is not None and config_max_epochs is not None:
+        warnings.warn(
+            "Both max_updates and max_epochs are specified. "
+            + f"Favoring max_epochs: {config_max_epochs}"
+        )
+
+    if config_max_epochs is not None:
+        max_updates = len(train_loader) * config_max_epochs
+        max_epochs = config_max_epochs
+    else:
+        max_updates = config_max_updates
+        max_epochs = max_updates / len(train_loader)
+
+    return max_updates, max_epochs
 
 
 def get_chunks(x, sizes):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ known_third_party = [
     "PIL", "cv2", "demjson", "fairscale", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "mmf",
     "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
     "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
-    "torchtext", "torchvision", "tqdm", "transformers"
+    "torchtext", "torchvision", "tqdm", "transformers", "pytorch_lightning"
 ]
 skip_glob = "**/build/**,website/**"
 combine_as_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ sklearn==0.0
 omegaconf==2.0.1rc4
 lmdb==0.98
 termcolor==1.1.0
+pytorch_lightning>=1.1.2

--- a/tests/lightning/__init__.py
+++ b/tests/lightning/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/tests/lightning/test_lightning_trainer.py
+++ b/tests/lightning/test_lightning_trainer.py
@@ -1,0 +1,137 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import torch
+from mmf.trainers.lightning_trainer import LightningTrainer
+from mmf.utils.build import build_optimizer
+from omegaconf import OmegaConf
+from pytorch_lightning.callbacks.base import Callback
+from tests.test_utils import NumbersDataset, SimpleLightningModel, SimpleModel
+from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+
+
+trainer_config = OmegaConf.create(
+    {
+        "run_type": "train",
+        "training": {
+            "detect_anomaly": False,
+            "evaluation_interval": 1,
+            "log_interval": 2,
+            "update_frequency": 1,
+            "fp16": False,
+        },
+        "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
+    }
+)
+
+
+class LightningTrainerMock(LightningTrainer):
+    def __init__(self, callback):
+        self.data_module = MagicMock()
+        self._benchmark = False
+        self._callbacks = []
+        self._distributed = False
+        self._gpus = None
+        self._gradient_clip_val = False
+        self._num_nodes = 1
+        self._deterministic = True
+        self._automatic_optimization = False
+        self._callbacks = [callback]
+        self.config = trainer_config
+        dataset = NumbersDataset(100)
+        self.data_module.train_loader = torch.utils.data.DataLoader(
+            dataset=dataset, batch_size=1, shuffle=False, num_workers=1, drop_last=False
+        )
+        self.data_module.train_loader.current_dataset = MagicMock(return_value=dataset)
+
+    def calculate_max_updates_test(self, max_updates, max_epochs):
+        self.training_config = self.config.training
+        self.training_config["max_updates"] = max_updates
+        self.training_config["max_epochs"] = max_epochs
+
+        self._calculate_max_updates()
+        self._load_trainer()
+        return self._max_updates
+
+
+class TestLightningTrainer(unittest.TestCase, Callback):
+    def setUp(self):
+        self.trainer = LightningTrainerMock(self)
+        self.trainer.model = SimpleLightningModel(1, config=trainer_config)
+        self.trainer.model.train()
+        self.lightning_losses = []
+
+        mmf_model = SimpleModel(1)
+        mmf_model.train()
+        mmf_optimizer = build_optimizer(mmf_model, trainer_config)
+        self.mmf_losses = []
+        self.mmf_trainer = TrainerTrainingLoopMock(
+            100, 5, None, config=trainer_config, optimizer=mmf_optimizer
+        )
+        self.mmf_trainer._extract_loss = self._extract_loss_test
+        self._callback_enabled = False
+
+    def test_epoch_over_updates(self):
+        trainer = self.trainer
+        max_updates = trainer.calculate_max_updates_test(2, 0.04)
+        self.assertEqual(max_updates, 4)
+
+        self._check_values(0, 0)
+        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+        self._check_values(4, 0)
+
+    def test_fractional_epoch(self):
+        trainer = self.trainer
+        max_updates = trainer.calculate_max_updates_test(None, 0.04)
+        self.assertEqual(max_updates, 4)
+
+        self._check_values(0, 0)
+        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+        self._check_values(4, 0)
+
+    def test_updates(self):
+        trainer = self.trainer
+        max_updates = trainer.calculate_max_updates_test(2, None)
+        self.assertEqual(max_updates, 2)
+
+        self._check_values(0, 0)
+        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+        self._check_values(2, 0)
+
+    def _check_values(self, current_iteration, current_epoch):
+        trainer = self.trainer.trainer
+        self.assertEqual(trainer.global_step, current_iteration)
+        self.assertEqual(trainer.current_epoch, current_epoch)
+
+    def test_loss_computation(self):
+        # check to see the same losses between the two trainers
+        # TODO: @sash, change this to True once PL PR #4369 is merged
+        self._callback_enabled = False
+
+        # compute mmf_trainer training losses
+        self.mmf_trainer.training_loop()
+
+        # compute lightning_trainer training losses
+        trainer = self.trainer
+        trainer.calculate_max_updates_test(5, None)
+        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+
+    def _extract_loss_test(self, report: Dict[str, Any]) -> torch.Tensor:
+        loss_dict = report.losses
+        loss = sum([loss.mean() for loss in loss_dict.values()])
+        self.mmf_losses.append(loss.item())
+        return loss
+
+    def on_train_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
+    ):
+        if self._callback_enabled:
+            self.lightning_losses.append(outputs["loss"].item())
+
+    def on_train_end(self, trainer, pl_module):
+        if self._callback_enabled:
+            for lightning_loss, mmf_loss in zip(self.lightning_losses, self.mmf_losses):
+                self.assertEqual(lightning_loss, mmf_loss)


### PR DESCRIPTION
* pytorch lighting stub mostly involving training
* Tests for lightning trainer included

- [X] MVP 0. Training: Goal - Train a model from scratch and reach similar accuracy as using mmf_trainer
   - [X] Setup the training pipeline: done
   - [X] Training on the right device: done
   - [X] Clip gradients: done
   - [X] Optimizer: done
   - [X] LR scheduler (incl. warmup etc): done
   - [X] testcase: train visual_bert on vqa from scratch fo 10 iterations, compare the value: done
   - [X] tests... 

Note, the test is affected by: [Blocking] `end_train_batch_step` does not return train outputs properly: PR #[4369](https://github.com/PyTorchLightning/pytorch-lightning/pull/4369)

