### PR TITLE
[fix] fix gradient accumulation when update_frequency != 1

### DIFF
--- a/mmf/common/report.py
+++ b/mmf/common/report.py
@@ -74,7 +74,7 @@ class Report(OrderedDict):
     def fields(self):
         return list(self.keys())
 
-    def accumulate_tensor_fields(self, report, field_list):
+    def accumulate_tensor_fields_and_loss(self, report, field_list):
         for key in field_list:
             if key not in self.keys():
                 warnings.warn(
@@ -84,3 +84,16 @@ class Report(OrderedDict):
                 continue
             if isinstance(self[key], torch.Tensor):
                 self[key] = torch.cat((self[key], report[key]), dim=0)
+
+        self._accumulate_loss(report)
+
+    def _accumulate_loss(self, report):
+        for key, value in report.losses.items():
+            if key not in self.losses.keys():
+                warnings.warn(
+                    f"{key} not found in report. Loss calculation "
+                    + "might not work as expected."
+                )
+                continue
+            if isinstance(self.losses[key], torch.Tensor):
+                self.losses[key] += value

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -20,7 +20,7 @@ training:
     # completed first. Default: null means epochs won't be used
     max_epochs: null
 
-    # After `log_interval` iterations, current iteration's training loss will be
+    # After `log_interval` updates, current update's training loss will be
     # reported. This will also report validation on a single batch from validation set
     # to provide an estimate on validation side
     log_interval: 100
@@ -56,11 +56,11 @@ training:
     # Whether to pin memory in dataloader
     pin_memory: false
 
-    # After `checkpoint_interval` iterations, MMF will make a snapshot
+    # After `checkpoint_interval` number of updates, MMF will make a snapshot
     # which will involve creating a checkpoint for current training scenarios
     checkpoint_interval: 1000
     # This will evaluate evaluation metrics on whole validation set after
-    # evaluation interval
+    # evaluation interval number of updates
     evaluation_interval: 1000
     # Whether gradients should be clipped
     clip_gradients: false
@@ -117,7 +117,7 @@ training:
     find_unused_parameters: false
 
     # By default metrics evaluation is turned off during training. Set this to true
-    # to enable evaluation every log_interval
+    # to enable evaluation every log_interval number of updates
     evaluate_metrics: false
 
     # This will enable anomaly detection mode in PyTorch. Use this for debugging

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,12 +117,13 @@ class NumbersDataset(torch.utils.data.Dataset):
 class SimpleModel(torch.nn.Module):
     def __init__(self, size):
         super().__init__()
-        self.linear = torch.nn.Linear(size, 4)
+        self.linear = torch.nn.Linear(size, 1)
 
     def forward(self, prepared_batch):
         batch = prepared_batch[DATA_ITEM_KEY]
-        model_output = {"losses": {"loss": torch.sum(self.linear(batch))}}
-        return model_output
+        output = self.linear(batch)
+        loss = torch.nn.MSELoss()(output, batch)
+        return {"losses": {"loss": loss}, "logits": output}
 
 
 def assertModulesEqual(mod1, mod2):

--- a/tests/trainers/test_fp16.py
+++ b/tests/trainers/test_fp16.py
@@ -30,7 +30,7 @@ class MMFTrainerMock(TrainerTrainingLoopMock, MMFTrainer):
     def __init__(
         self, num_train_data, max_updates, max_epochs, device="cuda", fp16_model=False
     ):
-        super().__init__(num_train_data, max_updates, max_epochs)
+        super().__init__(num_train_data, max_updates, max_epochs, fp16=True)
         self.device = torch.device(device)
         if fp16_model:
             assert (


### PR DESCRIPTION
* fix gradient accumulation when update_frequency is not equal to 1
  * The issue is caused by "start_update" being called at an irregular time so the gradients are actually not being accumulated in between update_frequency. When optimizer's `zero_grad` is called, grad is manually set to zero and therefore the gradients are not being accumulated. This fix made it so that `zero_grad` is called in the correct interval so that grad are being accumulated in between update_frequency.   
* fix `combined_report` not taking into account the new losses causing metrics calculation to be incorrect.
* add test (including logging)
  * add test to make sure there is a final update even if the num batches from the current update < update frequency.
* address issue: https://github.com/facebookresearch/mmf/issues/626