### PR TITLE
[feat] detection datasets (COCO, Visual Genome) and mAP metric

### DIFF
--- a/mmf/configs/datasets/coco/detection.yaml
+++ b/mmf/configs/datasets/coco/detection.yaml
@@ -1,0 +1,31 @@
+dataset_config:
+  detection_coco:
+    use_images: true
+    zoo_requirements:
+    - coco.detection_2017
+    data_dir: ${env.data_dir}/datasets
+    images:
+      train:
+      - coco/detection_2017/images/train2017
+      val:
+      - coco/detection_2017/images/val2017
+      test:
+      - coco/detection_2017/images/test2017
+    annotations:
+      train:
+      - coco/detection_2017/annotations/annotations/instances_train2017.json
+      val:
+      - coco/detection_2017/annotations/annotations/instances_val2017.json
+      test:
+      - coco/detection_2017/annotations/annotations/image_info_test-dev2017.json
+    load_attributes: false  # COCO has no attribute annotations
+    processors:
+      detection_image_and_target_processor:
+        type: detr_image_and_target
+        params:
+          train_image_sizes: [480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800]
+          train_resize_random_sizes: [400, 500, 600]
+          train_crop_size: [384, 600]
+          test_image_size: 800
+          max_size: 1333
+    max_target_enc_size: 16382  # maximum number of bytes to encode detection targets into pickle

--- a/mmf/configs/datasets/visual_genome/detection.yaml
+++ b/mmf/configs/datasets/visual_genome/detection.yaml
@@ -1,0 +1,31 @@
+dataset_config:
+  detection_visual_genome:
+    use_images: true
+    zoo_requirements:
+    - visual_genome.detection_split_by_coco_2017
+    data_dir: ${env.data_dir}/datasets
+    images:
+      train:
+      - visual_genome/detection_split_by_coco_2017/images
+      val:
+      - visual_genome/detection_split_by_coco_2017/images
+      test:
+      - visual_genome/detection_split_by_coco_2017/images
+    annotations:
+      train:
+      - visual_genome/detection_split_by_coco_2017/annotations/instances_train_split_by_coco_2017.json
+      val:
+      - visual_genome/detection_split_by_coco_2017/annotations/instances_val_split_by_coco_2017.json
+      test:
+      - visual_genome/detection_split_by_coco_2017/annotations/instances_val_split_by_coco_2017.json
+    load_attributes: true  # Visual Genome has attribute annotations
+    processors:
+      detection_image_and_target_processor:
+        type: detr_image_and_target
+        params:
+          train_image_sizes: [480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800]
+          train_resize_random_sizes: [400, 500, 600]
+          train_crop_size: [384, 600]
+          test_image_size: 800
+          max_size: 1333
+    max_target_enc_size: 16382  # maximum number of bytes to encode detection targets into pickle

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -188,6 +188,22 @@ coco:
         file_name: annotations.tar.gz
         hashcode: 8861b854eff965d22dd38e331e43886aeab8ac1c99798abf80f935efdf621079
 
+  detection_2017:
+    version: 1.0_2021_02_05
+    resources:
+      images:
+      - url: http://images.cocodataset.org/zips/test2017.zip
+        file_name: test2017.zip
+      - url: http://images.cocodataset.org/zips/train2017.zip
+        file_name: train2017.zip
+      - url: http://images.cocodataset.org/zips/val2017.zip
+        file_name: val2017.zip
+      annotations:
+      - url: http://images.cocodataset.org/annotations/image_info_test2017.zip
+        file_name: image_info_test2017.zip
+      - url: http://images.cocodataset.org/annotations/annotations_trainval2017.zip
+        file_name: annotations_trainval2017.zip
+
   resnet152:
     version: 1.0_2020_05_29
     resources:
@@ -521,3 +537,17 @@ flickr_coco_captions:
       annotations:
       - url: https://cs.stanford.edu/people/karpathy/deepimagesent/caption_datasets.zip
         file_name: annotations.zip
+
+visual_genome:
+  detection_split_by_coco_2017:
+    version: 1.0_2021_02_05
+    resources:
+      images:
+      - url: https://cs.stanford.edu/people/rak248/VG_100K_2/images.zip
+        file_name: images.zip
+      - url: https://cs.stanford.edu/people/rak248/VG_100K_2/images2.zip
+        file_name: images2.zip
+      annotations:
+      - url: mmf://datasets/visual_genome/detection_split_by_coco_2017/annotations/annotations_split_by_coco_2017.tar.gz
+        file_name: annotations_split_by_coco_2017.tar.gz
+        hashcode: 19129558ef8ba766c1009106ec6f46d62221ec3bb87af505c4157b7e9bcc8e66

--- a/mmf/datasets/builders/coco/__init__.py
+++ b/mmf/datasets/builders/coco/__init__.py
@@ -1,7 +1,16 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-__all__ = ["COCOBuilder", "COCODataset", "MaskedCOCOBuilder", "MaskedCOCODataset"]
+__all__ = [
+    "COCOBuilder",
+    "COCODataset",
+    "DetectionCOCOBuilder",
+    "DetectionCOCODataset",
+    "MaskedCOCOBuilder",
+    "MaskedCOCODataset",
+]
 
 from .builder import COCOBuilder
 from .dataset import COCODataset
+from .detection_builder import DetectionCOCOBuilder
+from .detection_dataset import DetectionCOCODataset
 from .masked_builder import MaskedCOCOBuilder
 from .masked_dataset import MaskedCOCODataset

--- a/mmf/datasets/builders/coco/detection_builder.py
+++ b/mmf/datasets/builders/coco/detection_builder.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.builders.coco.detection_dataset import DetectionCOCODataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("detection_coco")
+class DetectionCOCOBuilder(MMFDatasetBuilder):
+    def __init__(self):
+        super().__init__(
+            dataset_name="detection_coco", dataset_class=DetectionCOCODataset
+        )
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/coco/detection.yaml"

--- a/mmf/datasets/builders/coco/detection_dataset.py
+++ b/mmf/datasets/builders/coco/detection_dataset.py
@@ -1,0 +1,188 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import os
+from typing import Dict
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from mmf.common.sample import Sample
+from mmf.datasets.base_dataset import BaseDataset
+from mmf.utils.distributed import gather_tensor_along_batch, object_to_byte_tensor
+from torch import Tensor, nn
+
+
+class DetectionCOCODataset(BaseDataset):
+    def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
+        if "name" in kwargs:
+            name = kwargs["name"]
+        elif "dataset_name" in kwargs:
+            name = kwargs["dataset_name"]
+        else:
+            name = "detection_coco"
+        super().__init__(name, config, dataset_type, *args, **kwargs)
+        self.dataset_name = name
+
+        image_dir = self.config.images[self._dataset_type][imdb_file_index]
+        self.image_dir = os.path.join(self.config.data_dir, image_dir)
+        coco_json = self.config.annotations[self._dataset_type][imdb_file_index]
+        self.coco_json = os.path.join(self.config.data_dir, coco_json)
+
+        self.coco_dataset = torchvision.datasets.CocoDetection(
+            self.image_dir, self.coco_json
+        )
+
+        self.postprocessors = {"bbox": PostProcess()}
+
+    def __getitem__(self, idx):
+        img, target = self.coco_dataset[idx]
+        image_id = self.coco_dataset.ids[idx]
+        target = {"image_id": image_id, "annotations": target}
+        img, target = self._load_coco_annotations(
+            img, target, load_attributes=self.config.load_attributes
+        )
+        transform_out = self.detection_image_and_target_processor(
+            {"img": img, "target": target, "dataset_type": self._dataset_type}
+        )
+        img = transform_out["img"]
+        target = transform_out["target"]
+
+        current_sample = Sample()
+        current_sample.image_id = torch.tensor(image_id, dtype=torch.long)
+        current_sample.image = img
+        current_sample.targets_enc = object_to_byte_tensor(
+            target, max_size=self.config.max_target_enc_size
+        )
+        current_sample.orig_size = target["orig_size"].clone().detach()
+
+        return current_sample
+
+    def __len__(self):
+        return len(self.coco_dataset)
+
+    def format_for_prediction(self, report):
+        # gather detection output keys across processes
+        pred_boxes = gather_tensor_along_batch(report.pred_boxes)
+        pred_logits = gather_tensor_along_batch(report.pred_logits)
+        orig_size = gather_tensor_along_batch(report.orig_size)
+
+        outputs = {"pred_logits": pred_logits, "pred_boxes": pred_boxes}
+        image_ids = report.image_id.tolist()
+        results = self.postprocessors["bbox"](outputs, orig_size)
+
+        predictions = []
+        for image_id, r in zip(image_ids, results):
+            scores = r["scores"].tolist()
+            labels = r["labels"].tolist()
+            # convert boxes from xyxy to xywh
+            xmin, ymin, xmax, ymax = r["boxes"].unbind(1)
+            boxes_xywh = torch.stack((xmin, ymin, xmax - xmin, ymax - ymin), dim=1)
+            boxes_xywh = boxes_xywh.tolist()
+
+            # group the boxes by image_id for de-duplication in `on_prediction_end`
+            # (duplication is introduced by DistributedSampler)
+            predictions.append(
+                (
+                    image_id,
+                    [
+                        {
+                            "image_id": image_id,
+                            "category_id": labels[k],
+                            "bbox": box_xywh,
+                            "score": scores[k],
+                        }
+                        for k, box_xywh in enumerate(boxes_xywh)
+                    ],
+                )
+            )
+
+        return predictions
+
+    def on_prediction_end(self, predictions):
+        # de-duplicate the predictions (duplication is introduced by DistributedSampler)
+        prediction_dict = {image_id: entries for image_id, entries in predictions}
+
+        unique_entries = []
+        for image_id in sorted(prediction_dict):
+            unique_entries.extend(prediction_dict[image_id])
+
+        return unique_entries
+
+    def _load_coco_annotations(self, image, target, load_attributes=False):
+        w, h = image.size
+        image_id = target["image_id"]
+        image_id = torch.tensor([image_id])
+        anno = target["annotations"]
+        anno = [obj for obj in anno if "iscrowd" not in obj or obj["iscrowd"] == 0]
+
+        boxes = [obj["bbox"] for obj in anno]
+        boxes = torch.as_tensor(boxes, dtype=torch.float32).reshape(-1, 4)
+        boxes[:, 2:] += boxes[:, :2]
+        boxes[:, 0::2].clamp_(min=0, max=w)
+        boxes[:, 1::2].clamp_(min=0, max=h)
+        classes = [obj["category_id"] for obj in anno]
+        classes = torch.tensor(classes, dtype=torch.int64)
+        attributes = None
+        if load_attributes:
+            # load the attribute annotations in the Visual Genome dataset
+            # following vqa-maskrcnn-benchmark, -1 will be used as ignore label
+            # (https://gitlab.com/meetshah1995/vqa-maskrcnn-benchmark)
+            MAX_ATTR_NUM = 16
+            attributes = -torch.ones(len(classes), MAX_ATTR_NUM, dtype=torch.int64)
+            for n_obj, obj in enumerate(anno):
+                attributes[n_obj] = torch.as_tensor(
+                    obj["attribute_ids_max16"], dtype=torch.int64
+                )
+
+        keep = (boxes[:, 3] > boxes[:, 1]) & (boxes[:, 2] > boxes[:, 0])
+        boxes = boxes[keep]
+        classes = classes[keep]
+        if attributes is not None:
+            attributes = attributes[keep]
+
+        target = {}
+        target["boxes"] = boxes
+        target["orig_boxes"] = boxes
+        target["labels"] = classes
+        if attributes is not None:
+            target["attributes"] = attributes
+        target["image_id"] = image_id
+        # for conversion to coco api
+        area = torch.tensor([obj["area"] for obj in anno])
+        target["area"] = area[keep]
+        target["orig_area"] = target["area"]
+        iscrowd = torch.tensor([obj.get("iscrowd", 0) for obj in anno])
+        target["iscrowd"] = iscrowd[keep]
+        target["orig_size"] = torch.as_tensor([int(h), int(w)])
+        target["size"] = torch.as_tensor([int(h), int(w)])
+
+        return image, target
+
+
+class PostProcess(nn.Module):
+    # Mostly copy-pasted from
+    # https://github.com/facebookresearch/detr/blob/master/models/detr.py
+    @torch.no_grad()
+    def forward(self, outputs: Dict[str, Tensor], target_sizes: Tensor):
+        out_logits, out_bbox = outputs["pred_logits"], outputs["pred_boxes"]
+
+        assert len(out_logits) == len(target_sizes)
+        assert target_sizes.shape[1] == 2
+
+        prob = F.softmax(out_logits, -1)
+        scores, labels = prob[..., :-1].max(-1)
+
+        # convert to [x0, y0, x1, y1] format
+        from mmf.utils.box_ops import box_cxcywh_to_xyxy
+
+        boxes = box_cxcywh_to_xyxy(out_bbox)
+        # and from relative [0, 1] to absolute [0, height] coordinates
+        img_h, img_w = target_sizes.unbind(1)
+        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)
+        boxes = boxes * scale_fct[:, None, :]
+
+        results = [
+            {"scores": s, "labels": l, "boxes": b}
+            for s, l, b in zip(scores, labels, boxes)
+        ]
+
+        return results

--- a/mmf/datasets/builders/visual_entailment/dataset.py
+++ b/mmf/datasets/builders/visual_entailment/dataset.py
@@ -41,8 +41,14 @@ class VisualEntailmentDataset(VQA2Dataset):
                     features["image_info_0"]
                 )
             current_sample.update(features)
+        else:
+            image_path = sample_info["Flikr30kID"]
+            current_sample.image = self.image_db.from_path(image_path)["images"][0]
 
         label = LABEL_TO_INT_MAPPING[sample_info["gold_label"]]
         current_sample.targets = torch.tensor(label, dtype=torch.long)
 
         return current_sample
+
+    def format_for_prediction(self, report):
+        return []

--- a/mmf/datasets/builders/visual_genome/detection_builder.py
+++ b/mmf/datasets/builders/visual_genome/detection_builder.py
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.common.registry import registry
+from mmf.datasets.builders.visual_genome.detection_dataset import (
+    DetectionVisualGenomeDataset,
+)
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("detection_visual_genome")
+class DetectionVisualGenomeBuilder(MMFDatasetBuilder):
+    def __init__(self):
+        super().__init__(
+            dataset_name="detection_visual_genome",
+            dataset_class=DetectionVisualGenomeDataset,
+        )
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/visual_genome/detection.yaml"

--- a/mmf/datasets/builders/visual_genome/detection_dataset.py
+++ b/mmf/datasets/builders/visual_genome/detection_dataset.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from mmf.datasets.builders.coco.detection_dataset import DetectionCOCODataset
+
+
+class DetectionVisualGenomeDataset(DetectionCOCODataset):
+    def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
+        super().__init__(config, dataset_type, imdb_file_index, *args, **kwargs)
+        if "name" in kwargs:
+            name = kwargs["name"]
+        elif "dataset_name" in kwargs:
+            name = kwargs["dataset_name"]
+        else:
+            name = "detection_visual_genome"
+        self.dataset_name = name

--- a/mmf/datasets/processors/detection_transforms.py
+++ b/mmf/datasets/processors/detection_transforms.py
@@ -1,0 +1,251 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/datasets/transforms.py
+import random
+from typing import List, Optional, Union
+
+import torch
+import torchvision.transforms as T
+import torchvision.transforms.functional as F
+from mmf.common.registry import registry
+from mmf.datasets.processors.processors import BaseProcessor
+from mmf.utils.box_ops import box_xyxy_to_cxcywh
+from torch import Tensor
+
+
+def crop(image: Tensor, target: dict, region: List[int]):
+    cropped_image = F.crop(image, *region)
+
+    target = target.copy()
+    i, j, h, w = region
+
+    # should we do something wrt the original size?
+    target["size"] = torch.tensor([h, w])
+
+    fields = ["labels", "area", "iscrowd"]
+
+    if "boxes" in target:
+        boxes = target["boxes"]
+        max_size = torch.as_tensor([w, h], dtype=torch.float32)
+        cropped_boxes = boxes - torch.as_tensor([j, i, j, i])
+        cropped_boxes = torch.min(cropped_boxes.reshape(-1, 2, 2), max_size)
+        cropped_boxes = cropped_boxes.clamp(min=0)
+        area = (cropped_boxes[:, 1, :] - cropped_boxes[:, 0, :]).prod(dim=1)
+        target["boxes"] = cropped_boxes.reshape(-1, 4)
+        target["area"] = area
+        fields.append("boxes")
+
+    if "attributes" in target:
+        fields.append("attributes")
+
+    # remove elements for which the boxes have zero area
+    if "boxes" in target:
+        # favor boxes selection when defining which elements to keep
+        # this is compatible with previous implementation
+        cropped_boxes = target["boxes"].reshape(-1, 2, 2)
+        keep = torch.all(cropped_boxes[:, 1, :] > cropped_boxes[:, 0, :], dim=1)
+
+        for field in fields:
+            target[field] = target[field][keep]
+
+    return cropped_image, target
+
+
+def hflip(image: Tensor, target: dict):
+    flipped_image = F.hflip(image)
+
+    w, h = image.size
+
+    target = target.copy()
+    if "boxes" in target:
+        boxes = target["boxes"]
+        boxes = boxes[:, [2, 1, 0, 3]] * torch.as_tensor(
+            [-1, 1, -1, 1]
+        ) + torch.as_tensor([w, 0, w, 0])
+        target["boxes"] = boxes
+
+    return flipped_image, target
+
+
+def get_size_with_aspect_ratio(
+    image_size: List[int], size: int, max_size: Optional[int] = None
+):
+    w, h = image_size
+    if max_size is not None:
+        min_original_size = float(min((w, h)))
+        max_original_size = float(max((w, h)))
+        if max_original_size / min_original_size * size > max_size:
+            size = int(round(max_size * min_original_size / max_original_size))
+
+    if (w <= h and w == size) or (h <= w and h == size):
+        return (h, w)
+
+    if w < h:
+        ow = size
+        oh = int(size * h / w)
+    else:
+        oh = size
+        ow = int(size * w / h)
+
+    return (oh, ow)
+
+
+def get_size(
+    image_size: List[int], size: Union[int, List[int]], max_size: Optional[int] = None
+):
+    if isinstance(size, (list, tuple)):
+        return size[::-1]
+    else:
+        return get_size_with_aspect_ratio(image_size, size, max_size)
+
+
+def resize(
+    image: Tensor,
+    target: dict,
+    size: Union[int, List[int]],
+    max_size: Optional[int] = None,
+):
+    # size can be min_size (scalar) or (w, h) tuple
+
+    size = get_size(image.size, size, max_size)
+    rescaled_image = F.resize(image, size)
+
+    if target is None:
+        return rescaled_image, None
+
+    ratios = tuple(
+        float(s) / float(s_orig) for s, s_orig in zip(rescaled_image.size, image.size)
+    )
+    ratio_width, ratio_height = ratios
+
+    target = target.copy()
+    if "boxes" in target:
+        boxes = target["boxes"]
+        scaled_boxes = boxes * torch.as_tensor(
+            [ratio_width, ratio_height, ratio_width, ratio_height]
+        )
+        target["boxes"] = scaled_boxes
+
+    if "area" in target:
+        area = target["area"]
+        scaled_area = area * (ratio_width * ratio_height)
+        target["area"] = scaled_area
+
+    h, w = size
+    target["size"] = torch.tensor([h, w])
+
+    return rescaled_image, target
+
+
+def pad(image: Tensor, target: dict, padding: List[int]):
+    # assumes that we only pad on the bottom right corners
+    padded_image = F.pad(image, (0, 0, padding[0], padding[1]))
+    if target is None:
+        return padded_image, None
+    target = target.copy()
+    # should we do something wrt the original size?
+    target["size"] = torch.tensor(padded_image[::-1])
+    return padded_image, target
+
+
+@registry.register_processor("detection_random_size_crop")
+class RandomSizeCrop(BaseProcessor):
+    def __init__(self, min_size: int, max_size: int):
+        self.min_size = min_size
+        self.max_size = max_size
+
+    def __call__(self, img: Tensor, target: dict):
+        w = random.randint(self.min_size, min(img.width, self.max_size))
+        h = random.randint(self.min_size, min(img.height, self.max_size))
+        region = T.RandomCrop.get_params(img, [h, w])
+        return crop(img, target, region)
+
+
+@registry.register_processor("detection_random_horizontal_flip")
+class RandomHorizontalFlip(BaseProcessor):
+    def __init__(self, p=0.5):
+        self.p = p
+
+    def __call__(self, img: Tensor, target: dict):
+        if random.random() < self.p:
+            return hflip(img, target)
+        return img, target
+
+
+@registry.register_processor("detection_random_resize")
+class RandomResize(BaseProcessor):
+    def __init__(self, sizes, max_size=None):
+        assert isinstance(sizes, (list, tuple))
+        self.sizes = sizes
+        self.max_size = max_size
+
+    def __call__(self, img: Tensor, target: Optional[dict] = None):
+        size = random.choice(self.sizes)
+        return resize(img, target, size, self.max_size)
+
+
+@registry.register_processor("detection_random_select")
+class RandomSelect(BaseProcessor):
+    """
+    Randomly selects between transforms1 and transforms2,
+    with probability p for transforms1 and (1 - p) for transforms2
+    """
+
+    def __init__(self, transforms1, transforms2, p=0.5):
+        self.transforms1 = transforms1
+        self.transforms2 = transforms2
+        self.p = p
+
+    def __call__(self, img: Tensor, target: dict):
+        if random.random() < self.p:
+            return self.transforms1(img, target)
+        return self.transforms2(img, target)
+
+
+@registry.register_processor("detection_to_tensor")
+class ToTensor(BaseProcessor):
+    def __init__(self):
+        pass
+
+    def __call__(self, img: Tensor, target: dict):
+        return F.to_tensor(img), target
+
+
+@registry.register_processor("detection_normalize")
+class Normalize(BaseProcessor):
+    def __init__(self, mean, std):
+        self.mean = mean
+        self.std = std
+
+    def __call__(self, image: Tensor, target: Optional[dict] = None):
+        image = F.normalize(image, mean=self.mean, std=self.std)
+        if target is None:
+            return image, None
+        target = target.copy()
+        h, w = image.shape[-2:]
+        if "boxes" in target:
+            boxes = target["boxes"]
+            boxes = box_xyxy_to_cxcywh(boxes)
+            boxes = boxes / torch.tensor([w, h, w, h], dtype=torch.float32)
+            target["boxes"] = boxes
+        return image, target
+
+
+@registry.register_processor("detection_compose")
+class Compose(BaseProcessor):
+    def __init__(self, transforms):
+        self.transforms = transforms
+
+    def __call__(self, image: Tensor, target: dict):
+        for t in self.transforms:
+            image, target = t(image, target)
+        return image, target
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + "("
+        for t in self.transforms:
+            format_string += "\n"
+            format_string += "    {0}".format(t)
+        format_string += "\n)"
+        return format_string

--- a/mmf/modules/metrics.py
+++ b/mmf/modules/metrics.py
@@ -1202,3 +1202,78 @@ class RecallAt10_rev_ret(RecallAtK_ret):
     ):
         ratk = super().calculate(sample_list, model_output, 10, flip=True)
         return ratk
+
+
+@registry.register_metric("detection_mean_ap")
+class DetectionMeanAP(BaseMetric):
+    """Metric for calculating the detection mean average precision (mAP) using the COCO
+    evaluation toolkit, returning the default COCO-style mAP@IoU=0.50:0.95
+
+    **Key:** ``detection_mean_ap``
+    """
+
+    def __init__(self, dataset_json_files, *args, **kwargs):
+        """Initialization function detection mean AP (mAP)
+
+        Args:
+            dataset_json_files (Dict): paths to the dataset (instance) json files
+                for each dataset type and dataset name in the following format:
+                ``{'val/detection_coco': '/path/to/instances_val2017.json', ...}``
+
+        """
+        super().__init__("detection_mean_ap")
+        self.required_params = ["__prediction_report__"]
+        self.dataset_json_files = dataset_json_files
+
+    def calculate(
+        self, sample_list, model_output, execute_on_master_only=True, *args, **kwargs
+    ):
+        """Calculate detection mean AP (mAP) from the prediction list and the dataset
+        annotations. The function returns COCO-style mAP@IoU=0.50:0.95.
+
+        Args:
+            sample_list (SampleList): SampleList provided by DataLoader for
+                                current iteration.
+            model_output (Dict): Dict returned by model. This should contain
+                                "prediction_report" field, which is a list of
+                                detection predictions from the model.
+            execute_on_master_only (bool): Whether to only run mAP evaluation on the
+                                master node over the gathered detection prediction
+                                (to avoid wasting computation and CPU OOM).
+                                Default: True (only run mAP evaluation on master).
+
+        Returns:
+            torch.FloatTensor: COCO-style mAP@IoU=0.50:0.95.
+
+        """
+        # as the detection mAP metric is run on the entire dataset-level predictions,
+        # which are *already* gathered from all notes, the evaluation should only happen
+        # in one node and broadcasted to other nodes (to avoid CPU OOM due to concurrent
+        # mAP evaluation)
+        from pycocotools.coco import COCO
+        from pycocotools.cocoeval import COCOeval
+        from mmf.utils.distributed import is_master, broadcast_tensor
+        from mmf.utils.general import get_current_device
+
+        device = get_current_device()
+        if execute_on_master_only and not is_master():
+            # dummy mAP to be override in boardcasting
+            mAP = torch.tensor(-1, dtype=torch.float, device=device)
+        else:
+            predictions = model_output.prediction_report
+
+            cocoGt = COCO(
+                self.dataset_json_files[sample_list.dataset_name][
+                    sample_list.dataset_type
+                ]
+            )
+            cocoDt = cocoGt.loadRes(predictions)
+            cocoEval = COCOeval(cocoGt, cocoDt, "bbox")
+            cocoEval.evaluate()
+            cocoEval.accumulate()
+            cocoEval.summarize()
+            mAP = torch.tensor(cocoEval.stats[0], dtype=torch.float, device=device)
+
+        if execute_on_master_only:
+            mAP = broadcast_tensor(mAP, src=0)
+        return mAP

--- a/mmf/utils/box_ops.py
+++ b/mmf/utils/box_ops.py
@@ -1,0 +1,57 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/util/box_ops.py
+import torch
+from torch import Tensor
+from torchvision.ops.boxes import box_area
+
+
+def box_cxcywh_to_xyxy(x: Tensor):
+    x_c, y_c, w, h = x.unbind(-1)
+    b = [(x_c - 0.5 * w), (y_c - 0.5 * h), (x_c + 0.5 * w), (y_c + 0.5 * h)]
+    return torch.stack(b, dim=-1)
+
+
+def box_xyxy_to_cxcywh(x: Tensor):
+    x0, y0, x1, y1 = x.unbind(-1)
+    b = [(x0 + x1) / 2, (y0 + y1) / 2, (x1 - x0), (y1 - y0)]
+    return torch.stack(b, dim=-1)
+
+
+def box_iou(boxes1: Tensor, boxes2: Tensor):
+    area1 = box_area(boxes1)
+    area2 = box_area(boxes2)
+
+    lt = torch.max(boxes1[:, None, :2], boxes2[:, :2])  # [N,M,2]
+    rb = torch.min(boxes1[:, None, 2:], boxes2[:, 2:])  # [N,M,2]
+
+    wh = (rb - lt).clamp(min=0)  # [N,M,2]
+    inter = wh[:, :, 0] * wh[:, :, 1]  # [N,M]
+
+    union = area1[:, None] + area2 - inter
+
+    iou = inter / union
+    return iou, union
+
+
+def generalized_box_iou(boxes1: Tensor, boxes2: Tensor):
+    """
+    Generalized IoU from https://giou.stanford.edu/
+    The boxes should be in [x0, y0, x1, y1] format
+    Returns a [N, M] pairwise matrix, where N = len(boxes1)
+    and M = len(boxes2)
+    """
+    # degenerate boxes gives inf / nan results
+    # so do an early check
+    assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
+    assert (boxes2[:, 2:] >= boxes2[:, :2]).all()
+    iou, union = box_iou(boxes1, boxes2)
+
+    lt = torch.min(boxes1[:, None, :2], boxes2[:, :2])
+    rb = torch.max(boxes1[:, None, 2:], boxes2[:, 2:])
+
+    wh = (rb - lt).clamp(min=0)  # [N,M,2]
+    area = wh[:, :, 0] * wh[:, :, 1]
+
+    return iou - (area - union) / area

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ iopath==0.1.3
 pytorch_lightning==1.1.6
 datasets==1.2.1
 matplotlib==3.3.4
+pycocotools==2.0.2


### PR DESCRIPTION
This PR is built upon https://github.com/facebookresearch/mmf/pull/739

- add `detection_coco` dataset
- add `detection_visual_genome` datasets
- add supporting detection utilities
- add `detection_mean_ap` metric
- add `DETRImageAndTargetProcessor` to load DETR image and box transforms

Test Plan:

Tested locally and verified the outputs