### PR TITLE
[fix] Allow loading checkpoint from a folder

### DIFF
--- a/mmf/models/movie_mcan.py
+++ b/mmf/models/movie_mcan.py
@@ -24,7 +24,9 @@ class MoVieMcan(BaseModel):
         super().__init__(config)
         self.config = config
         self._global_config = registry.get("config")
-        self._datasets = self._global_config.datasets.split(",")
+        self._datasets = self._global_config.datasets
+        if isinstance(self._datasets, str):
+            self._datasets = self._datasets.split(",")
 
     @classmethod
     def config_path(cls):

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -99,11 +99,18 @@ def _load_pretrained_model(model_name_or_path, *args, **kwargs):
         config = ckpt["config"]
     else:
         config = load_yaml(configs[0])
-
     model_config = config.get("model_config", config)
     ckpt = ckpt.get("model", ckpt)
+
     # Also handle the case of model_name is path
-    model_config = model_config.get(model_name.split(os.path.sep)[-1].split(".")[0])
+    if PathManager.exists(model_name):
+        # This shouldn't happen
+        assert len(model_config.keys()) == 1, "Checkpoint contains more than one model?"
+        # Take first key
+        model_config = model_config[list(model_config.keys())[0]]
+    else:
+        model_config = model_config.get(model_name.split(os.path.sep)[-1].split(".")[0])
+
     return {"config": model_config, "checkpoint": ckpt, "full_config": config}
 
 

--- a/tests/models/interfaces/test_interfaces.py
+++ b/tests/models/interfaces/test_interfaces.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -20,15 +21,20 @@ class TestModelInterfaces(unittest.TestCase):
     def test_mmbt_hm_interface(self):
         model = MMBT.from_pretrained("mmbt.hateful_memes.images")
         self._test_model_performance(model)
+        self._test_mmbt_hm_interface_from_file()
+        self._test_mmbt_hm_interface_from_folder()
 
-    @test_utils.skip_if_no_network
-    @test_utils.skip_if_windows
-    @test_utils.skip_if_macos
-    def test_mmbt_hm_interface_from_file(self):
+    def _test_mmbt_hm_interface_from_file(self):
         with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
             self._create_checkpoint_file(tmp.name)
 
             model = MMBT.from_pretrained(tmp.name, interface=True)
+            self._test_model_performance(model)
+
+    def _test_mmbt_hm_interface_from_folder(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._create_checkpoint_folder(tmpdir)
+            model = MMBT.from_pretrained(tmpdir, interface=True)
             self._test_model_performance(model)
 
     def _test_model_performance(self, model):
@@ -47,11 +53,7 @@ class TestModelInterfaces(unittest.TestCase):
         np.testing.assert_almost_equal(result["confidence"], 0.8342, decimal=3)
 
     def _create_checkpoint_file(self, path):
-        home = str(Path.home())
-        data_dir = get_mmf_env(key="data_dir")
-        model_folder = os.path.join(
-            home, data_dir, "models", "mmbt.hateful_memes.images"
-        )
+        model_folder = self._get_model_folder()
         model_file = os.path.join(model_folder, "model.pth")
         config_file = os.path.join(model_folder, "config.yaml")
         config = load_yaml(config_file)
@@ -59,3 +61,19 @@ class TestModelInterfaces(unittest.TestCase):
             ckpt = torch.load(f)
         ckpt["config"] = config
         torch.save(ckpt, path)
+
+    def _create_checkpoint_folder(self, path):
+        model_folder = self._get_model_folder()
+        model_file = os.path.join(model_folder, "model.pth")
+        config_file = os.path.join(model_folder, "config.yaml")
+        shutil.copy(model_file, path)
+        shutil.copy(config_file, path)
+
+    def _get_model_folder(self):
+        home = str(Path.home())
+        data_dir = get_mmf_env(key="data_dir")
+        model_folder = os.path.join(
+            home, data_dir, "models", "mmbt.hateful_memes.images"
+        )
+
+        return model_folder


### PR DESCRIPTION
- Needed for e2e movie+mcan

Test Plan:

- Tested locally with e2e movie+mcan handler
- Adds tests for loading from a folder
- Combines older file based test to main pretrained as they had
sequential dep
