### PR TITLE
[feat] add visualization API and notebook

### DIFF
--- a/mmf/utils/download.py
+++ b/mmf/utils/download.py
@@ -12,17 +12,20 @@ These can be replaced if your particular file system does not support them.
 import collections
 import datetime
 import hashlib
+import io
 import json
 import os
 import shutil
 import time
 from pathlib import Path
 
+import numpy as np
 import requests
 import tqdm
 from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
 from mmf.utils.general import get_absolute_path
+from PIL import Image
 
 
 class DownloadableFile:
@@ -491,3 +494,9 @@ def download_from_google_drive(gd_id, destination, redownload=True):
         response.close()
 
     return download
+
+
+def get_image_from_url(url):
+    response = requests.get(url)
+    img = np.array(Image.open(io.BytesIO(response.content)))
+    return img

--- a/mmf/utils/features/__init__.py
+++ b/mmf/utils/features/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/mmf/utils/features/visualizing_image.py
+++ b/mmf/utils/features/visualizing_image.py
@@ -1,0 +1,546 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+ coding=utf-8
+ Copyright 2018, Antonio Mendoza Hao Tan, Mohit Bansal
+ Adapted From Facebook Inc, Detectron2
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.import copy
+ """
+import colorsys
+import io
+import os
+from typing import Union
+
+import matplotlib as mpl
+import matplotlib.colors as mplc
+import matplotlib.figure as mplfigure
+import numpy as np
+import requests
+import torch
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from mmf.utils.download import get_image_from_url
+from PIL import Image
+
+
+_SMALL_OBJ = 1000
+
+
+def get_data(query: str, delim: str = ","):
+    assert isinstance(query, str)
+    if os.path.isfile(query):
+        with open(query) as f:
+            data = eval(f.read())
+    else:
+        req = requests.get(query)
+        try:
+            data = requests.json()
+        except Exception:
+            data = req.content.decode()
+            assert data is not None, "could not connect"
+            try:
+                data = eval(data)
+            except Exception:
+                data = data.split("\n")
+        req.close()
+    return data
+
+
+def img_tensorize(im: str):
+    assert isinstance(im, str)
+    if os.path.isfile(im):
+        img = np.array(Image.open(im))
+    else:
+        img = get_image_from_url(im)
+        assert img is not None, f"could not connect to: {im}"
+    return img
+
+
+class SingleImageViz:
+    def __init__(
+        self,
+        img: Union[str, np.ndarray],
+        scale: float = 1.2,
+        edgecolor: str = "g",
+        alpha: float = 0.5,
+        linestyle: str = "-",
+        saveas: str = "test_out.jpg",
+        rgb: bool = True,
+        pynb: bool = False,
+        id2obj: list = None,
+        id2attr: list = None,
+        pad: float = 0.7,
+    ):
+        """
+        img: an RGB image of shape (H, W, 3).
+        """
+        if isinstance(img, torch.Tensor):
+            img = img.numpy().astype("np.uint8")
+        if isinstance(img, str):
+            img = img_tensorize(img)
+        assert isinstance(img, np.ndarray)
+
+        width, height = img.shape[1], img.shape[0]
+        fig = mplfigure.Figure(frameon=False)
+        dpi = fig.get_dpi()
+        width_in = (width * scale + 1e-2) / dpi
+        height_in = (height * scale + 1e-2) / dpi
+        fig.set_size_inches(width_in, height_in)
+        ax = fig.add_axes([0.0, 0.0, 1.0, 1.0])
+        ax.axis("off")
+        ax.set_xlim(0.0, width)
+        ax.set_ylim(height)
+
+        np.random.seed(42)  # generate same random
+
+        self.saveas = saveas
+        self.rgb = rgb
+        self.pynb = pynb
+        self.img = img
+        self.edgecolor = edgecolor
+        self.alpha = 0.5
+        self.linestyle = linestyle
+        self.font_size = int(np.sqrt(min(height, width)) * scale // 3)
+        self.width = width
+        self.height = height
+        self.scale = scale
+        self.fig = fig
+        self.ax = ax
+        self.pad = pad
+        self.id2obj = id2obj
+        self.id2attr = id2attr
+        self.canvas = FigureCanvasAgg(fig)
+
+    def add_box(self, box: np.ndarray, color: np.ndarray = None):
+        if color is None:
+            color = self.edgecolor
+        (x0, y0, x1, y1) = box
+        width = x1 - x0
+        height = y1 - y0
+        self.ax.add_patch(
+            mpl.patches.Rectangle(
+                (x0, y0),
+                width,
+                height,
+                fill=False,
+                edgecolor=color,
+                linewidth=self.font_size // 3,
+                alpha=self.alpha,
+                linestyle=self.linestyle,
+            )
+        )
+
+    def draw_boxes(
+        self,
+        boxes: torch.Tensor,
+        obj_ids: torch.Tensor = None,
+        obj_scores: torch.Tensor = None,
+        attr_ids: torch.Tensor = None,
+        attr_scores: torch.Tensor = None,
+    ):
+        if len(boxes.shape) > 2:
+            boxes = boxes[0]
+        if len(obj_ids.shape) > 1:
+            obj_ids = obj_ids[0]
+        if len(obj_scores.shape) > 1:
+            obj_scores = obj_scores[0]
+        if len(attr_ids.shape) > 1:
+            attr_ids = attr_ids[0]
+        if len(attr_scores.shape) > 1:
+            attr_scores = attr_scores[0]
+        if isinstance(boxes, torch.Tensor):
+            boxes = boxes.numpy()
+        if isinstance(boxes, list):
+            boxes = np.array(boxes)
+        assert isinstance(boxes, np.ndarray)
+        areas = np.prod(boxes[:, 2:] - boxes[:, :2], axis=1)
+        sorted_idxs = np.argsort(-areas).tolist()
+        boxes = boxes[sorted_idxs] if boxes is not None else None
+        obj_ids = obj_ids[sorted_idxs] if obj_ids is not None else None
+        obj_scores = obj_scores[sorted_idxs] if obj_scores is not None else None
+        attr_ids = attr_ids[sorted_idxs] if attr_ids is not None else None
+        attr_scores = attr_scores[sorted_idxs] if attr_scores is not None else None
+
+        assigned_colors = [self._random_color(maximum=1) for _ in range(len(boxes))]
+        assigned_colors = [assigned_colors[idx] for idx in sorted_idxs]
+        if obj_ids is not None:
+            labels = self._create_text_labels_attr(
+                obj_ids, obj_scores, attr_ids, attr_scores
+            )
+            for i in range(len(boxes)):
+                color = assigned_colors[i]
+                self.add_box(boxes[i], color)
+                self.draw_labels(labels[i], boxes[i], color)
+
+    def draw_labels(self, label: str, box: np.ndarray, color: np.ndarray):
+        x0, y0, x1, y1 = box
+        text_pos = (x0, y0)
+        instance_area = (y1 - y0) * (x1 - x0)
+        small = _SMALL_OBJ * self.scale
+        if instance_area < small or y1 - y0 < 40 * self.scale:
+            if y1 >= self.height - 5:
+                text_pos = (x1, y0)
+            else:
+                text_pos = (x0, y1)
+
+        height_ratio = (y1 - y0) / np.sqrt(self.height * self.width)
+        lighter_color = self._change_color_brightness(color, brightness_factor=0.7)
+        font_size = np.clip((height_ratio - 0.02) / 0.08 + 1, 1.2, 2)
+        font_size *= 0.75 * self.font_size
+
+        self.draw_text(text=label, position=text_pos, color=lighter_color)
+
+    def draw_text(
+        self, text: str, position: tuple, color: tuple = "g", ha: str = "left"
+    ):
+        rotation = 0
+        font_size = self.font_size
+        color = np.maximum(list(mplc.to_rgb(color)), 0.2)
+        color[np.argmax(color)] = max(0.8, np.max(color))
+        bbox = {
+            "facecolor": "black",
+            "alpha": self.alpha,
+            "pad": self.pad,
+            "edgecolor": "none",
+        }
+        x, y = position
+        self.ax.text(
+            x,
+            y,
+            text,
+            size=font_size * self.scale,
+            family="sans-serif",
+            bbox=bbox,
+            verticalalignment="top",
+            horizontalalignment=ha,
+            color=color,
+            zorder=10,
+            rotation=rotation,
+        )
+
+    def save(self, saveas: str = None):
+        if saveas is None:
+            saveas = self.saveas
+        if saveas.lower().endswith(".jpg") or saveas.lower().endswith(".png"):
+            im = Image.open(self._get_buffer()[:, :, ::-1])
+            im.save(saveas)
+        else:
+            self.fig.savefig(saveas)
+
+    def _create_text_labels_attr(
+        self,
+        classes: torch.Tensor,
+        scores: torch.Tensor,
+        attr_classes: torch.Tensor,
+        attr_scores: torch.Tensor,
+    ):
+        labels = [self.id2obj[i] for i in classes]
+        attr_labels = [self.id2attr[i] for i in attr_classes]
+        labels = [
+            f"{label} {score:.2f} {attr} {attr_score:.2f}"
+            for label, score, attr, attr_score in zip(
+                labels, scores, attr_labels, attr_scores
+            )
+        ]
+        return labels
+
+    def _create_text_labels(self, classes: torch.Tensor, scores: torch.Tensor):
+        labels = [self.id2obj[i] for i in classes]
+        if scores is not None:
+            if labels is None:
+                labels = ["{:.0f}%".format(s * 100) for s in scores]
+            else:
+                labels = [
+                    "{} {:.0f}%".format(li, s * 100) for li, s in zip(labels, scores)
+                ]
+        return labels
+
+    def _random_color(self, maximum: int = 255):
+        idx = np.random.randint(0, len(_COLORS))
+        ret = _COLORS[idx] * maximum
+        if not self.rgb:
+            ret = ret[::-1]
+        return ret
+
+    def _get_buffer(self):
+        if not self.pynb:
+            s, (width, height) = self.canvas.print_to_buffer()
+            if (width, height) != (self.width, self.height):
+                img = Image.fromarray(self.img)
+                img = img.resize((width, height), Image.NEAREST)
+            else:
+                img = self.img
+        else:
+            buf = io.BytesIO()  # works for cairo backend
+            self.canvas.print_rgba(buf)
+            width, height = self.width, self.height
+            s = buf.getvalue()
+            img = self.img
+
+        buffer = np.frombuffer(s, dtype="uint8")
+        img_rgba = buffer.reshape(height, width, 4)
+        rgb, alpha = np.split(img_rgba, [3], axis=2)
+
+        try:
+            import numexpr as ne  # fuse them with numexpr
+
+            visualized_image = ne.evaluate(
+                "img * (1 - alpha / 255.0) + rgb * (alpha / 255.0)"
+            )
+        except ImportError:
+            alpha = alpha.astype("float32") / 255.0
+            visualized_image = img * (1 - alpha) + rgb * alpha
+
+        return visualized_image.astype("uint8")
+
+    def _change_color_brightness(self, color: np.ndarray, brightness_factor: float):
+        assert brightness_factor >= -1.0 and brightness_factor <= 1.0
+        color = mplc.to_rgb(color)
+        polygon_color = colorsys.rgb_to_hls(*mplc.to_rgb(color))
+        modified_lightness = polygon_color[1] + (brightness_factor * polygon_color[1])
+        modified_lightness = 0.0 if modified_lightness < 0.0 else modified_lightness
+        modified_lightness = 1.0 if modified_lightness > 1.0 else modified_lightness
+        modified_color = colorsys.hls_to_rgb(
+            polygon_color[0], modified_lightness, polygon_color[2]
+        )
+        return modified_color
+
+
+# Color map
+_COLORS = (
+    np.array(
+        [
+            0.000,
+            0.447,
+            0.741,
+            0.850,
+            0.325,
+            0.098,
+            0.929,
+            0.694,
+            0.125,
+            0.494,
+            0.184,
+            0.556,
+            0.466,
+            0.674,
+            0.188,
+            0.301,
+            0.745,
+            0.933,
+            0.635,
+            0.078,
+            0.184,
+            0.300,
+            0.300,
+            0.300,
+            0.600,
+            0.600,
+            0.600,
+            1.000,
+            0.000,
+            0.000,
+            1.000,
+            0.500,
+            0.000,
+            0.749,
+            0.749,
+            0.000,
+            0.000,
+            1.000,
+            0.000,
+            0.000,
+            0.000,
+            1.000,
+            0.667,
+            0.000,
+            1.000,
+            0.333,
+            0.333,
+            0.000,
+            0.333,
+            0.667,
+            0.000,
+            0.333,
+            1.000,
+            0.000,
+            0.667,
+            0.333,
+            0.000,
+            0.667,
+            0.667,
+            0.000,
+            0.667,
+            1.000,
+            0.000,
+            1.000,
+            0.333,
+            0.000,
+            1.000,
+            0.667,
+            0.000,
+            1.000,
+            1.000,
+            0.000,
+            0.000,
+            0.333,
+            0.500,
+            0.000,
+            0.667,
+            0.500,
+            0.000,
+            1.000,
+            0.500,
+            0.333,
+            0.000,
+            0.500,
+            0.333,
+            0.333,
+            0.500,
+            0.333,
+            0.667,
+            0.500,
+            0.333,
+            1.000,
+            0.500,
+            0.667,
+            0.000,
+            0.500,
+            0.667,
+            0.333,
+            0.500,
+            0.667,
+            0.667,
+            0.500,
+            0.667,
+            1.000,
+            0.500,
+            1.000,
+            0.000,
+            0.500,
+            1.000,
+            0.333,
+            0.500,
+            1.000,
+            0.667,
+            0.500,
+            1.000,
+            1.000,
+            0.500,
+            0.000,
+            0.333,
+            1.000,
+            0.000,
+            0.667,
+            1.000,
+            0.000,
+            1.000,
+            1.000,
+            0.333,
+            0.000,
+            1.000,
+            0.333,
+            0.333,
+            1.000,
+            0.333,
+            0.667,
+            1.000,
+            0.333,
+            1.000,
+            1.000,
+            0.667,
+            0.000,
+            1.000,
+            0.667,
+            0.333,
+            1.000,
+            0.667,
+            0.667,
+            1.000,
+            0.667,
+            1.000,
+            1.000,
+            1.000,
+            0.000,
+            1.000,
+            1.000,
+            0.333,
+            1.000,
+            1.000,
+            0.667,
+            1.000,
+            0.333,
+            0.000,
+            0.000,
+            0.500,
+            0.000,
+            0.000,
+            0.667,
+            0.000,
+            0.000,
+            0.833,
+            0.000,
+            0.000,
+            1.000,
+            0.000,
+            0.000,
+            0.000,
+            0.167,
+            0.000,
+            0.000,
+            0.333,
+            0.000,
+            0.000,
+            0.500,
+            0.000,
+            0.000,
+            0.667,
+            0.000,
+            0.000,
+            0.833,
+            0.000,
+            0.000,
+            1.000,
+            0.000,
+            0.000,
+            0.000,
+            0.167,
+            0.000,
+            0.000,
+            0.333,
+            0.000,
+            0.000,
+            0.500,
+            0.000,
+            0.000,
+            0.667,
+            0.000,
+            0.000,
+            0.833,
+            0.000,
+            0.000,
+            1.000,
+            0.000,
+            0.000,
+            0.000,
+            0.143,
+            0.143,
+            0.143,
+            0.857,
+            0.857,
+            0.857,
+            1.000,
+            1.000,
+            1.000,
+        ]
+    )
+    .astype(np.float32)
+    .reshape(-1, 3)
+)

--- a/mmf/utils/visualize.py
+++ b/mmf/utils/visualize.py
@@ -2,8 +2,11 @@
 
 from typing import Any, List, Optional, Tuple
 
+import numpy as np
 import torch
 import torchvision
+from mmf.utils.features.visualizing_image import SingleImageViz, img_tensorize
+from PIL import Image
 
 
 def visualize_images(
@@ -45,3 +48,29 @@ def visualize_images(
 
     plt.axis("off")
     plt.imshow(grid.permute(1, 2, 0))
+
+
+def visualize_frcnn_features(
+    image_path: str, features_path: str, objids: List[str], attrids: List[str]
+):
+    img = img_tensorize(image_path)
+
+    output_dict = np.load(features_path, allow_pickle=True).item()
+
+    frcnn_visualizer = SingleImageViz(img, id2obj=objids, id2attr=attrids)
+    frcnn_visualizer.draw_boxes(
+        output_dict.get("boxes"),
+        output_dict.pop("obj_ids"),
+        output_dict.pop("obj_probs"),
+        output_dict.pop("attr_ids"),
+        output_dict.pop("attr_probs"),
+    )
+
+    height, width, channels = img.shape
+
+    buffer = frcnn_visualizer._get_buffer()
+    array = np.uint8(np.clip(buffer, 0, 255))
+
+    image = Image.fromarray(array)
+
+    visualize_images([image], (height, width))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 # This is required to make sorting same as fbcode as all absolute imports
 # are considered third party there
 known_third_party = [
-    "PIL", "cv2", "demjson", "fairscale", "filelock", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "mmf",
-    "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
+    "PIL", "cv2", "demjson", "fairscale", "filelock", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "matplotlib",
+    "mmf", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
     "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
     "torchtext", "torchvision", "tqdm", "transformers", "pytorch_lightning"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ termcolor==1.1.0
 iopath==0.1.3
 pytorch_lightning==1.1.6
 datasets==1.2.1
+matplotlib==3.3.4

--- a/tests/utils/test_visualize.py
+++ b/tests/utils/test_visualize.py
@@ -1,0 +1,116 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+
+import numpy as np
+import torch
+from mmf.utils.features.visualizing_image import SingleImageViz
+
+
+class TestVisualize(unittest.TestCase):
+
+    objids = np.array(["obj0", "obj1", "obj2", "obj3"])
+    attrids = np.array(["attr0", "attr1", "attr2", "attr3"])
+    img = np.array(
+        [
+            [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5, 5]],
+            [[6, 6, 6], [7, 7, 7], [8, 8, 8], [9, 9, 9], [10, 10, 10], [11, 11, 11]],
+            [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5, 5]],
+            [[6, 6, 6], [7, 7, 7], [8, 8, 8], [9, 9, 9], [10, 10, 10], [11, 11, 11]],
+            [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5, 5]],
+            [[6, 6, 6], [7, 7, 7], [8, 8, 8], [9, 9, 9], [10, 10, 10], [11, 11, 11]],
+        ],
+        dtype=np.uint8,
+    )
+    output_dict = {
+        "obj_ids": torch.tensor([0, 1]),
+        "obj_probs": torch.tensor([0.5, 0.25]),
+        "attr_ids": torch.tensor([2, 3]),
+        "attr_probs": torch.tensor([0.3, 0.6]),
+        "boxes": torch.tensor([[0, 0, 1, 1], [1, 1, 2, 2]]),
+    }
+
+    buffer = np.array(
+        [
+            [
+                [0, 0, 0],
+                [0, 0, 0],
+                [62, 48, 70],
+                [112, 87, 124],
+                [53, 41, 58],
+                [38, 30, 42],
+                [28, 22, 31],
+            ],
+            [
+                [6, 6, 6],
+                [3, 3, 3],
+                [3, 3, 3],
+                [4, 4, 4],
+                [4, 4, 4],
+                [4, 4, 4],
+                [5, 5, 5],
+            ],
+            [
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [3, 3, 3],
+                [3, 3, 3],
+                [4, 4, 4],
+                [5, 5, 5],
+            ],
+            [
+                [6, 6, 6],
+                [7, 7, 7],
+                [8, 8, 8],
+                [9, 9, 9],
+                [9, 9, 9],
+                [10, 10, 10],
+                [11, 11, 11],
+            ],
+            [
+                [6, 6, 6],
+                [7, 7, 7],
+                [8, 8, 8],
+                [9, 9, 9],
+                [9, 9, 9],
+                [10, 10, 10],
+                [11, 11, 11],
+            ],
+            [
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [3, 3, 3],
+                [3, 3, 3],
+                [4, 4, 4],
+                [5, 5, 5],
+            ],
+            [
+                [6, 6, 6],
+                [7, 7, 7],
+                [8, 8, 8],
+                [9, 9, 9],
+                [9, 9, 9],
+                [10, 10, 10],
+                [11, 11, 11],
+            ],
+        ]
+    )
+
+    def test_single_image_viz(self) -> None:
+
+        frcnn_visualizer = SingleImageViz(
+            self.img, id2obj=self.objids, id2attr=self.attrids
+        )
+        frcnn_visualizer.draw_boxes(
+            self.output_dict.get("boxes"),
+            self.output_dict.pop("obj_ids"),
+            self.output_dict.pop("obj_probs"),
+            self.output_dict.pop("attr_ids"),
+            self.output_dict.pop("attr_probs"),
+        )
+
+        buffer = frcnn_visualizer._get_buffer()
+
+        self.assertTrue((buffer == self.buffer).all())


### PR DESCRIPTION
Add a visualization API for the frcnn
features, which takes in image and feature
paths and uses the huggingface visualization
tools to show the image.

Also added a jupyter notebook that will display
the images accordingly if the features and images
are in the correct place.
