### PR TITLE
[feat] add the UniT model and supporting utils

### DIFF
--- a/mmf/configs/models/unit/defaults.yaml
+++ b/mmf/configs/models/unit/defaults.yaml
@@ -1,0 +1,95 @@
+model_config:
+  unit:
+    base_ckpt_path: ''  # the initial DETR parameters to start from (this should be a checkpoint file trained w/ DETR package)
+    base_ckpt_load_backbone_only: false
+    detection_loss_weight: 1.
+
+    keep_only_bert_cls:
+      # whether to keep only the [CLS] token's hidden states in transformer
+      vl:
+        vqa2: false
+        hateful_memes: true
+        visual_entailment: true
+      glue:
+        glue_qnli: true
+        glue_sst2: true
+        glue_mnli_mismatched: true
+        glue_qqp: true
+    loss_on_all_hs: false
+
+    base_args:
+      lr_backbone: 1e-5
+      backbone: resnet50
+      dilation: false
+      position_embedding: sine
+      enc_layers: 6
+      dec_layers: 6
+      dim_feedforward: 2048
+      encoder_hidden_dim: 256
+      dropout: 0.1
+      nheads: 8
+      # Override the config
+      pre_norm: false
+      pass_pos_and_query: true
+      # detection losses
+      aux_loss: true
+      use_bcl: false
+      set_cost_class: 1.
+      set_cost_bbox: 5.
+      set_cost_giou: 2.
+      mask_loss_coef: 1.
+      dice_loss_coef: 1.
+      bbox_loss_coef: 5.
+      giou_loss_coef: 2.
+      attr_loss_coef: 1.
+      eos_coef: 0.1
+      # separate dimensionality for decoder
+      decoder_hidden_dim: 256
+      num_queries: {}
+      share_decoders: false
+      residual_in_encoder: true
+      use_task_embedding_in_img_encoder: false
+      use_task_embedding_in_lang_encoder: false
+      # Visual Genome attribute data properties
+      attribute_class_num: 401
+      max_attribute_num: 16
+      bert_config:
+        bert_model_name: bert-base-uncased
+
+    heads:
+      detection:
+        detection_coco:
+          task_idx: 0
+          num_classes: 91
+          use_attr: false
+        detection_visual_genome:
+          task_idx: 1
+          num_classes: 1601
+          use_attr: true
+      vl:
+        vqa2:
+          task_idx: 3
+          num_labels: 3129
+          loss_type: binary_cross_entropy_with_logits
+        visual_entailment:
+          task_idx: 9
+          num_labels: 3
+          loss_type: cross_entropy
+      glue:
+        glue_qnli:
+          task_idx: 5
+          num_labels: 2
+          loss_type: cross_entropy
+        glue_mnli_mismatched:
+          task_idx: 6
+          num_labels: 3
+          loss_type: cross_entropy
+        glue_sst2:
+          task_idx: 7
+          num_labels: 2
+          loss_type: cross_entropy
+        glue_qqp:
+          task_idx: 8
+          num_labels: 2
+          loss_type: cross_entropy
+    max_task_num: 256

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -315,6 +315,13 @@ vqa2:
       - url: mmf://datasets/vqa2/grid/features/features.tar.gz
         file_name: features.tar.gz
         hashcode: 96f4290c6bcbc5767dea5efc44e802667a146769d615dad33944493e3ad638bb
+  split_by_coco_2017:
+    version: 1.0_2021_02_05
+    resources:
+      annotations:
+      - url: mmf://datasets/vqa2/split_by_coco_2017/annotations/annotations_split_by_coco_2017.tar.gz
+        file_name: annotations_split_by_coco_2017.tar.gz
+        hashcode: 51b90dfef9c295ca8d5c4c893b9d2e0ea3b3ff0d2f043c0c0480a1542ea48c62
 
 vizwiz:
   v2019:

--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -470,3 +470,22 @@ butd:
     - url: mmf://models/butd/butd.coco.tar.gz
       file_name: butd.coco.tar.gz
       hashcode: 55e57d791e6e5c785b96d8254ef48f3d9b5b107ff1152560b09d868f88c3598f
+
+unit:
+  defaults: ${unit.all_8_datasets.shared_dec_with_coco_init}
+  all_8_datasets:
+    shared_dec_with_coco_init:
+      # Model from project : projects/unit
+      # - val/detection_coco/detection_mean_ap: 0.3899,
+      # - val/detection_visual_genome/detection_mean_ap: 0.0329,
+      # - val/vqa2/vqa_accuracy: 0.6696,
+      # - val/visual_entailment/accuracy: 0.7316,
+      # - val/glue_qnli/accuracy: 0.8790,
+      # - val/glue_sst2/accuracy: 0.8922,
+      # - val/glue_mnli_mismatched/accuracy: 0.8090,
+      # - val/glue_qqp/accuracy: 0.9065
+      version: 1.0_2021_02_25
+      resources:
+      - url: mmf://models/unit.all_8_datasets.shared_dec_with_coco_init/unit.all_8_datasets.shared_dec_with_coco_init.tar.gz
+        file_name: unit.all_8_datasets.shared_dec_with_coco_init.tar.gz
+        hashcode: b85796246601c477d354d6ad315b55a200b4c7ba6bf7e263ef82bca74bdcab1c

--- a/mmf/models/unit/__init__.py
+++ b/mmf/models/unit/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+__all__ = ["UniT"]
+
+from .unit import UniT

--- a/mmf/models/unit/backbone.py
+++ b/mmf/models/unit/backbone.py
@@ -1,0 +1,146 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/backbone.py
+"""
+Backbone modules.
+"""
+import math
+from collections import OrderedDict
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from mmf.models.unit.misc import NestedTensor
+from torch import nn
+from torchvision.models._utils import IntermediateLayerGetter
+from torchvision.ops.misc import FrozenBatchNorm2d
+
+
+class BackboneBase(nn.Module):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        train_backbone: bool,
+        num_channels: int,
+        return_interm_layers: bool,
+    ):
+        super().__init__()
+        for name, parameter in backbone.named_parameters():
+            if (
+                not train_backbone
+                or "layer2" not in name
+                and "layer3" not in name
+                and "layer4" not in name
+            ):
+                parameter.requires_grad_(False)
+        if return_interm_layers:
+            return_layers = {"layer1": "0", "layer2": "1", "layer3": "2", "layer4": "3"}
+        else:
+            return_layers = {"layer4": 0}
+        self.body = IntermediateLayerGetter(backbone, return_layers=return_layers)
+        self.num_channels = num_channels
+
+    def forward(self, tensor_list: NestedTensor):
+        xs = self.body(tensor_list.tensors)
+        out = OrderedDict()
+        for name, x in xs.items():
+            mask = F.interpolate(
+                tensor_list.mask[None].float(), size=x.shape[-2:]
+            ).bool()[0]
+            out[name] = NestedTensor(x, mask)
+        return out
+
+
+class Backbone(BackboneBase):
+    """ResNet backbone with frozen BatchNorm."""
+
+    def __init__(
+        self,
+        name: str,
+        train_backbone: bool,
+        return_interm_layers: bool,
+        dilation: bool,
+    ):
+        backbone = getattr(torchvision.models, name)(
+            replace_stride_with_dilation=[False, False, dilation],
+            pretrained=True,
+            norm_layer=FrozenBatchNorm2d,
+        )
+        num_channels = 512 if name in ("resnet18", "resnet34") else 2048
+        super().__init__(backbone, train_backbone, num_channels, return_interm_layers)
+
+
+class Joiner(nn.Sequential):
+    def __init__(self, backbone: nn.Module, position_embedding: nn.Module):
+        super().__init__(backbone, position_embedding)
+
+    def forward(self, tensor_list: NestedTensor):
+        xs = self[0](tensor_list)
+        out = []
+        pos = []
+        for _, x in xs.items():
+            out.append(x)
+            # position encoding
+            pos.append(self[1](x).to(x.tensors.dtype))
+
+        return out, pos
+
+
+class PositionEmbeddingSine(nn.Module):
+    """
+    This is a more standard version of the position embedding, very similar to the one
+    used by the Attention is all you need paper, generalized to work on images.
+    """
+
+    def __init__(
+        self, num_pos_feats=64, temperature=10000, normalize=False, scale=None
+    ):
+        super().__init__()
+        self.num_pos_feats = num_pos_feats
+        self.temperature = temperature
+        self.normalize = normalize
+        if scale is not None and normalize is False:
+            raise ValueError("normalize should be True if scale is passed")
+        if scale is None:
+            scale = 2 * math.pi
+        self.scale = scale
+
+    def forward(self, tensor_list: NestedTensor):
+        x = tensor_list.tensors
+        mask = tensor_list.mask
+        not_mask = ~mask
+        y_embed = not_mask.cumsum(1, dtype=torch.float32)
+        x_embed = not_mask.cumsum(2, dtype=torch.float32)
+        if self.normalize:
+            eps = 1e-6
+            y_embed = y_embed / (y_embed[:, -1:, :] + eps) * self.scale
+            x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
+
+        dim_t = torch.arange(self.num_pos_feats, dtype=torch.float32, device=x.device)
+        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_pos_feats)
+
+        pos_x = x_embed[:, :, :, None] / dim_t
+        pos_y = y_embed[:, :, :, None] / dim_t
+        pos_x = torch.stack(
+            (pos_x[:, :, :, 0::2].sin(), pos_x[:, :, :, 1::2].cos()), dim=4
+        ).flatten(3)
+        pos_y = torch.stack(
+            (pos_y[:, :, :, 0::2].sin(), pos_y[:, :, :, 1::2].cos()), dim=4
+        ).flatten(3)
+        pos = torch.cat((pos_y, pos_x), dim=3).permute(0, 3, 1, 2)
+        return pos
+
+
+def build_unit_convnet_backbone(args):
+    position_embedding = PositionEmbeddingSine(
+        args.encoder_hidden_dim // 2, normalize=True
+    )
+    train_backbone = args.lr_backbone > 0
+    return_interm_layers = False
+    backbone = Backbone(
+        args.backbone, train_backbone, return_interm_layers, args.dilation
+    )
+    model = Joiner(backbone, position_embedding)
+    model.num_channels = backbone.num_channels
+    return model

--- a/mmf/models/unit/matcher.py
+++ b/mmf/models/unit/matcher.py
@@ -1,0 +1,124 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/matcher.py
+"""
+Modules to compute the matching cost and solve the corresponding LSAP.
+"""
+from typing import Dict, List
+
+import torch
+from mmf.utils.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
+from torch import Tensor, nn
+
+from scipy.optimize import linear_sum_assignment
+
+
+class HungarianMatcher(nn.Module):
+    """
+    This class computes an assignment between the targets and the predictions of the
+    network
+
+    For efficiency reasons, the targets don't include the no_object. Because of this,
+    in general, there are more predictions than targets. In this case, we do a 1-to-1
+    matching of the best predictions, while the others are un-matched (and thus treated
+    as non-objects).
+    """
+
+    def __init__(
+        self,
+        cost_class: float = 1,
+        cost_bbox: float = 1,
+        cost_giou: float = 1,
+        logsoftmax: bool = False,
+    ):
+        """Creates the matcher
+
+        Params:
+            cost_class: This is the relative weight of the classification error in the
+                matching cost
+            cost_bbox: This is the relative weight of the L1 error of the bounding box
+                coordinates in the matching cost
+            cost_giou: This is the relative weight of the giou loss of the bounding box
+                in the matching cost
+        """
+        super().__init__()
+        self.cost_class = cost_class
+        self.cost_bbox = cost_bbox
+        self.cost_giou = cost_giou
+        self.norm = nn.LogSoftmax(-1) if logsoftmax else nn.Softmax(-1)
+        assert (
+            cost_class != 0 or cost_bbox != 0 or cost_giou != 0
+        ), "all costs cant be 0"
+
+    @torch.no_grad()
+    def forward(self, outputs: Dict[str, Tensor], targets: List[Dict[str, Tensor]]):
+        """ Performs the matching
+
+        Params:
+            outputs: This is a dict that contains at least these entries:
+                 "pred_logits": Tensor of dim [batch_size, num_queries, num_classes]
+                    with the classification logits
+                 "pred_boxes": Tensor of dim [batch_size, num_queries, 4] with the
+                    predicted box coordinates
+
+            targets: This is a list of targets (len(targets) = batch_size), where each
+                    target is a dict containing:
+                 "labels": Tensor of dim [num_target_boxes] (where num_target_boxes is
+                    the number of ground-truth objects in the target) containing the
+                    class labels
+                 "boxes": Tensor of dim [num_target_boxes, 4] containing the target box
+                    coordinates
+
+        Returns:
+            A list of size batch_size, containing tuples of (index_i, index_j) where:
+                - index_i is the indices of the selected predictions (in order)
+                - index_j is the indices of the corresponding selected targets (in
+                  order)
+            For each batch element, it holds:
+                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+        """
+        bs, num_queries = outputs["pred_logits"].shape[:2]
+
+        # We flatten to compute the cost matrices in a batch
+        out_prob = self.norm(
+            outputs["pred_logits"].flatten(0, 1)
+        )  # [batch_size * num_queries, num_classes]
+        out_bbox = outputs["pred_boxes"].flatten(0, 1)  # [batch_size * num_queries, 4]
+
+        # Also concat the target labels and boxes
+        tgt_ids = torch.cat([v["labels"] for v in targets])
+        tgt_bbox = torch.cat([v["boxes"] for v in targets])
+
+        # Compute the classification cost. Contrary to the loss, we don't use the NLL,
+        # but approximate it in 1 - proba[target class].
+        # The 1 is a constant that doesn't change the matching, it can be omitted.
+        cost_class = -out_prob[:, tgt_ids]
+
+        # Compute the L1 cost between boxes
+        cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+
+        # Compute the giou cost betwen boxes
+        cost_giou = -generalized_box_iou(
+            box_cxcywh_to_xyxy(out_bbox).float(), box_cxcywh_to_xyxy(tgt_bbox)
+        )
+
+        # Final cost matrix
+        C = (
+            self.cost_bbox * cost_bbox
+            + self.cost_class * cost_class
+            + self.cost_giou * cost_giou
+        )
+        C = C.view(bs, num_queries, -1).cpu()
+
+        sizes = [len(v["boxes"]) for v in targets]
+        indices = [
+            linear_sum_assignment(c[i]) for i, c in enumerate(C.split(sizes, -1))
+        ]
+        return [
+            (
+                torch.as_tensor(i, dtype=torch.int64),
+                torch.as_tensor(j, dtype=torch.int64),
+            )
+            for i, j in indices
+        ]

--- a/mmf/models/unit/misc.py
+++ b/mmf/models/unit/misc.py
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/util/misc.py
+from typing import List
+
+import torch
+from torch import Tensor
+
+
+class NestedTensor(object):
+    """
+    A data class to hold images of different sizes in a batch.
+
+    It contains `tensors` to hold padded images to the maximum size and `mask` to
+    indicate the actual image region of each padded image
+    """
+
+    def __init__(self, tensors: Tensor, mask: Tensor):
+        self.tensors = tensors
+        self.mask = mask
+
+    def to(self, *args, **kwargs):
+        cast_tensor = self.tensors.to(*args, **kwargs)
+        cast_mask = self.mask.to(*args, **kwargs) if self.mask is not None else None
+        return type(self)(cast_tensor, cast_mask)
+
+    def decompose(self):
+        return self.tensors, self.mask
+
+    @classmethod
+    def from_tensor_list(cls, tensor_list: List[Tensor]):
+        """
+        convert a list of images in CHW format in `tensor_list` to a NestedTensor by
+        padding them to maximum image size.
+        """
+        if tensor_list[0].ndim == 3:
+            max_size = tuple(max(s) for s in zip(*[img.shape for img in tensor_list]))
+            # min_size = tuple(min(s) for s in zip(*[img.shape for img in tensor_list]))
+            batch_shape = (len(tensor_list),) + max_size
+            b, c, h, w = batch_shape
+            dtype = tensor_list[0].dtype
+            device = tensor_list[0].device
+            tensor = torch.zeros(batch_shape, dtype=dtype, device=device)
+            mask = torch.ones((b, h, w), dtype=torch.bool, device=device)
+            for img, pad_img, m in zip(tensor_list, tensor, mask):
+                pad_img[: img.shape[0], : img.shape[1], : img.shape[2]].copy_(img)
+                m[: img.shape[1], : img.shape[2]] = False
+        else:
+            raise Exception("tensor_list must contain images in CHW format")
+        return cls(tensor, mask)

--- a/mmf/models/unit/transformer.py
+++ b/mmf/models/unit/transformer.py
@@ -1,0 +1,533 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/transformer.py
+import copy
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+
+class Transformer(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+
+        self.args = args
+        self.d_model_enc = args.encoder_hidden_dim
+        self.d_model_dec = args.decoder_hidden_dim
+        self.dropout = args.dropout
+        self.nhead = args.nheads
+        self.dim_feedforward = args.dim_feedforward
+        self.num_encoder_layers = args.enc_layers
+        self.num_decoder_layers = args.dec_layers
+        self.normalize_before = args.pre_norm
+        self.return_intermediate_dec = True
+        self.pass_pos_and_query = args.pass_pos_and_query
+        self.share_decoders = args.share_decoders
+        self.activation = "relu"
+
+        self.pass_pos_and_query = self.pass_pos_and_query
+        encoder_layer = TransformerEncoderLayer(
+            self.d_model_enc,
+            self.nhead,
+            self.dim_feedforward,
+            self.dropout,
+            self.activation,
+            self.normalize_before,
+        )
+        encoder_norm = nn.LayerNorm(self.d_model_enc) if self.normalize_before else None
+        self.encoder = TransformerEncoder(
+            encoder_layer, self.num_encoder_layers, encoder_norm
+        )
+
+        if self.d_model_dec != self.d_model_enc:
+            self.enc2dec_proj = nn.Linear(self.d_model_enc, self.d_model_dec)
+            self.pos_embed_proj = nn.Linear(self.d_model_enc, self.d_model_dec)
+        else:
+            self.enc2dec_proj = nn.Identity()
+            self.pos_embed_proj = nn.Identity()
+
+        if self.share_decoders:
+            decoder_layer = TransformerDecoderLayer(
+                self.d_model_dec,
+                self.nhead,
+                self.dim_feedforward,
+                self.dropout,
+                self.activation,
+                self.normalize_before,
+            )
+            decoder_norm = nn.LayerNorm(self.d_model_dec)
+            self.decoder = TransformerDecoder(
+                decoder_layer,
+                self.num_decoder_layers,
+                decoder_norm,
+                return_intermediate=self.return_intermediate_dec,
+            )
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class UniTTransformer(Transformer):
+    def __init__(self, args):
+        super().__init__(args=args)
+
+        num_queries = self.args.num_queries
+        self.decoders = nn.ModuleDict()
+        for task in num_queries:
+            task_dict = nn.ModuleDict()
+            for dataset in num_queries[task]:
+                if self.share_decoders:
+                    task_dict[dataset] = self.decoder
+                else:
+                    task_dict[dataset] = self.build_decoder_layer(
+                        d_model_dec=self.d_model_dec,
+                        nhead=self.nhead,
+                        dim_feedforward=self.dim_feedforward,
+                        dropout=self.dropout,
+                        activation=self.activation,
+                        normalize_before=self.normalize_before,
+                        num_decoder_layers=self.num_decoder_layers,
+                        return_intermediate_dec=self.return_intermediate_dec,
+                    )
+            self.decoders[task] = task_dict
+            # A separate decoder for VQA
+
+        MAX_TASK_NUM = 256
+        if args.use_task_embedding_in_img_encoder:
+            self.task_embeddings_enc = nn.Embedding(MAX_TASK_NUM, self.d_model_enc)
+        # when adding the task embedding to the beginning of the decoder, we'll strip
+        # it from the hidden state outputs to make it compatible with previous models
+        self.mem_out_begin_idx = 1 if args.use_task_embedding_in_img_encoder else 0
+
+    def build_decoder_layer(
+        self,
+        d_model_dec=512,
+        nhead=8,
+        num_decoder_layers=6,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+    ):
+        decoder_layer = TransformerDecoderLayer(
+            d_model_dec, nhead, dim_feedforward, dropout, activation, normalize_before
+        )
+        decoder_norm = nn.LayerNorm(d_model_dec)
+        return TransformerDecoder(
+            decoder_layer,
+            num_decoder_layers,
+            decoder_norm,
+            return_intermediate=return_intermediate_dec,
+        )
+
+    def forward(
+        self,
+        img_src: Optional[Tensor] = None,
+        img_mask: Optional[Tensor] = None,
+        img_pos: Optional[Tensor] = None,
+        text_src: Optional[Tensor] = None,
+        text_mask: Optional[Tensor] = None,
+        text_pos: Optional[Tensor] = None,
+        query_embed: Optional[Tensor] = None,
+        task_type: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        task_idx: Optional[int] = None,
+    ):
+        # flatten NxCxHxW to HWxNxC
+        memories = []
+        pos_embeds = []
+        masks = []
+
+        if img_src is not None:
+            bs, c, h, w = img_src.shape
+            img_src = img_src.flatten(2).permute(2, 0, 1)
+            img_pos = img_pos.flatten(2).permute(2, 0, 1)
+            img_mask = img_mask.flatten(1)
+            if text_src is None:
+                query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)
+                if self.pass_pos_and_query:
+                    tgt = torch.zeros_like(query_embed)
+                else:
+                    img_src, tgt, query_embed, img_pos = (
+                        img_src + 0.1 * img_pos,
+                        query_embed,
+                        None,
+                        None,
+                    )
+            img_src, img_mask, img_pos = self._prefix_task_embedding_to_encoder_inputs(
+                img_src, img_mask, img_pos, task_idx
+            )
+            memory = self.encoder(img_src, src_key_padding_mask=img_mask, pos=img_pos)
+
+            if self.mem_out_begin_idx != 0:
+                img_src = img_src[self.mem_out_begin_idx :]
+                img_pos = img_pos[self.mem_out_begin_idx :]
+                img_mask = img_mask[:, self.mem_out_begin_idx :]
+                memory = memory[self.mem_out_begin_idx :]
+
+            if self.args.residual_in_encoder:
+                memory = img_src + memory
+
+            memory = self.enc2dec_proj(memory)
+            img_pos = self.pos_embed_proj(img_pos)
+            memories.append(memory)
+            pos_embeds.append(img_pos)
+            masks.append(img_mask)
+
+        if text_src is not None:
+            text_src = text_src.permute(1, 0, 2)
+            memories.append(text_src)
+            text_pos = text_pos.unsqueeze(1).repeat(1, text_src.size(1), 1)
+            pos_embeds.append(text_pos)
+            masks.append(text_mask != 1)
+
+            query_embed = query_embed.unsqueeze(1).repeat(1, text_src.size(1), 1)
+            if self.pass_pos_and_query:
+                tgt = torch.zeros_like(query_embed)
+            else:
+                raise NotImplementedError()
+
+        decoder = self.decoders[task_type][dataset_name]
+
+        memories = torch.cat(memories)
+        masks = torch.cat(masks, dim=-1)
+        pos_embeds = torch.cat(pos_embeds)
+
+        hs = decoder(
+            tgt,
+            memories,
+            memory_key_padding_mask=masks,
+            pos=pos_embeds,
+            query_pos=query_embed,
+        )
+        hs = hs.transpose(1, 2)
+        # hs is num_layer x batch_size x seq_length x hidden_dim
+
+        return hs, memories.permute(1, 2, 0)
+
+    def _prefix_task_embedding_to_encoder_inputs(
+        self, img_src, img_mask, img_pos, task_idx
+    ):
+        if not self.args.use_task_embedding_in_img_encoder:
+            return img_src, img_mask, img_pos
+
+        bs = img_src.size(1)
+        task_embed = self.task_embeddings_enc.weight[task_idx]
+        task_embed = task_embed.unsqueeze(0).unsqueeze(0).repeat(1, bs, 1)
+        img_src = torch.cat([task_embed, img_src], dim=0)
+
+        # 0 for non-padding in img_mask
+        img_mask_pad = torch.zeros_like(img_mask[:, :1])
+        img_mask = torch.cat([img_mask_pad, img_mask], dim=1)
+        img_pos_pad = torch.zeros_like(img_pos[:1])
+        img_pos = torch.cat([img_pos_pad, img_pos], dim=0)
+
+        return img_src, img_mask, img_pos
+
+
+class TransformerEncoder(nn.Module):
+    def __init__(self, encoder_layer, num_layers, norm=None):
+        super().__init__()
+        self.layers = _get_clones(encoder_layer, num_layers)
+        self.num_layers = num_layers
+        self.norm = norm
+
+    def forward(
+        self,
+        src,
+        mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        output = src
+
+        for layer in self.layers:
+            output = layer(
+                output,
+                src_mask=mask,
+                src_key_padding_mask=src_key_padding_mask,
+                pos=pos,
+            )
+
+        if self.norm is not None:
+            output = self.norm(output)
+
+        return output
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, decoder_layer, num_layers, norm=None, return_intermediate=False):
+        super().__init__()
+        self.layers = _get_clones(decoder_layer, num_layers)
+        self.num_layers = num_layers
+        self.norm = norm
+        self.return_intermediate = return_intermediate
+
+    def forward(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        output = tgt
+
+        intermediate = []
+
+        for layer in self.layers:
+            output = layer(
+                output,
+                memory,
+                tgt_mask=tgt_mask,
+                memory_mask=memory_mask,
+                tgt_key_padding_mask=tgt_key_padding_mask,
+                memory_key_padding_mask=memory_key_padding_mask,
+                pos=pos,
+                query_pos=query_pos,
+            )
+            if self.return_intermediate:
+                intermediate.append(self.norm(output))
+
+        if self.norm is not None:
+            output = self.norm(output)
+            if self.return_intermediate:
+                intermediate.pop()
+                intermediate.append(output)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate)
+
+        return output
+
+
+class TransformerEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+    ):
+        super().__init__()
+        self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        # Implementation of Feedforward model
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+
+        self.activation = _get_activation_fn(activation)
+        self.normalize_before = normalize_before
+
+    def with_pos_embed(self, tensor, pos: Optional[Tensor]):
+        return tensor if pos is None else tensor + pos
+
+    def forward_post(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        q = k = self.with_pos_embed(src, pos)
+        src2 = self.self_attn(
+            q, k, value=src, attn_mask=src_mask, key_padding_mask=src_key_padding_mask
+        )[0]
+        src = src + self.dropout1(src2)
+        src = self.norm1(src)
+        src2 = self.linear2(self.dropout(self.activation(self.linear1(src))))
+        src = src + self.dropout2(src2)
+        src = self.norm2(src)
+        return src
+
+    def forward_pre(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        src2 = self.norm1(src)
+        q = k = self.with_pos_embed(src2, pos)
+        src2 = self.self_attn(
+            q, k, value=src2, attn_mask=src_mask, key_padding_mask=src_key_padding_mask
+        )[0]
+        src = src + self.dropout1(src2)
+        src2 = self.norm2(src)
+        src2 = self.linear2(self.dropout(self.activation(self.linear1(src2))))
+        src = src + self.dropout2(src2)
+        return src
+
+    def forward(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
+        if self.normalize_before:
+            return self.forward_pre(src, src_mask, src_key_padding_mask, pos)
+        return self.forward_post(src, src_mask, src_key_padding_mask, pos)
+
+
+class TransformerDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+    ):
+        super().__init__()
+        self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        self.multihead_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        # Implementation of Feedforward model
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+
+        self.norm1 = nn.LayerNorm(d_model)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.norm3 = nn.LayerNorm(d_model)
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+        self.dropout3 = nn.Dropout(dropout)
+
+        self.activation = _get_activation_fn(activation)
+        self.normalize_before = normalize_before
+
+    def with_pos_embed(self, tensor, pos: Optional[Tensor]):
+        return tensor if pos is None else tensor + pos
+
+    def forward_post(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        q = k = self.with_pos_embed(tgt, query_pos)
+        tgt2 = self.self_attn(
+            q, k, value=tgt, attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask
+        )[0]
+        tgt = tgt + self.dropout1(tgt2)
+        tgt = self.norm1(tgt)
+        tgt2 = self.multihead_attn(
+            query=self.with_pos_embed(tgt, query_pos),
+            key=self.with_pos_embed(memory, pos),
+            value=memory,
+            attn_mask=memory_mask,
+            key_padding_mask=memory_key_padding_mask,
+        )[0]
+        tgt = tgt + self.dropout2(tgt2)
+        tgt = self.norm2(tgt)
+        tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt))))
+        tgt = tgt + self.dropout3(tgt2)
+        tgt = self.norm3(tgt)
+        return tgt
+
+    def forward_pre(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        tgt2 = self.norm1(tgt)
+        q = k = self.with_pos_embed(tgt2, query_pos)
+        tgt2 = self.self_attn(
+            q, k, value=tgt2, attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask
+        )[0]
+        tgt = tgt + self.dropout1(tgt2)
+        tgt2 = self.norm2(tgt)
+        tgt2 = self.multihead_attn(
+            query=self.with_pos_embed(tgt2, query_pos),
+            key=self.with_pos_embed(memory, pos),
+            value=memory,
+            attn_mask=memory_mask,
+            key_padding_mask=memory_key_padding_mask,
+        )[0]
+        tgt = tgt + self.dropout2(tgt2)
+        tgt2 = self.norm3(tgt)
+        tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt2))))
+        tgt = tgt + self.dropout3(tgt2)
+        return tgt
+
+    def forward(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
+        if self.normalize_before:
+            return self.forward_pre(
+                tgt,
+                memory,
+                tgt_mask,
+                memory_mask,
+                tgt_key_padding_mask,
+                memory_key_padding_mask,
+                pos,
+                query_pos,
+            )
+        return self.forward_post(
+            tgt,
+            memory,
+            tgt_mask,
+            memory_mask,
+            tgt_key_padding_mask,
+            memory_key_padding_mask,
+            pos,
+            query_pos,
+        )
+
+
+def _get_clones(module, N):
+    return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+
+def _get_activation_fn(activation):
+    """Return an activation function given a string"""
+    if activation == "relu":
+        return F.relu
+    if activation == "gelu":
+        return F.gelu
+    if activation == "glu":
+        return F.glu
+    raise RuntimeError(f"activation should be relu/gelu, not {activation}.")

--- a/mmf/models/unit/unit.py
+++ b/mmf/models/unit/unit.py
@@ -1,0 +1,355 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import logging
+from copy import deepcopy
+from typing import Dict
+
+import torch
+from mmf.common.registry import registry
+from mmf.models import BaseModel
+from mmf.models.unit.unit_base_model import (
+    MLP,
+    AttributeHead,
+    UniTBaseModel,
+    build_detection_loss,
+)
+from mmf.modules.encoders import TransformerEncoder
+from mmf.utils.distributed import byte_tensor_to_object
+from torch import Tensor, nn
+from transformers.modeling_bert import BertPredictionHeadTransform
+
+
+logger = logging.getLogger(__name__)
+
+
+@registry.register_model("unit")
+class UniT(BaseModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.config = config
+
+    @classmethod
+    def config_path(cls):
+        return "configs/models/unit/defaults.yaml"
+
+    # Backward compatibility for code from older mmbt
+    @classmethod
+    def format_state_key(cls, key):
+        return key.replace("detr_model.", "unit_base_model.")
+
+    def build(self):
+        # build the base model (based on DETR)
+        self.unit_base_model = UniTBaseModel(self.config.base_args)
+
+        def keep_only_backbone_params(model_state_dict):
+            keys = list(model_state_dict.keys())
+            for k in keys:
+                if "backbone" not in k:
+                    model_state_dict.pop(k)
+
+        ckpt_path = self.config.base_ckpt_path
+        if ckpt_path != "":
+            logger.info("initializing base model (UniT) from {}".format(ckpt_path))
+            if ckpt_path.startswith("https"):
+                base_checkpoint = torch.hub.load_state_dict_from_url(
+                    ckpt_path, check_hash=True
+                )
+            else:
+                base_checkpoint = torch.load(ckpt_path)
+            if self.config.base_ckpt_load_backbone_only:
+                keep_only_backbone_params(base_checkpoint["model"])
+                self.unit_base_model.load_state_dict(
+                    base_checkpoint["model"], strict=False
+                )
+            else:
+                self.unit_base_model.load_state_dict(
+                    base_checkpoint["model"], strict=True
+                )
+
+        # build the text encoder (BERT)
+        self.bert_model = TransformerEncoder(self.config.base_args.bert_config)
+        detr_hidden_dim = self.config.base_args.decoder_hidden_dim
+        bert_config = deepcopy(self.bert_model.config)
+        self.bert_projection = nn.Linear(bert_config.hidden_size, detr_hidden_dim)
+        self.bert_pos_projection = nn.Linear(bert_config.hidden_size, detr_hidden_dim)
+
+        self.classifiers = nn.ModuleDict()
+
+        self.task_embeddings_lang = nn.Identity()
+        if self.config.base_args.use_task_embedding_in_lang_encoder:
+            self.task_embeddings_lang = nn.Embedding(
+                self.config.max_task_num, bert_config.hidden_size
+            )
+
+        bert_config.hidden_size = detr_hidden_dim
+
+        # build the task-specific output heads
+        self.class_embeds = nn.ModuleDict()
+        self.bbox_embeds = nn.ModuleDict()
+        self.det_losses = nn.ModuleDict()
+        for dataset_name in self.config.base_args.num_queries.get("detection", []):
+            num_cls = self.config.heads["detection"][dataset_name]["num_classes"]
+            self.class_embeds[dataset_name] = nn.Linear(detr_hidden_dim, num_cls + 1)
+            self.bbox_embeds[dataset_name] = MLP(detr_hidden_dim, detr_hidden_dim, 4, 3)
+            attr_head = None
+            if self.config.heads["detection"][dataset_name]["use_attr"]:
+                attr_head = AttributeHead(
+                    num_cls, self.config.base_args.attribute_class_num, detr_hidden_dim
+                )
+            self.det_losses[dataset_name] = build_detection_loss(
+                self.config.base_args, num_cls, attr_head
+            )
+
+        vl_classifiers = nn.ModuleDict()
+        for dataset_name in self.config.base_args.num_queries.get("vl", []):
+            vl_classifiers[dataset_name] = nn.Sequential(
+                BertPredictionHeadTransform(bert_config),
+                nn.Linear(
+                    bert_config.hidden_size,
+                    self.config.heads["vl"][dataset_name]["num_labels"],
+                ),
+            )
+
+        self.classifiers["vl"] = vl_classifiers
+        self.dropout = nn.Dropout(bert_config.hidden_dropout_prob)
+
+        glue_classifiers = nn.ModuleDict()
+        for dataset_name in self.config.base_args.num_queries.get("glue", []):
+            glue_classifiers[dataset_name] = nn.Sequential(
+                BertPredictionHeadTransform(bert_config),
+                nn.Linear(
+                    bert_config.hidden_size,
+                    self.config.heads["glue"][dataset_name]["num_labels"],
+                ),
+            )
+
+        self.classifiers["glue"] = glue_classifiers
+
+        self.loss_calculation_fn = {}
+        self.loss_calculation_fn["detection"] = self.detection_loss_calculation
+        self.loss_calculation_fn["vl"] = self.classifier_loss_calculation
+        self.loss_calculation_fn["glue"] = self.classifier_loss_calculation
+
+        self.losses_dict = {}
+        self.losses_dict["vl"] = {
+            name: self.get_loss_fn(self.config.heads["vl"][name]["loss_type"])
+            for name in self.config.heads["vl"]
+        }
+        self.losses_dict["glue"] = {
+            name: self.get_loss_fn(self.config.heads["glue"][name]["loss_type"])
+            for name in self.config.heads["glue"]
+        }
+
+    def forward_bert_with_task_idx(self, sample_list):
+        bert = self.bert_model.module
+        input_ids = sample_list.input_ids
+        attention_mask = sample_list.input_mask
+        token_type_ids = sample_list.segment_ids
+        device = input_ids.device
+
+        position_ids = torch.arange(input_ids.size(1), dtype=torch.long, device=device)
+
+        input_shape = input_ids.size()
+
+        if attention_mask is None:
+            attention_mask = torch.ones(input_shape, device=device)
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+        embedding_output = bert.embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+        )
+
+        start_idx = 0
+        if self.config.base_args.use_task_embedding_in_lang_encoder:
+            bs = input_ids.size(0)
+            task_idx = self.get_task_idx(sample_list.dataset_name)
+            task_embed = self.task_embeddings_lang.weight[task_idx]
+            task_embed = task_embed.unsqueeze(0).unsqueeze(0).repeat(bs, 1, 1)
+            embedding_output = torch.cat([task_embed, embedding_output], dim=1)
+            task_attention_mask = embedding_output.new_ones((bs, 1))
+            attention_mask = torch.cat([task_attention_mask, attention_mask], dim=1)
+            start_idx = 1
+
+        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_attention_mask = extended_attention_mask.to(
+            dtype=next(self.parameters()).dtype
+        )  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+        head_mask = [None for _ in range(bert.config.num_hidden_layers)]
+        encoder_outputs = bert.encoder(
+            embedding_output,
+            attention_mask=extended_attention_mask,
+            head_mask=head_mask,
+        )
+        sequence_output = encoder_outputs[0][:, start_idx:, :]
+        pos_embeddings = self.bert_model.embeddings.position_embeddings(position_ids)
+
+        return sequence_output, pos_embeddings
+
+    def forward(self, sample_list):
+        detr_outputs = {}
+        task_type = self.get_task_type(sample_list.dataset_name)
+        text_src = None
+        text_mask = None
+        text_pos = None
+        img_src = None
+        if task_type == "vl" or task_type == "glue":
+            if task_type == "vl":
+                img_src = sample_list.image
+            text_src, pos_embeddings = self.forward_bert_with_task_idx(sample_list)
+            # 768 -> 256
+            text_src = self.bert_projection(text_src)
+            text_pos = self.bert_pos_projection(pos_embeddings)
+
+            text_mask = sample_list.input_mask
+            if self.config.keep_only_bert_cls[task_type][sample_list.dataset_name]:
+                # take only the [CLS] token's hidden state
+                text_src = text_src[:, 0:1, :]
+                text_pos = text_pos[0:1, :]
+                text_mask = text_mask[:, 0:1]
+        elif task_type == "detection":
+            img_src = sample_list.image
+
+        detr_outputs = self.unit_base_model(
+            img_src=img_src,
+            text_src=text_src,
+            text_mask=text_mask,
+            text_pos=text_pos,
+            task_type=task_type,
+            dataset_name=sample_list.dataset_name,
+            task_idx=self.get_task_idx(sample_list.dataset_name),
+        )
+
+        output = self.loss_calculation_fn[task_type](detr_outputs, sample_list)
+        return output
+
+    def detection_loss_calculation(self, detr_outputs: Dict[str, Tensor], sample_list):
+        hs = detr_outputs["hidden_states"]
+
+        outputs_class = self.class_embeds[sample_list.dataset_name](hs)
+        outputs_coord = self.bbox_embeds[sample_list.dataset_name](hs).sigmoid()
+        detr_outputs.update(
+            {
+                "pred_logits": outputs_class[-1],
+                "pred_boxes": outputs_coord[-1],
+                "hs_for_attr": hs[-1],
+            }
+        )
+        # skip loss computation on test set (which usually doesn't contain labels)
+        if sample_list.dataset_type != "test":
+            if self.config.base_args.aux_loss:
+                detr_outputs["aux_outputs"] = [
+                    {"pred_logits": a, "pred_boxes": b, "hs_for_attr": c}
+                    for a, b, c in zip(outputs_class[:-1], outputs_coord[:-1], hs[:-1])
+                ]
+
+            criterion = self.det_losses[sample_list.dataset_name]
+            targets = [byte_tensor_to_object(t) for t in sample_list.targets_enc]
+            targets = [{k: v.to(hs.device) for k, v in t.items()} for t in targets]
+            sample_list.targets = targets
+            loss_dict = criterion(detr_outputs, sample_list.targets)
+            weight_dict = criterion.weight_dict
+            loss_prefix = f"{sample_list.dataset_type}/{sample_list.dataset_name}/"
+            losses = {
+                (loss_prefix + f"{k}"): loss_dict[k]
+                * weight_dict[k]
+                * self.config.detection_loss_weight
+                for k in loss_dict.keys()
+                if k in weight_dict
+            }
+            detr_outputs["losses"] = losses
+
+        return detr_outputs
+
+    def classifier_loss_calculation(self, detr_outputs: Dict[str, Tensor], sample_list):
+        task_type = self.get_task_type(sample_list.dataset_name)
+        hs = detr_outputs["hidden_states"]
+        if not self.config.loss_on_all_hs:
+            hs = detr_outputs["hidden_states"][-1:]
+        num_queries = self.config.base_args.num_queries[task_type][
+            sample_list.dataset_name
+        ]
+        assert hs[0].size(1) == num_queries
+        losses = {}
+        scores = None
+        detr_outputs = {}
+        num_labels = self.config.heads[task_type][sample_list.dataset_name][
+            "num_labels"
+        ]
+
+        for idx, current_hs in enumerate(hs):
+            pooled_output = current_hs[:, -num_queries, :]
+            pooled_output = self.dropout(pooled_output)
+            logits = self.classifiers[task_type][sample_list.dataset_name](
+                pooled_output
+            )
+            reshaped_logits = logits.contiguous().view(-1, num_labels)
+            scores = reshaped_logits
+            # skip loss computation on test set (which usually doesn't contain labels)
+            if sample_list.dataset_type != "test":
+                loss_prefix = f"{sample_list.dataset_type}/{sample_list.dataset_name}/"
+                loss = self.losses_dict[task_type][sample_list.dataset_name](
+                    scores, sample_list.targets
+                )
+                if sample_list.dataset_name == "vqa2":
+                    loss *= sample_list.targets.size(1)
+                losses[loss_prefix + f"loss_{idx}"] = loss
+
+        detr_outputs["scores"] = scores
+        detr_outputs["losses"] = losses
+        return detr_outputs
+
+    def get_optimizer_parameters(self, config):
+        detr_params = [
+            {
+                "params": [
+                    p
+                    for n, p in self.unit_base_model.named_parameters()
+                    if "backbone" not in n and p.requires_grad
+                ]
+            },
+            {
+                "params": [
+                    p
+                    for n, p in self.unit_base_model.named_parameters()
+                    if "backbone" in n and p.requires_grad
+                ],
+                "lr": self.config.base_args.lr_backbone,
+            },
+        ]
+
+        vqa_params = [
+            {"params": self.bert_model.parameters()},
+            {"params": self.bert_projection.parameters()},
+            {"params": self.task_embeddings_lang.parameters()},
+            {"params": self.bert_pos_projection.parameters()},
+            {"params": self.classifiers.parameters()},
+            {"params": self.class_embeds.parameters()},
+            {"params": self.bbox_embeds.parameters()},
+            {"params": self.det_losses.parameters()},
+        ]
+        return vqa_params + detr_params
+
+    def get_task_idx(self, dataset_name):
+        task_type = self.get_task_type(dataset_name)
+        assert task_type in self.config.heads
+        return self.config.heads[task_type][dataset_name]["task_idx"]
+
+    def get_task_type(self, dataset_name):
+        task_type = "detection"
+        if dataset_name in self.config.heads["vl"]:
+            task_type = "vl"
+        elif dataset_name in self.config.heads["glue"]:
+            task_type = "glue"
+        return task_type
+
+    def get_loss_fn(self, loss_type):
+        if loss_type == "binary_cross_entropy_with_logits":
+            return nn.functional.binary_cross_entropy_with_logits
+        elif loss_type == "cross_entropy":
+            return nn.functional.cross_entropy
+        else:
+            raise Exception(f"Unknown loss type: {loss_type}")

--- a/mmf/models/unit/unit_base_model.py
+++ b/mmf/models/unit/unit_base_model.py
@@ -1,0 +1,458 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Mostly copy-pasted from
+# https://github.com/facebookresearch/detr/blob/master/models/detr.py
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from mmf.models.unit.backbone import build_unit_convnet_backbone
+from mmf.models.unit.matcher import HungarianMatcher
+from mmf.models.unit.misc import NestedTensor
+from mmf.models.unit.transformer import UniTTransformer
+from mmf.utils import box_ops
+from mmf.utils.distributed import get_world_size, is_dist_initialized
+from torch import Tensor, nn
+
+
+class UniTBaseModel(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+
+        self.num_queries = args.num_queries
+        self.backbone = build_unit_convnet_backbone(args)
+        self.transformer = UniTTransformer(args)
+        encoder_hidden_dim = self.transformer.d_model_enc
+        decoder_hidden_dim = self.transformer.d_model_dec
+
+        self.query_embeds = nn.ModuleDict()
+        for task_type in self.num_queries:
+            task_dict = nn.ModuleDict()
+            for dataset in self.num_queries[task_type]:
+                task_dict[dataset] = nn.Embedding(
+                    self.num_queries[task_type][dataset], decoder_hidden_dim
+                )
+            self.query_embeds[task_type] = task_dict
+
+        self.input_proj = nn.Conv2d(
+            self.backbone.num_channels, encoder_hidden_dim, kernel_size=1
+        )
+
+    def forward(
+        self,
+        img_src: Tensor,
+        text_src: Optional[Tensor] = None,
+        text_mask: Optional[Tensor] = None,
+        text_pos: Optional[Tensor] = None,
+        output_hidden_states_only: bool = False,
+        task_type: str = "detection",
+        dataset_name: str = "detection_coco",
+        task_idx: Optional[int] = None,
+    ):
+        img_mask = None
+        img_pos = [None]
+        if img_src is not None:
+            if not isinstance(img_src, NestedTensor):
+                img_src = NestedTensor.from_tensor_list(img_src)
+            features, img_pos = self.backbone(img_src)
+
+            img_src, img_mask = features[-1].decompose()
+            img_src = self.input_proj(img_src)
+
+        query_embed = self.query_embeds[task_type][dataset_name]
+        hs, _ = self.transformer(
+            img_src=img_src,
+            img_mask=img_mask,
+            img_pos=img_pos[-1],
+            text_src=text_src,
+            text_mask=text_mask,
+            text_pos=text_pos,
+            query_embed=query_embed.weight,
+            task_type=task_type,
+            dataset_name=dataset_name,
+            task_idx=task_idx,
+        )
+
+        if hs is not None:
+            assert hs.size(2) == self.num_queries[task_type][dataset_name]
+
+        return {"hidden_states": hs}
+
+
+class MLP(nn.Module):
+    """ Very simple multi-layer perceptron (also called FFN)"""
+
+    def __init__(self, input_dim, hidden_dim, output_dim, num_layers):
+        super().__init__()
+        self.num_layers = num_layers
+        h = [hidden_dim] * (num_layers - 1)
+        self.layers = nn.ModuleList(
+            nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim])
+        )
+
+    def forward(self, x: Tensor):
+        for i, layer in enumerate(self.layers):
+            x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
+        return x
+
+
+class AttributeHead(nn.Module):
+    def __init__(self, object_class_num, attribute_class_num, representation_size):
+        super().__init__()
+
+        # copy-pasted from
+        # https://github.com/ronghanghu/vqa-maskrcnn-benchmark-m4c/blob/0fbccee2dfed10d652bcf014f9f8bfafd8478f51/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py#L52-L61  # NoQA
+        self.cls_embed = nn.Embedding(object_class_num + 1, 256)
+        self.attr_linear1 = nn.Linear(representation_size + 256, 512)
+        self.attr_linear2 = nn.Linear(512, attribute_class_num)
+
+        nn.init.normal_(self.cls_embed.weight, std=0.01)
+        nn.init.normal_(self.attr_linear1.weight, std=0.01)
+        nn.init.normal_(self.attr_linear2.weight, std=0.01)
+        nn.init.constant_(self.attr_linear1.bias, 0)
+        nn.init.constant_(self.attr_linear2.bias, 0)
+
+    def forward(self, hidden_states: Tensor, labels: Tensor):
+        # copy-pasted from
+        # https://github.com/ronghanghu/vqa-maskrcnn-benchmark-m4c/blob/0fbccee2dfed10d652bcf014f9f8bfafd8478f51/maskrcnn_benchmark/modeling/roi_heads/box_head/roi_box_predictors.py#L76-L96  # NoQA
+
+        # get embeddings of indices using gt cls labels
+        cls_embed_out = self.cls_embed(labels)
+
+        # concat with fc7 feats
+        concat_attr = torch.cat([hidden_states, cls_embed_out], dim=-1)
+
+        # pass through attr head layers
+        fc_attr = self.attr_linear1(concat_attr)
+        attr_score = F.relu(self.attr_linear2(fc_attr))
+
+        return attr_score
+
+
+class SetCriterion(nn.Module):
+    """ This class computes the loss for DETR.
+    The process happens in two steps:
+        1) we compute hungarian assignment between ground truth boxes and the outputs
+           of the model
+        2) we supervise each pair of matched ground-truth / prediction (supervise class
+           and box)
+    """
+
+    def __init__(
+        self,
+        num_classes,
+        matcher,
+        weight_dict,
+        eos_coef,
+        losses,
+        attribute_head=None,
+        attribute_class_num=None,
+        max_attribute_num=None,
+    ):
+        """ Create the criterion.
+        Parameters:
+            num_classes: number of object categories, omitting the special no-object
+                category
+            matcher: module able to compute a matching between targets and proposals
+            weight_dict: dict containing as key the names of the losses and as values
+                their relative weight.
+            eos_coef: relative classification weight applied to the no-object category
+            losses: list of all the losses to be applied. See get_loss for list of
+                available losses.
+        """
+        super().__init__()
+        self.num_classes = num_classes
+        self.matcher = matcher
+        self.weight_dict = weight_dict
+        self.eos_coef = eos_coef
+        self.losses = losses
+        empty_weight = torch.ones(self.num_classes + 1)
+        empty_weight[-1] = self.eos_coef
+        self.register_buffer("empty_weight", empty_weight)
+        self.attribute_head = attribute_head
+        self.attribute_class_num = attribute_class_num
+        self.max_attribute_num = max_attribute_num
+
+    def loss_labels(self, outputs, targets, indices, num_boxes, log=True):
+        """Classification loss (NLL)
+        targets dicts must contain the key "labels" containing a tensor of dim
+            [nb_target_boxes]
+        """
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"]
+
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+
+        loss_ce = F.cross_entropy(
+            src_logits.transpose(1, 2), target_classes, self.empty_weight
+        )
+        losses = {"loss_ce": loss_ce}
+
+        if self.attribute_head is not None and "attributes" in targets[0]:
+            attribute_logits = self.attribute_head(
+                outputs["hs_for_attr"], target_classes
+            )
+            target_attributes_o = torch.cat(
+                [t["attributes"][J] for t, (_, J) in zip(targets, indices)]
+            )
+            target_attributes = -torch.ones(
+                *src_logits.shape[:2], 16, dtype=torch.int64, device=src_logits.device
+            )
+            target_attributes[idx] = target_attributes_o
+            losses["loss_attr"] = self._attribute_loss(
+                attribute_logits, target_attributes
+            )
+
+        return losses
+
+    def loss_labels_balanced(self, outputs, targets, indices, num_boxes, log=True):
+        """Classification loss (NLL)
+        targets dicts must contain the key "labels" containing a tensor of dim
+            [nb_target_boxes]
+        """
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"]
+
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+
+        sl = src_logits.flatten(0, 1)
+        tc = target_classes.flatten(0, 1)
+        pos = tc != self.num_classes
+        loss_pos = F.cross_entropy(sl[pos], tc[pos], reduction="none").sum() / num_boxes
+        loss_neg = F.cross_entropy(sl[~pos], tc[~pos], reduction="none").sum() / (
+            sl.shape[0] - num_boxes
+        )
+
+        loss_ce = (1 - self.eos_coef) * loss_pos + self.eos_coef * loss_neg
+        losses = {"loss_ce": loss_ce}
+
+        if self.attribute_head is not None:
+            raise NotImplementedError()
+
+        return losses
+
+    @torch.no_grad()
+    def loss_cardinality(self, outputs, targets, indices, num_boxes):
+        """ Compute the cardinality error, ie the absolute error in the number of
+        predicted non-empty boxes
+        This is not really a loss, it is intended for logging purposes only. It doesn't
+        propagate gradients
+        """
+        pred_logits = outputs["pred_logits"]
+        device = pred_logits.device
+        tgt_lengths = torch.as_tensor(
+            [len(v["labels"]) for v in targets], device=device
+        )
+        # Count the number of predictions that are NOT "no-object" (which is the last
+        # class)
+        card_pred = (pred_logits.argmax(-1) != pred_logits.shape[-1] - 1).sum(1)
+        card_err = F.l1_loss(card_pred.float(), tgt_lengths.float())
+        losses = {"cardinality_error": card_err}
+        return losses
+
+    def loss_boxes(self, outputs, targets, indices, num_boxes):
+        """Compute the losses related to the bounding boxes, the L1 regression loss and
+                the GIoU loss
+           targets dicts must contain the key "boxes" containing a tensor of dim
+                [nb_target_boxes, 4]
+           The target boxes are expected in format (center_x, center_y, h, w),
+                normalized by the image size.
+        """
+        assert "pred_boxes" in outputs
+        idx = self._get_src_permutation_idx(indices)
+        src_boxes = outputs["pred_boxes"][idx]
+        target_boxes = torch.cat(
+            [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+        )
+
+        loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction="none")
+
+        losses = {}
+        losses["loss_bbox"] = loss_bbox.sum() / num_boxes
+
+        loss_giou = 1 - torch.diag(
+            box_ops.generalized_box_iou(
+                box_ops.box_cxcywh_to_xyxy(src_boxes).float(),
+                box_ops.box_cxcywh_to_xyxy(target_boxes),
+            )
+        )
+        losses["loss_giou"] = loss_giou.sum() / num_boxes
+        return losses
+
+    def _get_src_permutation_idx(self, indices):
+        # permute predictions following indices
+        batch_idx = torch.cat(
+            [torch.full_like(src, i) for i, (src, _) in enumerate(indices)]
+        )
+        src_idx = torch.cat([src for (src, _) in indices])
+        return batch_idx, src_idx
+
+    def _get_tgt_permutation_idx(self, indices):
+        # permute targets following indices
+        batch_idx = torch.cat(
+            [torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)]
+        )
+        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
+        return batch_idx, tgt_idx
+
+    def get_loss(self, loss, outputs, targets, indices, num_boxes, **kwargs):
+        loss_map = {
+            "labels": self.loss_labels,
+            "labels_balanced": self.loss_labels_balanced,
+            "cardinality": self.loss_cardinality,
+            "boxes": self.loss_boxes,
+        }
+        assert loss in loss_map, f"do you really want to compute {loss} loss?"
+        return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
+
+    def forward(self, outputs, targets):
+        """ This performs the loss computation.
+        Parameters:
+             outputs: dict of tensors, see the output specification of the model for
+                      the format
+             targets: list of dicts, such that len(targets) == batch_size.
+                      The expected keys in each dict depends on the losses applied, see
+                      each loss' doc
+        """
+        outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
+
+        # Retrieve the matching between the outputs of the last layer and the targets
+        indices = self.matcher(outputs_without_aux, targets)
+
+        # Compute the average number of target boxes accross all nodes, for
+        # normalization purposes
+        num_boxes = sum(len(t["labels"]) for t in targets)
+        num_boxes = torch.as_tensor(
+            [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
+        )
+        if is_dist_initialized():
+            torch.distributed.all_reduce(num_boxes)
+        num_boxes = torch.clamp(num_boxes / get_world_size(), min=1).item()
+
+        # Compute all the requested losses
+        losses = {}
+        for loss in self.losses:
+            losses.update(self.get_loss(loss, outputs, targets, indices, num_boxes))
+
+        # In case of auxiliary losses, we repeat this process with the output of each
+        # intermediate layer.
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                indices = self.matcher(aux_outputs, targets)
+                for loss in self.losses:
+                    kwargs = {}
+                    if loss in ("labels", "labels_balanced"):
+                        # Logging is enabled only for the last layer
+                        kwargs = {"log": False}
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices, num_boxes, **kwargs
+                    )
+                    l_dict = {k + f"_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        return losses
+
+    def _attribute_loss(self, attribute_logits, attributes):
+        _N, _B, _C = attribute_logits.size()
+        assert _C == self.attribute_class_num
+        attribute_logits = attribute_logits.view(_N * _B, _C)
+
+        assert attributes.size(0) == _N
+        assert attributes.size(1) == _B
+        assert attributes.size(2) == self.max_attribute_num
+        attributes = attributes.view(_N * _B, self.max_attribute_num)
+
+        # https://github.com/ronghanghu/vqa-maskrcnn-benchmark-m4c/blob/0fbccee2dfed10d652bcf014f9f8bfafd8478f51/maskrcnn_benchmark/modeling/roi_heads/box_head/loss.py#L185-L222  # NoQA
+        n_boxes = attribute_logits.shape[0]
+
+        # N_BOXES, N_ATTR -> N_BOXES, 1, N_ATTR
+        attribute_logits = attribute_logits.unsqueeze(1)
+
+        # N_BOXES, 1, N_ATTR -> N_BOXES, MAX_ATTR_PER_INST, N_ATTR
+        # -> N_BOXES * MAX_ATTR_PER_INST, N_ATTR
+        attribute_logits = (
+            attribute_logits.expand(n_boxes, 16, self.attribute_class_num)
+            .contiguous()
+            .view(-1, self.attribute_class_num)
+        )
+
+        # Normalize each box loss by # of valid GT attributes (ie attr != -1)
+        # Repeat number of valid attributes per box along the rows and take transpose
+        inv_per_box_weights = (
+            (attributes >= 0).sum(dim=1).repeat(16, 1).transpose(0, 1).flatten()
+        )
+        per_box_weights = inv_per_box_weights.float().reciprocal()
+        per_box_weights[per_box_weights > 1] = 0.0
+
+        attributes = attributes.view(-1)
+        attribute_loss = 0.5 * F.cross_entropy(
+            attribute_logits, attributes, reduction="none", ignore_index=-1
+        )
+
+        attribute_loss = (attribute_loss * per_box_weights).view(n_boxes, -1).sum(dim=1)
+
+        # Find number of boxes with atleast valid attribute
+        n_valid_boxes = len(attribute_loss.nonzero())
+
+        if n_valid_boxes > 0:
+            attribute_loss = (attribute_loss / n_valid_boxes).sum()
+        else:
+            attribute_loss = (attribute_loss * 0.0).sum()
+
+        return attribute_loss
+
+
+def build_detection_loss(args, num_classes, attribute_head):
+    matcher = HungarianMatcher(
+        cost_class=args.set_cost_class,
+        cost_bbox=args.set_cost_bbox,
+        cost_giou=args.set_cost_giou,
+        logsoftmax=args.use_bcl,
+    )
+    weight_dict = {"loss_ce": 1, "loss_bbox": args.bbox_loss_coef}
+    weight_dict["loss_giou"] = args.giou_loss_coef
+    weight_dict["loss_attr"] = args.attr_loss_coef
+    if args.aux_loss:
+        aux_weight_dict = {}
+        for i in range(args.dec_layers - 1):
+            aux_weight_dict.update({k + f"_{i}": v for k, v in weight_dict.items()})
+        weight_dict.update(aux_weight_dict)
+
+    losses = []
+    if args.use_bcl:
+        losses.append("labels_balanced")
+    else:
+        losses.append("labels")
+    losses.extend(["boxes", "cardinality"])
+
+    criterion = SetCriterion(
+        num_classes,
+        matcher=matcher,
+        weight_dict=weight_dict,
+        eos_coef=args.eos_coef,
+        losses=losses,
+        attribute_head=attribute_head,
+        attribute_class_num=args.attribute_class_num,
+        max_attribute_num=args.max_attribute_num,
+    )
+    return criterion

--- a/mmf/modules/optimizers.py
+++ b/mmf/modules/optimizers.py
@@ -1,7 +1,84 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import math
+from typing import Callable
 
+import torch
 from mmf.common.registry import registry
 from transformers.optimization import AdamW
 
 
 registry.register_optimizer("adam_w")(AdamW)
+
+
+@registry.register_optimizer("adam_w_skip_params_with_zero_grad")
+class AdamWSkipParamsWithZeroGrad(AdamW):
+    def step(self, closure: Callable = None):
+        """
+        Performs a single optimization step.
+        Arguments:
+            closure (:obj:`Callable`, `optional`): A closure that reevaluates the model
+            and returns the loss.
+
+        modified from
+        https://github.com/huggingface/transformers/blob/d2f9cb838ec1ed7f62ddfb850dccd223e19441ad/src/transformers/optimization.py#L259-L318  # NoQA
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if p.grad.abs().sum().item() == 0:
+                    continue
+                grad = p.grad.data
+                if grad.is_sparse:
+                    raise RuntimeError(
+                        "Adam does not support sparse gradients, please consider "
+                        "SparseAdam instead"
+                    )
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state["step"] = 0
+                    # Exponential moving average of gradient values
+                    state["exp_avg"] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state["exp_avg_sq"] = torch.zeros_like(p.data)
+
+                exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
+                beta1, beta2 = group["betas"]
+
+                state["step"] += 1
+
+                # Decay the first and second moment running average coefficient
+                # In-place operations to update the averages at the same time
+                exp_avg.mul_(beta1).add_(grad, alpha=1.0 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1.0 - beta2)
+                denom = exp_avg_sq.sqrt().add_(group["eps"])
+
+                step_size = group["lr"]
+                if group["correct_bias"]:  # No bias correction for Bert
+                    bias_correction1 = 1.0 - beta1 ** state["step"]
+                    bias_correction2 = 1.0 - beta2 ** state["step"]
+                    step_size = (
+                        step_size * math.sqrt(bias_correction2) / bias_correction1
+                    )
+
+                p.data.addcdiv_(exp_avg, denom, value=-step_size)
+
+                # Just adding the square of the weights to the loss function is *not*
+                # the correct way of using L2 regularization/weight decay with Adam,
+                # since that will interact with the m and v parameters in strange ways.
+                #
+                # Instead we want to decay the weights in a manner that doesn't interact
+                # with the m/v parameters. This is equivalent to adding the square
+                # of the weights to the loss with plain (non-momentum) SGD.
+                # Add weight decay at the end (fixed version)
+                if group["weight_decay"] > 0.0:
+                    p.data.add_(p.data, alpha=-group["lr"] * group["weight_decay"])
+
+        return loss

--- a/projects/unit/configs/all_8_datasets/separate_dec.yaml
+++ b/projects/unit/configs/all_8_datasets/separate_dec.yaml
@@ -1,0 +1,10 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    base_args:
+      share_decoders: false
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW

--- a/projects/unit/configs/all_8_datasets/shared_dec.yaml
+++ b/projects/unit/configs/all_8_datasets/shared_dec.yaml
@@ -1,0 +1,103 @@
+includes:
+- ../vqa2_dataset_cfg.yaml
+- ../visual_entailment_dataset_cfg.yaml
+
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+          detection_visual_genome: 100
+        vl:
+          vqa2: 25
+          # hateful_memes: 25
+          visual_entailment: 25
+        glue:
+          glue_qnli: 25
+          glue_qqp: 25
+          glue_sst2: 25
+          glue_mnli_mismatched: 25
+      share_decoders: true
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    - detection_visual_genome
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection_2017/annotations/annotations/instances_val2017.json
+        detection_visual_genome:
+          val: ${env.data_dir}/datasets/visual_genome/detection_split_by_coco_2017/annotations/instances_val_split_by_coco_2017.json
+  - type: accuracy
+    key: accuracy
+    datasets:
+    - visual_entailment
+    - glue_qnli
+    - glue_qqp
+    - glue_sst2
+    - glue_mnli_mismatched
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 500000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+multitasking:
+  enabled: true
+  sampling_ratios:
+    detection_coco: 0.2
+    detection_visual_genome: 0.07
+    visual_entailment: 0.12
+    vqa2: 0.26
+    glue_qnli: 0.1
+    glue_mnli_mismatched: 0.1
+    glue_qqp: 0.1
+    glue_sst2: 0.05
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/coco/single_task.yaml
+++ b/projects/unit/configs/coco/single_task.yaml
@@ -1,0 +1,63 @@
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+      share_decoders: false
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection_2017/annotations/annotations/instances_val2017.json
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 150000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: detection_coco/detection_mean_ap
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/coco_vg_vqa2/separate_dec.yaml
+++ b/projects/unit/configs/coco_vg_vqa2/separate_dec.yaml
@@ -1,0 +1,10 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    base_args:
+      share_decoders: false
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW

--- a/projects/unit/configs/coco_vg_vqa2/shared_dec.yaml
+++ b/projects/unit/configs/coco_vg_vqa2/shared_dec.yaml
@@ -1,0 +1,75 @@
+includes:
+- ../vqa2_dataset_cfg.yaml
+
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+          detection_visual_genome: 100
+        vl:
+          vqa2: 25
+      share_decoders: true
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    - detection_visual_genome
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection_2017/annotations/annotations/instances_val2017.json
+        detection_visual_genome:
+          val: ${env.data_dir}/datasets/visual_genome/detection_split_by_coco_2017/annotations/instances_val_split_by_coco_2017.json
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad  # skip update on unused params in a batch
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 450000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/coco_vqa2/separate_dec.yaml
+++ b/projects/unit/configs/coco_vqa2/separate_dec.yaml
@@ -1,0 +1,10 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    base_args:
+      share_decoders: false
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW

--- a/projects/unit/configs/coco_vqa2/shared_dec.yaml
+++ b/projects/unit/configs/coco_vqa2/shared_dec.yaml
@@ -1,0 +1,71 @@
+includes:
+- ../vqa2_dataset_cfg.yaml
+
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        detection:
+          detection_coco: 100
+        vl:
+          vqa2: 25
+      share_decoders: true
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_coco
+    params:
+      dataset_json_files:
+        detection_coco:
+          val: ${env.data_dir}/datasets/coco/detection_2017/annotations/annotations/instances_val2017.json
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad  # skip update on unused params in a batch
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 300000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/vg/single_task.yaml
+++ b/projects/unit/configs/vg/single_task.yaml
@@ -1,0 +1,63 @@
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        detection:
+          detection_visual_genome: 100
+      share_decoders: false
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_visual_genome
+    params:
+      dataset_json_files:
+        detection_visual_genome:
+          val: ${env.data_dir}/datasets/visual_genome/detection_split_by_coco_2017/annotations/instances_val_split_by_coco_2017.json
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 150000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: detection_visual_genome/detection_mean_ap
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/vg_vqa2/separate_dec.yaml
+++ b/projects/unit/configs/vg_vqa2/separate_dec.yaml
@@ -1,0 +1,10 @@
+includes:
+- ./shared_dec.yaml
+
+model_config:
+  unit:
+    base_args:
+      share_decoders: false
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW

--- a/projects/unit/configs/vg_vqa2/shared_dec.yaml
+++ b/projects/unit/configs/vg_vqa2/shared_dec.yaml
@@ -1,0 +1,71 @@
+includes:
+- ../vqa2_dataset_cfg.yaml
+
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        detection:
+          detection_visual_genome: 100
+        vl:
+          vqa2: 25
+      share_decoders: true
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+  - type: detection_mean_ap
+    key: detection_mean_ap
+    datasets:
+    - detection_visual_genome
+    params:
+      dataset_json_files:
+        detection_visual_genome:
+          val: ${env.data_dir}/datasets/visual_genome/detection_split_by_coco_2017/annotations/instances_val_split_by_coco_2017.json
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad  # skip update on unused params in a batch
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 300000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/visual_entailment_dataset_cfg.yaml
+++ b/projects/unit/configs/visual_entailment_dataset_cfg.yaml
@@ -1,0 +1,30 @@
+dataset_config:
+  visual_entailment:
+    zoo_requirements:
+    - visual_entailment.defaults
+    - flickr30k.defaults
+    use_features: false
+    use_images: true
+    processors:
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: ResizeShortest
+              params:
+                min_size: 800
+                max_size: 1333
+            - ToTensor
+            - type: Normalize
+              params:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.229, 0.224, 0.225]
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 25

--- a/projects/unit/configs/vqa2/single_task.yaml
+++ b/projects/unit/configs/vqa2/single_task.yaml
@@ -1,0 +1,61 @@
+includes:
+- ../vqa2_dataset_cfg.yaml
+
+model_config:
+  unit:
+    base_args:
+      num_queries:
+        vl:
+          vqa2: 25
+      share_decoders: false
+      decoder_hidden_dim: 768
+      dilation: true
+      use_task_embedding_in_img_encoder: true
+      use_task_embedding_in_lang_encoder: true
+    losses:
+    - logit_bce
+    # initialize the ResNet convnet backbone from DETR
+    base_ckpt_path: https://dl.fbaipublicfiles.com/detr/detr-r50-dc5-f0fb7ef5.pth
+    base_ckpt_load_backbone_only: true
+
+evaluation:
+  metrics:
+  - type: vqa_accuracy
+    datasets:
+    - vqa2
+
+optimizer:
+  type: adam_w  # HuggingFace transformer's AdamW
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+training:
+  num_workers: 2
+  # these are mostly the same as in COCO detection training
+  clip_norm_mode: all
+  clip_gradients: true
+  max_grad_l2_norm: 0.1
+  lr_scheduler: true
+  lr_ratio: 0.1
+  batch_size: 64
+  max_updates: 150000
+  checkpoint_interval: 10000
+  evaluation_interval: 10000
+  dataset_size_proportional_sampling: false
+  early_stop:
+    enabled: false
+    criteria: vqa2/vqa_accuracy
+    minimize: false
+  stdout_capture: false
+  find_unused_parameters: true
+
+checkpoint:
+  max_to_keep: 5

--- a/projects/unit/configs/vqa2_dataset_cfg.yaml
+++ b/projects/unit/configs/vqa2_dataset_cfg.yaml
@@ -1,0 +1,57 @@
+dataset_config:
+  vqa2:
+    zoo_requirements:
+    - coco.defaults
+    - vqa2.defaults
+    - vqa2.split_by_coco_2017
+    return_features_info: true
+    use_features: false
+    use_images: true
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 25
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: ResizeShortest
+              params:
+                min_size: 800
+                max_size: 1333
+            - ToTensor
+            - type: Normalize
+              params:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.229, 0.224, 0.225]
+    images:
+      train:
+      - coco/defaults/images/train2014
+      - coco/defaults/images/val2014
+      - coco/defaults/images/train2014
+      - coco/defaults/images/val2014
+      - coco/defaults/images/val2014
+      val:
+      - coco/defaults/images/val2014
+      test:
+      - coco/defaults/images/test2015
+    annotations:
+      # the train, val, test splits are built according to COCO train2017, val2017, and test2015 splits, which don't overlap
+      # - COCO train2017 contains the entire train2014 plus part of val2014, excluding those in val2017
+      # - COCO val2017 is a subset of COCO val2014
+      train:
+      - vqa2/split_by_coco_2017/annotations/imdb_train2017_in_train2014.npy
+      - vqa2/split_by_coco_2017/annotations/imdb_train2017_in_val2014.npy
+      - vqa2/split_by_coco_2017/annotations/imdb_vg_karpathytrain_in_train2014.npy
+      - vqa2/split_by_coco_2017/annotations/imdb_vg_karpathytrain_in_val2014_not_in_val2017.npy
+      - vqa2/split_by_coco_2017/annotations/imdb_vg_karpathytest_not_in_val2017.npy
+      val:
+      - vqa2/split_by_coco_2017/annotations/imdb_val2017.npy
+      test:
+      - vqa2/defaults/annotations/imdb_test2015.npy


### PR DESCRIPTION
This PR is built upon https://github.com/facebookresearch/mmf/pull/740

- add the UniT model
- add `AdamWSkipParamsWithZeroGrad` optimizer (skips unused params)
- provide dataset zoo download for VQAv2 splits w.r.t. COCO 2017.
- provide model zoo download for UniT.

Test Plan:

Tested locally and verified the outputs

---

Evaluating the UniT model zoo entry
```
# on a 8-GPU machine
python mmf_cli/run.py \
    config=projects/unit/configs/all_8_datasets/shared_dec.yaml \
    datasets=detection_coco,detection_visual_genome,vqa2,visual_entailment,glue_qnli,glue_sst2,glue_mnli_mismatched,glue_qqp \
    model=unit \
    run_type=val \
    training.batch_size=8 \
    checkpoint.resume_zoo=unit.defaults
```

Evaluation outputs on the 8-dataset model:
```
val/detection_coco/detection_mean_ap: 0.3899,
val/detection_visual_genome/detection_mean_ap: 0.0329,
val/vqa2/vqa_accuracy: 0.6696,
val/visual_entailment/accuracy: 0.7316,
val/glue_qnli/accuracy: 0.8790,
val/glue_sst2/accuracy: 0.8922,
val/glue_mnli_mismatched/accuracy: 0.8090,
val/glue_qqp/accuracy: 0.9065
```