### PR TITLE
[enhancement] be more explicit in isort

### DIFF
--- a/.github/workflows/linter_test.yaml
+++ b/.github/workflows/linter_test.yaml
@@ -53,7 +53,7 @@ jobs:
       run: |
         conda activate mmf
         isort --version
-        isort -c -sp .
+        isort -c -df -sp .
 
     - name: Run linter
       shell: bash -l {0}


### PR DESCRIPTION
* print in ci the difference that isort would make
* allow isort to be more explicit.
* my pytorch lightning PR is experiencing some local/circleci inconsistencies for isort despite using the same version.  