### PR TITLE
[fix, test] Fix recall metric bug, add test

### DIFF
--- a/tests/modules/test_metrics.py
+++ b/tests/modules/test_metrics.py
@@ -110,6 +110,31 @@ class TestModuleMetrics(unittest.TestCase):
         )
         self.assertAlmostEqual(metric.calculate(sample, predicted).item(), value, 4)
 
+    def _test_recall_at_k_metric(self, metric, value):
+        sample = Sample()
+        predicted = dict()
+
+        first_dimension = 10
+        second_dimension = 100  # second dim MUST be 100
+        sample.targets = torch.ones(first_dimension, second_dimension)
+        predicted["scores"] = torch.ones(first_dimension, second_dimension)
+
+        for i in range(first_dimension):
+            for j in range(second_dimension):
+                # sample = [[0, 1, 2, ..., 99], [0, 1, ..., 99], ...]
+                sample.targets[i][j] = j
+                if j == second_dimension - 1 and i != 0:
+                    # changes last value or 'chosen candidate'
+                    # to a lower rank as i increases
+                    # predicted = [[0, 2, 4, ..., 198], [0, 2, ..., 196, 191],
+                    # [0, ..., 196, 189], [0, ..., 196, 187], ...]
+                    predicted["scores"][i][j] = j * 2 - 1 - (i + 2) * 2
+                else:
+                    # predicted = [[0, 2, 4, ..., 198], [0, 2, ...], ...]
+                    predicted["scores"][i][j] = j * 2
+
+        self.assertAlmostEqual(metric.calculate(sample, predicted), value)
+
     def test_micro_f1(self):
         metric = metrics.MicroF1()
         self._test_binary_metric(metric, 0.5)
@@ -165,3 +190,15 @@ class TestModuleMetrics(unittest.TestCase):
         metric = metrics.MacroAP()
         self._test_binary_metric(metric, 0.6666666)
         self._test_multiclass_metric(metric, 0.3888888)
+
+    def test_recall_at_1(self):
+        metric = metrics.RecallAt1()
+        self._test_recall_at_k_metric(metric, 0.1)
+
+    def test_recall_at_5(self):
+        metric = metrics.RecallAt5()
+        self._test_recall_at_k_metric(metric, 0.3)
+
+    def test_recall_at_10(self):
+        metric = metrics.RecallAt10()
+        self._test_recall_at_k_metric(metric, 0.8)


### PR DESCRIPTION
- Fix infinite recursion error #725
- Add back mistakenly removed code
- Add test for recall metric at 1, 5, and 10

This is a response to bug #725 

I believe `process_ranks` may have been accidentally deleted in this commit so I added it back: 
https://github.com/facebookresearch/mmf/commit/6b6f4fc221c46f8c55d55a06e110f3d8f9ca2417

I also added a testing file, which basically ranks all of the expected values in increasing order (so the last candidate is always the chosen one).

Both the expected values and predicted values are (10, 100) tensors. As the index of top level array increases, I alter the final value to be decreasing by 2, so the chosen candidates are 198 (maximum value 99*2), 191, 189, 187, ...

I decrease it in this way so that each of the candidates become out of the bounds for the increasing Recall Metrics. The rankings are `tensor([ 1,  4,  5,  6,  7,  8,  9, 10, 11, 12])`

This makes the results varying for each metric:

`RecallAt1` --> 1/10 = .1
`RecallAt5` --> 3/10 = .3
`RecallAt10` --> 8/10 = .8

I would love for people to take a look at `metrics.py` line `462` (`process_ranks`)
There are print statements in here from the previous commit, but I do not see print statements anywhere else in the modules, should I delete these, leave them, do we have a different logging style? Thanks!