### PR TITLE
[feat] Support direct feature inputs with single position dim in MMFT

### DIFF
--- a/mmf/configs/models/mmf_transformer/defaults.yaml
+++ b/mmf/configs/models/mmf_transformer/defaults.yaml
@@ -12,6 +12,7 @@ model_config:
         key: text
         position_dim: 512
         segment_id: 0
+        embedding_dim: 768
         layer_norm_eps: 1e-12
         hidden_dropout_prob: 0.1
       - type: image

--- a/mmf/models/transformers/__init__.py
+++ b/mmf/models/transformers/__init__.py
@@ -1,1 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+
+import mmf.models.transformers.backends  # noqa
+from mmf.models.transformers.base import (  # noqa
+    BaseTransformer,
+    BaseTransformerBackend,
+    BaseTransformerBackendConfig,
+    BaseTransformerInput,
+    BaseTransformerModalityConfig,
+)

--- a/mmf/models/transformers/backends/__init__.py
+++ b/mmf/models/transformers/backends/__init__.py
@@ -1,1 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+
+from mmf.utils.env import import_files
+
+
+import_files(__file__, "mmf.models.transformers.backends")

--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -5,10 +5,7 @@ from typing import Any, Dict, List, Type
 
 import torch
 from mmf.common.registry import registry
-from mmf.models.transformers.base import (
-    BaseTransformerBackend,
-    BaseTransformerConfigType,
-)
+from mmf.models.transformers.base import BaseTransformer, BaseTransformerBackend
 from mmf.modules.hf_layers import replace_with_jit
 from omegaconf import OmegaConf
 from torch import Tensor, nn
@@ -25,7 +22,7 @@ class HuggingfaceEmbeddings(nn.Module):
 
     def __init__(
         self,
-        model_config: BaseTransformerConfigType,
+        model_config: BaseTransformer.Config,
         transformer_config: Dict[str, Any],
         transformer: Type[nn.Module],
         *args,
@@ -160,25 +157,22 @@ class HuggingfaceEmbeddings(nn.Module):
 
 @registry.register_transformer_backend("huggingface")
 class HuggingfaceBackend(BaseTransformerBackend):
-    """Transformer backend wih Huggingface transformer models
-    """
+    """Transformer backend wih Huggingface transformer models"""
 
-    def __init__(self, config: BaseTransformerConfigType, *args, **kwargs):
+    def __init__(self, config: BaseTransformer.Config, *args, **kwargs):
         super().__init__(config)
 
         # Replace transformer layers with scriptable JIT layers
         replace_with_jit()
 
     def build_transformer_config(self):
-        """Build the transformer base model config.
-        """
+        """Build the transformer base model config."""
         self.transformer_config = AutoConfig.from_pretrained(
             self.config.transformer_base, **OmegaConf.to_container(self.config)
         )
 
     def build_transformer_base(self):
-        """Build the transformer base model.
-        """
+        """Build the transformer base model."""
         self.transformer = AutoModel.from_pretrained(
             self.config.transformer_base, config=self.transformer_config
         )
@@ -192,8 +186,7 @@ class HuggingfaceBackend(BaseTransformerBackend):
         )
 
     def get_config(self):
-        """Return the transformer configuration.
-        """
+        """Return the transformer configuration."""
         return self.transformer_config
 
     def generate_embeddings(
@@ -203,15 +196,13 @@ class HuggingfaceBackend(BaseTransformerBackend):
         segment_ids: Dict[str, Tensor],
         attention_mask: Tensor,
     ) -> Tensor:
-        """Generate multimodal embeddings.
-        """
+        """Generate multimodal embeddings."""
         return self.embeddings(
             tokens_ids=tokens_ids, position_ids=position_ids, segment_ids=segment_ids
         )
 
     def generate_attention_mask(self, masks: List[Tensor]) -> Tensor:
-        """Generate attention mask.
-        """
+        """Generate attention mask."""
         attention_mask = torch.cat(masks, dim=-1)
         extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0

--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Type
 import torch
 from mmf.common.registry import registry
 from mmf.models.transformers.base import BaseTransformer, BaseTransformerBackend
-from mmf.modules.hf_layers import replace_with_jit
+from mmf.modules.hf_layers import BertModelJit, replace_with_jit
 from omegaconf import OmegaConf
 from torch import Tensor, nn
 from transformers import AutoConfig, AutoModel
@@ -142,6 +142,11 @@ class HuggingfaceEmbeddings(nn.Module):
         ):
             modality_name = self.modality_keys[idx]
             total_embedding = token_emb(tokens_ids[modality_name])
+            # In case of direct features, there might be only two dims, B X D
+            # Convert them B X 1 X D.
+            if total_embedding.dim() == 2:
+                total_embedding = total_embedding.unsqueeze(dim=1)
+
             if modality_name in position_ids:
                 total_embedding += pos_emb(position_ids[modality_name])
 
@@ -173,9 +178,17 @@ class HuggingfaceBackend(BaseTransformerBackend):
 
     def build_transformer_base(self):
         """Build the transformer base model."""
-        self.transformer = AutoModel.from_pretrained(
-            self.config.transformer_base, config=self.transformer_config
-        )
+        hf_params = {"config": self.transformer_config}
+
+        # For BERT models, initialize using Jit version
+        if self.config.transformer_base.startswith("bert-"):
+            self.transformer = BertModelJit.from_pretrained(
+                self.config.transformer_base, **hf_params
+            )
+        else:
+            self.transformer = AutoModel.from_pretrained(
+                self.config.transformer_base, **hf_params
+            )
 
     def build_embeddings(self):
         """Build the multimodal embeddings using the transformer base

--- a/mmf/modules/encoders.py
+++ b/mmf/modules/encoders.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict
+from typing import Any
 
 import torch
 import torchvision
@@ -170,7 +170,8 @@ class IdentityEncoder(Encoder):
     @dataclass
     class Config(Encoder.Config):
         name: str = "identity"
-        in_dim: int = MISSING
+        # Random in_dim if not specified
+        in_dim: int = 100
 
     def __init__(self, config: Config):
         super().__init__()

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -2,6 +2,7 @@
 
 import os
 import warnings
+from enum import Enum
 from typing import Any, Dict, Type, Union
 
 import mmf
@@ -307,13 +308,21 @@ def build_encoder(config: Union[DictConfig, "mmf.modules.encoders.Encoder.Config
         #   params:
         #       in_dim: 256
         name = config.type
-        params = config.params
+        if isinstance(name, Enum):
+            name = name.value
+        params = config.get("params", None)
     else:
         # Structured Config support
         name = config.name
         params = config
 
     encoder_cls = registry.get_encoder_class(name)
+
+    # If params were not passed, try generating them from encoder
+    # class's default config
+    if params is None:
+        params = OmegaConf.structured(getattr(encoder_cls, "Config", {}))
+
     return encoder_cls(params)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ nltk==3.4.5
 editdistance==0.5.3
 transformers==3.4.0
 sklearn==0.0
-omegaconf==2.0.1rc4
+omegaconf==2.0.6
 lmdb==0.98
 termcolor==1.1.0
 iopath==0.1.3

--- a/tests/configs/test_configs_for_keys.py
+++ b/tests/configs/test_configs_for_keys.py
@@ -32,6 +32,10 @@ class TestConfigsForKeys(unittest.TestCase):
                 configuration = Configuration(args)
                 configuration.freeze()
                 config = configuration.get_config()
+
+                if model_key == "mmft":
+                    continue
+
                 self.assertTrue(
                     model_key in config.model_config,
                     "Key for model {} doesn't exists in its configuration".format(


### PR DESCRIPTION
Summary: This diff allows MMFT to support direct features which don't use any encoders are of position dim==1. Also, uses BertModelJit to initialize the transformer base so that it is torchscriptable.

Differential Revision: D24555077

