### PR TITLE
[feat] Sharded DDP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,12 @@ install_dep: &install_dep
       command: |
         source activate mmf
         pip install --upgrade setuptools
+        pip install --upgrade torch torchvision
         pip install --progress-bar off flake8==3.7.9
         pip install --progress-bar off black==19.3b0
         pip install --progress-bar off isort==4.3.21
         pip install --progress-bar off pytest
+        pip install --progress-bar off fairscale==0.1.7
         python setup.py clean --all
         python setup.py install
         python -c 'import torch; print("Torch version:", torch.__version__)'

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -195,6 +195,7 @@ class TrainerTrainingLoopMixin(ABC):
         if self.training_config.clip_gradients:
             clip_gradients(
                 self.model,
+                self.optimizer,
                 self.num_updates,
                 self.logistics_callback.tb_writer,
                 self.config,

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -117,7 +117,21 @@ class MMFTrainer(
             ), "Using fp16 requires torch version >- 1.6"
             assert self.device != torch.device("cpu"), "fp16 cannot be used on cpu"
 
-        self.scaler = torch.cuda.amp.GradScaler(enabled=self.training_config.fp16)
+        set_torch_grad_scaler = True
+        if self.training_config.fp16 and self.distributed:
+            try:
+                from fairscale.optim.oss import OSS
+                from fairscale.optim.grad_scaler import ShardedGradScaler
+
+                if isinstance(self.optimizer, OSS):
+                    self.scaler = ShardedGradScaler()
+                    set_torch_grad_scaler = False
+                    logger.info("Using FairScale ShardedGradScaler")
+            except ImportError:
+                logger.info("Using Pytorch AMP GradScaler")
+
+        if set_torch_grad_scaler:
+            self.scaler = torch.cuda.amp.GradScaler(enabled=self.training_config.fp16)
 
     def train(self):
         logger.info("===== Model =====")

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -26,15 +26,18 @@ def lr_lambda_update(i_iter, cfg):
         return pow(cfg.training.lr_ratio, idx)
 
 
-def clip_gradients(model, i_iter, writer, config, scale=1.0):
+def clip_gradients(model, optimizer, i_iter, writer, config, scale=1.0):
     max_grad_l2_norm = config.training.max_grad_l2_norm
     clip_norm_mode = config.training.clip_norm_mode
 
     if max_grad_l2_norm is not None:
         if clip_norm_mode == "all":
-            norm = nn.utils.clip_grad_norm_(
-                model.parameters(), max_grad_l2_norm * scale
-            )
+            if hasattr(optimizer, "clip_grad_norm"):
+                norm = optimizer.clip_grad_norm(max_grad_l2_norm * scale)
+            else:
+                norm = nn.utils.clip_grad_norm_(
+                    model.parameters(), max_grad_l2_norm * scale
+                )
             if writer is not None:
                 writer.add_scalars({"grad_norm": norm}, i_iter)
         else:

--- a/tests/trainers/lightning/test_grad_clipping.py
+++ b/tests/trainers/lightning/test_grad_clipping.py
@@ -28,7 +28,11 @@ class TestLightningTrainerGradClipping(unittest.TestCase, Callback):
 
         def _finish_update():
             clip_gradients(
-                mmf_trainer.model, mmf_trainer.num_updates, None, mmf_trainer.config
+                mmf_trainer.model,
+                mmf_trainer.optimizer,
+                mmf_trainer.num_updates,
+                None,
+                mmf_trainer.config,
             )
             for param in mmf_trainer.model.parameters():
                 mmf_grad = torch.clone(param.grad).detach().item()

--- a/tests/trainers/test_sharded_ddp.py
+++ b/tests/trainers/test_sharded_ddp.py
@@ -1,0 +1,114 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import os
+import unittest
+
+import torch
+from mmf.common.registry import registry
+from mmf.trainers.mmf_trainer import MMFTrainer
+from mmf.utils.build import build_optimizer
+from omegaconf import OmegaConf
+from tests.test_utils import SimpleModel, skip_if_no_cuda
+from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+
+
+try:
+    from fairscale.optim.oss import OSS
+    from fairscale.nn.data_parallel import ShardedDataParallel
+    from fairscale.optim.grad_scaler import ShardedGradScaler
+
+    FAIRSCALE_AVAILABLE = True
+except ImportError:
+    FAIRSCALE_AVAILABLE = False
+
+
+class MMFTrainerMock(TrainerTrainingLoopMock, MMFTrainer):
+    def __init__(
+        self,
+        config,
+        num_train_data,
+        max_updates,
+        max_epochs,
+        device="cuda",
+        fp16_model=False,
+    ):
+        super().__init__(num_train_data, max_updates, max_epochs, fp16=True)
+        self.device = torch.device(device)
+        self.config = config
+        self.model = SimpleModel(1)
+        self.model = self.model.cuda()
+        self.optimizer = build_optimizer(self.model, self.config)
+        self.distributed = True
+        self.local_rank = 0
+        self.parallelize_model()
+        self.load_fp16_scaler()
+
+
+class TestShardedDDP(unittest.TestCase):
+    def setUp(self):
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29501"
+        torch.distributed.init_process_group(
+            backend=torch.distributed.Backend.NCCL, rank=0, world_size=1
+        )
+        self.config_oss = OmegaConf.create(
+            {
+                "optimizer": {
+                    "type": "adam_w",
+                    "enable_state_sharding": True,
+                    "params": {"lr": 5e-5},
+                },
+                "training": {"find_unused_parameters": False},
+            }
+        )
+        self.config_no_oss = OmegaConf.create(
+            {
+                "optimizer": {
+                    "type": "adam_w",
+                    "enable_state_sharding": False,
+                    "params": {"lr": 5e-5},
+                },
+                "training": {"find_unused_parameters": False},
+            }
+        )
+        self.trainer = None
+
+    def tearDown(self):
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+        del self.trainer
+        registry.unregister("config")
+
+    @skip_if_no_cuda
+    @unittest.skipUnless(FAIRSCALE_AVAILABLE, "Tests for fairscale")
+    def test_no_sharding(self):
+        self.trainer = MMFTrainerMock(self.config_no_oss, 100, 2, 0.04)
+
+        self.assertFalse(isinstance(self.trainer.optimizer, OSS))
+
+        self.assertFalse(isinstance(self.trainer.model, ShardedDataParallel))
+        self.assertTrue(
+            isinstance(self.trainer.model, torch.nn.parallel.DistributedDataParallel)
+        )
+
+        self.assertFalse(isinstance(self.trainer.scaler, ShardedGradScaler))
+        self.assertTrue(isinstance(self.trainer.scaler, torch.cuda.amp.GradScaler))
+
+        self.assertEqual(self.trainer.current_iteration, 0)
+        self.trainer.training_loop()
+        self.assertEqual(self.trainer.current_iteration, 4)
+
+    @skip_if_no_cuda
+    @unittest.skipUnless(FAIRSCALE_AVAILABLE, "Tests for fairscale")
+    def test_sharding(self):
+        self.trainer = MMFTrainerMock(self.config_oss, 100, 2, 0.04)
+
+        self.assertTrue(isinstance(self.trainer.optimizer, OSS))
+
+        self.assertTrue(isinstance(self.trainer.model, ShardedDataParallel))
+
+        self.assertTrue(isinstance(self.trainer.scaler, ShardedGradScaler))
+
+        self.assertEqual(self.trainer.current_iteration, 0)
+        self.trainer.training_loop()
+        self.assertEqual(self.trainer.current_iteration, 4)

--- a/tests/trainers/test_sharded_ddp.py
+++ b/tests/trainers/test_sharded_ddp.py
@@ -77,7 +77,7 @@ class TestShardedDDP(unittest.TestCase):
         if torch.distributed.is_initialized():
             torch.distributed.destroy_process_group()
         del self.trainer
-        registry.unregister("config")
+        registry.unregister("distributed")
 
     @skip_if_no_cuda
     @unittest.skipUnless(FAIRSCALE_AVAILABLE, "Tests for fairscale")

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -65,6 +65,7 @@ class TrainerTrainingLoopMock(MMFTrainer):
             self.device = "cuda"
         else:
             self.device = "cpu"
+        self.distributed = False
 
         self.dataset_loader = MagicMock()
         self.dataset_loader.seed_sampler = MagicMock(return_value=None)


### PR DESCRIPTION
Adding ShardedDDP implementation

- Activates ShardedDDP when Optimizer State Sharding(OSS) is enabled.
- Works with both FP16 and FP32
- Requires fairscale to be installed


Test plan:

MMF Transformer VQA accuracy 44k iters (512 batch size): 

FP16 + OSS ShardedDDP + ShadedGradScaler : 65.87, mem: 17573.0 MB

FP16 : 65.56, mem : 19032.0 MB

OSS ShardedDDP: 65.90 , mem : 21073.0 MB
