### PR TITLE
[feat] Changes to support bento notebook tutorial

### DIFF
--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -4,11 +4,13 @@ MultiDatasetLoader class is used by DatasetLoader class to load multiple dataset
 and more granular
 """
 import logging
+import warnings
 
 import numpy as np
 from mmf.utils.build import build_dataloader_and_sampler, build_dataset
 from mmf.utils.distributed import broadcast_scalar, is_dist_initialized, is_master
 from mmf.utils.general import get_batch_size, get_current_device
+from omegaconf import OmegaConf
 
 
 logger = logging.getLogger(__name__)
@@ -121,9 +123,11 @@ class MultiDatasetLoader:
             if dataset in self.config.dataset_config:
                 dataset_config = self.config.dataset_config[dataset]
             else:
-                raise RuntimeError(
-                    f"Dataset {dataset} is missing from " "dataset_config in config."
+                warnings.warn(
+                    f"Dataset {dataset} is missing from dataset_config"
+                    + " in config. Proceeding with empty config."
                 )
+                dataset_config = OmegaConf.create()
 
             dataset_instance = build_dataset(dataset, dataset_config, self.dataset_type)
             if dataset_instance is None:

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -145,7 +145,7 @@ class Processor:
         processor_class = registry.get_processor_class(config.type)
 
         params = {}
-        if not hasattr(config, "params"):
+        if "params" not in config:
             logger.warning(
                 "Config doesn't have 'params' attribute to "
                 "specify parameters of the processor "

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -45,14 +45,15 @@ import logging
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Union
+from typing import List, Optional, Union
 
 from mmf.common.registry import registry
 from mmf.common.sample import to_device
-from mmf.modules.losses import Losses
+from mmf.modules.losses import LossConfig, Losses
 from mmf.utils.checkpoint import load_pretrained_model
 from mmf.utils.download import download_pretrained_model
 from mmf.utils.file_io import PathManager
+from mmf.utils.general import get_current_device
 from omegaconf import MISSING, DictConfig, OmegaConf
 from torch import nn
 
@@ -75,6 +76,7 @@ class BaseModel(nn.Module):
     class Config:
         # Name of the model that is used in registry
         model: str = MISSING
+        losses: Optional[List[LossConfig]] = MISSING
 
     def __init__(self, config: Union[DictConfig, Config]):
         super().__init__()
@@ -165,8 +167,7 @@ class BaseModel(nn.Module):
 
     def __call__(self, sample_list, *args, **kwargs):
         # Move to proper device i.e. same as the model before passing
-        model_device = next(self.parameters()).device
-        sample_list = to_device(sample_list, model_device)
+        sample_list = to_device(sample_list, get_current_device())
 
         model_output = super().__call__(sample_list, *args, **kwargs)
 

--- a/mmf/models/interfaces/mmbt.py
+++ b/mmf/models/interfaces/mmbt.py
@@ -12,6 +12,7 @@ from mmf.common.sample import Sample, SampleList
 from mmf.models.base_model import BaseModel
 from mmf.utils.build import build_processors
 from mmf.utils.download import download
+from mmf.utils.general import get_current_device
 from PIL import Image
 from torch import nn
 
@@ -23,8 +24,7 @@ BaseModelType = Type[BaseModel]
 
 
 class MMBTGridHMInterface(nn.Module):
-    """Interface for MMBT Grid for Hateful Memes.
-    """
+    """Interface for MMBT Grid for Hateful Memes."""
 
     def __init__(self, model: BaseModelType, config: mmf_typings.DictConfig):
         super().__init__()
@@ -76,8 +76,7 @@ class MMBTGridHMInterface(nn.Module):
 
         sample.image = image
         sample_list = SampleList([sample])
-        device = next(self.model.parameters()).device
-        sample_list = sample_list.to(device)
+        sample_list = sample_list.to(get_current_device())
 
         output = self.model(sample_list)
         scores = nn.functional.softmax(output["scores"], dim=1)

--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -27,14 +27,22 @@ in the following way:
 """
 import collections
 import warnings
-from typing import Dict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmf.common.registry import registry
+from omegaconf import MISSING
 from torch import Tensor
 from torch.nn.utils.rnn import pack_padded_sequence
+
+
+@dataclass
+class LossConfig:
+    type: str = MISSING
+    params: Dict[str, Any] = MISSING
 
 
 class Losses(nn.Module):
@@ -66,7 +74,9 @@ class Losses(nn.Module):
                                    passed in config
     """
 
-    def __init__(self, loss_list):
+    # TODO: Union types are not supported in OmegaConf.
+    # Later investigate for a workaround.for
+    def __init__(self, loss_list: List[Union[str, LossConfig]]):
         super().__init__()
         self.losses = nn.ModuleList()
         config = registry.get("config")
@@ -322,8 +332,7 @@ class CaptionCrossEntropyLoss(nn.Module):
 
 @registry.register_loss("nll_loss")
 class NLLLoss(nn.Module):
-    """Negative log likelikehood loss.
-    """
+    """Negative log likelikehood loss."""
 
     def __init__(self):
         super().__init__()

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import logging
+import warnings
 
 import omegaconf
 import torch
@@ -20,6 +21,7 @@ from mmf.trainers.core.reporting import TrainerReportingMixin
 from mmf.trainers.core.training_loop import TrainerTrainingLoopMixin
 from mmf.utils.build import build_model, build_optimizer
 from mmf.utils.general import print_model_parameters
+from omegaconf import OmegaConf
 
 
 logger = logging.getLogger(__name__)
@@ -80,7 +82,14 @@ class MMFTrainer(
 
     def load_model(self):
         logger.info("Loading model")
-        attributes = self.config.model_config[self.config.model]
+        if self.config.model in self.config.model_config:
+            attributes = self.config.model_config[self.config.model]
+        else:
+            warnings.warn(
+                f"Model {self.config.model}'s config not present. "
+                + "Continuing with empty config"
+            )
+            attributes = OmegaConf.create()
         # Easy way to point to config for other model
         if isinstance(attributes, str):
             attributes = self.config.model_config[attributes]

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -111,9 +111,21 @@ def build_dataset(
 
     # If config is not provided, we take it from default one
     if not config:
-        config = load_yaml_with_defaults(dataset_builder.config_path())
-        config = OmegaConf.select(config, f"dataset_config.{dataset_key}")
-        OmegaConf.set_struct(config, True)
+        config_path = dataset_builder.config_path()
+        if config_path is None:
+            # If config path wasn't defined, send an empty config path
+            # but don't force dataset to define a config
+            warnings.warn(
+                f"Config path not defined for {dataset_key}, "
+                + "continuing with empty config"
+            )
+            config = OmegaConf.create()
+        else:
+            config = load_yaml_with_defaults(config_path)
+            config = OmegaConf.select(config, f"dataset_config.{dataset_key}")
+            if config is None:
+                config = OmegaConf.create()
+            OmegaConf.set_struct(config, True)
 
     builder_instance: mmf_typings.DatasetBuilderType = dataset_builder()
     builder_instance.build_dataset(config, dataset_type)

--- a/mmf/utils/configuration.py
+++ b/mmf/utils/configuration.py
@@ -335,8 +335,8 @@ class Configuration:
 
             if default_dataset_config_path is None:
                 warning = (
-                    "Dataset {}'s builder class has no default configuration "
-                    + f"provided"
+                    f"Dataset {dataset}'s builder class has no default configuration "
+                    + "provided"
                 )
                 warnings.warn(warning)
                 continue

--- a/tests/models/interfaces/test_interfaces.py
+++ b/tests/models/interfaces/test_interfaces.py
@@ -12,6 +12,7 @@ import torch
 from mmf.models.mmbt import MMBT
 from mmf.utils.configuration import get_mmf_env, load_yaml
 from mmf.utils.file_io import PathManager
+from mmf.utils.general import get_current_device
 
 
 class TestModelInterfaces(unittest.TestCase):
@@ -38,6 +39,7 @@ class TestModelInterfaces(unittest.TestCase):
             self._test_model_performance(model)
 
     def _test_model_performance(self, model):
+        model = model.to(get_current_device())
         result = model.classify(
             "https://i.imgur.com/tEcsk5q.jpg", "look how many people love you"
         )

--- a/tests/models/test_cnn_lstm.py
+++ b/tests/models/test_cnn_lstm.py
@@ -8,7 +8,7 @@ from mmf.common.registry import registry
 from mmf.common.sample import Sample, SampleList
 from mmf.models.cnn_lstm import CNNLSTM
 from mmf.utils.configuration import Configuration
-from mmf.utils.general import get_mmf_root
+from mmf.utils.general import get_current_device, get_mmf_root
 from tests.test_utils import dummy_args
 
 
@@ -52,6 +52,10 @@ class TestModelCNNLSTM(unittest.TestCase):
         test_sample_list = SampleList([test_sample])
         test_sample_list.dataset_type = "train"
         test_sample_list.dataset_name = "clevr"
+
+        test_sample_list = test_sample_list.to(get_current_device())
+        cnn_lstm = cnn_lstm.to(get_current_device())
+
         output = cnn_lstm(test_sample_list)
 
         scores = output["scores"]

--- a/tests/models/test_visual_bert.py
+++ b/tests/models/test_visual_bert.py
@@ -9,6 +9,7 @@ from mmf.modules.hf_layers import replace_with_jit
 from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports
+from mmf.utils.general import get_current_device
 
 
 BERT_VOCAB_SIZE = 30255
@@ -69,6 +70,8 @@ class TestVisualBertPretraining(unittest.TestCase):
         )
 
         self.pretrain_model.eval()
+        self.pretrain_model = self.pretrain_model.to(get_current_device())
+        sample_list = sample_list.to(get_current_device())
 
         sample_list.dataset_name = "random"
         sample_list.dataset_type = "test"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ import unittest
 
 import torch
 from mmf.common.sample import Sample, SampleList
+from mmf.utils.general import get_current_device
 
 
 def compare_tensors(a, b):
@@ -150,6 +151,9 @@ def compare_torchscript_transformer_models(model, vocab_size):
     test_sample.image_feature_0 = torch.rand((1, 100, 2048)).float()
     test_sample.image = torch.rand((3, 300, 300)).float()
     test_sample_list = SampleList([test_sample])
+
+    model = model.to(get_current_device())
+    test_sample_list = test_sample_list.to(get_current_device())
 
     with torch.no_grad():
         model_output = model(test_sample_list)


### PR DESCRIPTION
Summary:
This diff aims to fix various things in MMF to provide an optimal bento notebook experience.

- Fix some hasattr checks to "in" checks
- Allow empty config_path for datasets and models
- Also, allow missing model key or dataset key in yaml configs
- Adds dataclass for LossConfig so as Losses can be initialized in the model through structured configs
- Fix the usage of next(model.parameters()) to get the device. This doesn't work with dataparallel
- Also, using arbitrary keys with text and image modality type. MMFT will now expect to find these in SampleList.
- Allow passing `input_mask` as `modality_mask` for text type

Differential Revision: D26170013

