### PR TITLE
[feat] multitask support: per-dataset evaluation loop, metrics, and sampling ratios

### DIFF
--- a/mmf/common/report.py
+++ b/mmf/common/report.py
@@ -76,6 +76,8 @@ class Report(OrderedDict):
 
     def accumulate_tensor_fields_and_loss(self, report, field_list):
         for key in field_list:
+            if key == "__prediction_report__":
+                continue
             if key not in self.keys():
                 warnings.warn(
                     f"{key} not found in report. Metrics calculation "

--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -56,9 +56,12 @@ class TestReporter(Dataset):
 
         PathManager.mkdirs(self.report_folder)
 
-    def next_dataset(self):
+    def next_dataset(self, flush_report=True):
         if self.current_dataset_idx >= 0:
-            self.flush_report()
+            if flush_report:
+                self.flush_report()
+            else:
+                self.report = []
 
         self.current_dataset_idx += 1
 
@@ -95,6 +98,10 @@ class TestReporter(Dataset):
         logger.info(f"Wrote predictions for {name} to {os.path.abspath(filepath)}")
         self.report = []
 
+    def postprocess_dataset_report(self):
+        if hasattr(self.current_dataset, "on_prediction_end"):
+            self.report = self.current_dataset.on_prediction_end(self.report)
+
     def csv_dump(self, filepath):
         with PathManager.open(filepath, "w") as f:
             title = self.report[0].keys()
@@ -123,12 +130,12 @@ class TestReporter(Dataset):
     def __getitem__(self, idx):
         return self.current_dataset[idx]
 
-    def add_to_report(self, report, model):
+    def add_to_report(self, report, model, execute_on_master_only=True):
         keys = ["id", "question_id", "image_id", "context_tokens", "captions", "scores"]
         for key in keys:
             report = self.reshape_and_gather(report, key)
 
-        if not is_master():
+        if execute_on_master_only and not is_master():
             return
 
         results = self.current_dataset.format_for_prediction(report)

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -17,34 +17,56 @@ logger = logging.getLogger(__name__)
 
 class TrainerEvaluationLoopMixin(ABC):
     def evaluation_loop(
-        self, loader, use_tqdm: bool = False, single_batch: bool = False
+        self, dataset_type: str, use_tqdm: bool = False, single_batch: bool = False
     ) -> Tuple[Dict[str, Any], Type[Meter]]:
         meter = Meter()
+        reporter = self.dataset_loader.get_test_reporter(dataset_type)
 
         with torch.no_grad():
             self.model.eval()
             disable_tqdm = not use_tqdm or not is_master()
-            combined_report = None
 
-            for batch in tqdm.tqdm(loader, disable=disable_tqdm):
-                report = self._forward(batch)
-                self.update_meter(report, meter)
+            while reporter.next_dataset(flush_report=False):
+                dataloader = reporter.get_dataloader()
 
-                # accumulate necessary params for metric calculation
-                if combined_report is None:
-                    combined_report = report
-                else:
-                    combined_report.accumulate_tensor_fields_and_loss(
-                        report, self.metrics.required_params
-                    )
-                    combined_report.batch_size += report.batch_size
+                combined_report = None
+                for batch in tqdm.tqdm(dataloader, disable=disable_tqdm):
+                    prepared_batch = reporter.prepare_batch(batch)
+                    model_output = self.model(prepared_batch)
+                    report = Report(prepared_batch, model_output)
 
-                if single_batch is True:
-                    break
+                    self.update_meter(report, meter)
 
-            combined_report.metrics = self.metrics(combined_report, combined_report)
-            self.update_meter(combined_report, meter, eval_mode=True)
-            logger.info("Validation Done")
+                    # accumulate necessary params for metric calculation
+                    if combined_report is None:
+                        # make a copy of report since `reporter.add_to_report` will
+                        # change some of the report keys later
+                        combined_report = Report(report)
+                    else:
+                        combined_report.accumulate_tensor_fields_and_loss(
+                            report, self.metrics.required_params
+                        )
+                        combined_report.batch_size += report.batch_size
+
+                    # Each node generates a separate copy of predict JSON from the report,
+                    # which will be used to evaluate dataset-level metrics
+                    # (such as mAP in object detection or CIDEr in image captioning)
+                    # Since `reporter.add_to_report` changes report keys (e.g. scores),
+                    # do this after `combined_report.accumulate_tensor_fields_and_loss`
+                    if "__prediction_report__" in self.metrics.required_params:
+                        reporter.add_to_report(
+                            report, self.model, execute_on_master_only=False
+                        )
+
+                    if single_batch is True:
+                        break
+
+                reporter.postprocess_dataset_report()
+                # add prediction_report is used for set-level metrics
+                combined_report.prediction_report = reporter.report
+
+                combined_report.metrics = self.metrics(combined_report, combined_report)
+                self.update_meter(combined_report, meter, eval_mode=True)
 
             # enable train mode again
             self.model.train()
@@ -67,6 +89,8 @@ class TrainerEvaluationLoopMixin(ABC):
                         model_output = self.model(prepared_batch)
                     report = Report(prepared_batch, model_output)
                     reporter.add_to_report(report, self.model)
+
+                reporter.postprocess_dataset_report()
 
             logger.info("Finished predicting")
             self.model.train()

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -42,7 +42,7 @@ class TrainerTrainingLoopMixin(ABC):
             and self.num_updates % self.training_config.evaluation_interval != 0
         ):
             # Create a new meter for this case
-            report, meter = self.evaluation_loop(self.val_loader)
+            report, meter = self.evaluation_loop("val")
 
             # Validation end callbacks
             self.on_validation_end(report=report, meter=meter)
@@ -135,7 +135,7 @@ class TrainerTrainingLoopMixin(ABC):
                     logger.info("Evaluation time. Running on full validation set...")
                     # Validation and Early stopping
                     # Create a new meter for this case
-                    report, meter = self.evaluation_loop(self.val_loader)
+                    report, meter = self.evaluation_loop("val")
 
                     # Validation end callbacks
                     stop = self.early_stop_callback.on_validation_end(

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -149,7 +149,5 @@ class MMFTrainer(
             else:
                 self.on_test_start()
                 logger.info(f"Starting inference on {dataset} set")
-                report, meter = self.evaluation_loop(
-                    getattr(self, f"{dataset}_loader"), use_tqdm=True
-                )
+                report, meter = self.evaluation_loop(dataset, use_tqdm=True)
                 self.on_test_end(report=report, meter=meter)

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -370,7 +370,7 @@ def get_current_device():
         return torch.device("cpu")
 
 
-def retry_n(n: int, fn: Callable, log_tries=False, *args, **kwargs) -> Any:
+def retry_n(n: int, fn: Callable, *args, log_tries=False, **kwargs) -> Any:
     """Retries a function n times with increasing exponentionally
     increasing sleep intervals in between. First argument is number of tries
     if n==1, means function will be called at least twice, first is try, second


### PR DESCRIPTION
This PR is built upon https://github.com/facebookresearch/mmf/pull/736

- change the current evaluation loop (that runs on the union of all
datasets) to per-dataset evaluation.
- generate prediction JSON object during evaluation loop, which can be
consumed by metrics that evaluate the entire dataset (e.g. mAP for
object detection or CIDEr for image captioning) and cannot be expressed
as averaging over per-batch metrics
- run metrics on a subset of datasets with (optional) `datasets` config
- allow specifying per-dataset sampling ratio for multi-task training

Test Plan:

Tested locally and verified the outputs

---
Example on specifying per-dataset metric with `datasets` (here `vqa_accuracy` will only run on vqa2 while `detection_mean_ap` will only run on detection_coco and detection_visual_genome). If `datasets` is not specified, the default behavior is to run on all dataset:
```
evaluation:
  metrics:
  - type: vqa_accuracy
    datasets:
    - vqa2
  - type: detection_mean_ap
    datasets:
    - detection_coco
    - detection_visual_genome
 ```
 
---
 Examples specifying per-dataset sampling ratio during training through `multitasking.enabled` and `multitasking.sampling_ratios`:
 ```
 multitasking:
  enabled: true
  sampling_ratios:
    detection_coco: 0.2
    detection_visual_genome: 0.07
    visual_entailment: 0.12
    vqa2: 0.26
    glue_qnli: 0.1
    glue_mnli_mismatched: 0.1
    glue_qqp: 0.1
    glue_sst2: 0.05
 ```