### PR TITLE
[fix] Fix windows build for iopath dependency

### DIFF
--- a/.github/workflows/cpu_test.yaml
+++ b/.github/workflows/cpu_test.yaml
@@ -50,7 +50,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade setuptools certifi
         pip install --progress-bar off torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        pip install --progress-bar off scipy==1.4.1 pybind11==2.5.0
+        pip install --progress-bar off scipy==1.4.1 pybind11==2.5.0 pywin32==225
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env
 


### PR DESCRIPTION
Fixes Windows build after it was broken due to iopath dependency inclusion. Latest version of pywin is not compatible with python3.8, so we need to fix it at v225. Reference : [issue](https://github.com/mhammond/pywin32/issues/1431).
