### PR TITLE
[feat] PL mvp1: validation + logging

### DIFF
--- a/artifacts/junit-macos-latest-python3.8.xml
+++ b/artifacts/junit-macos-latest-python3.8.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="0" failures="4" skipped="0" tests="144" time="347.018" timestamp="2021-02-10T11:14:35.440698" hostname="devfair0152"><testcase classname="tests.common.test_batch_collator.TestBatchCollator" name="test_call" time="0.003" /><testcase classname="tests.common.test_sample.TestSample" name="test_sample_working" time="0.001" /><testcase classname="tests.common.test_sample.TestSampleList" name="test_pin_memory" time="1.935" /><testcase classname="tests.common.test_sample.TestSampleList" name="test_to_dict" time="0.001" /><testcase classname="tests.common.test_sample.TestFunctions" name="test_to_device" time="0.002" /><testcase classname="tests.configs.test_configs_for_keys.TestConfigsForKeys" name="test_dataset_configs_for_keys" time="6.069" /><testcase classname="tests.configs.test_configs_for_keys.TestConfigsForKeys" name="test_model_configs_for_keys" time="4.333" /><testcase classname="tests.configs.test_zoo_urls.TestConfigsForKeys" name="test_sha256sums" time="1.628" /><testcase classname="tests.configs.test_zoo_urls.TestConfigsForKeys" name="test_zoos" time="62.754" /><testcase classname="tests.datasets.test_base_dataset.TestBaseDataset" name="test_init_processors" time="0.252" /><testcase classname="tests.datasets.test_mmf_dataset_builder.TestMMFDatasetBuilder" name="test_train_split_alignment" time="0.012" /><testcase classname="tests.datasets.test_mmf_dataset_builder.TestMMFDatasetBuilder" name="test_train_split_len" time="0.006" /><testcase classname="tests.datasets.test_mmf_dataset_builder.TestMMFDatasetBuilder" name="test_train_split_non_overlap" time="0.011" /><testcase classname="tests.datasets.test_multi_dataset_loader.TestMultiDatasetLoader" name="test_equal_sampling" time="0.162" /><testcase classname="tests.datasets.test_multi_dataset_loader.TestMultiDatasetLoader" name="test_proportional_sampling" time="0.188" /><testcase classname="tests.datasets.test_prediction_processors.TestDatasetProcessors" name="test_argmax_prediction_processor" time="0.005" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_caption_processor" time="0.019" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_evalai_answer_processor" time="0.001" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_multi_class_from_file" time="0.002" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_multi_hot_answer_from_vocab_processor" time="0.014" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_transformer_bbox_processor" time="0.001" /><testcase classname="tests.models.test_cnn_lstm.TestModelCNNLSTM" name="test_forward" time="0.273" /><testcase classname="tests.models.test_mmbt.TestMMBTTorchscript" name="test_finetune_model" time="11.038" /><testcase classname="tests.models.test_mmbt.TestMMBTTorchscript" name="test_load_save_finetune_model" time="13.344" /><testcase classname="tests.models.test_mmbt.TestMMBTTorchscript" name="test_modal_end_token" time="6.885" /><testcase classname="tests.models.test_mmbt.TestMMBTConfig" name="test_mmbt_directly_from_config" time="0.007" /><testcase classname="tests.models.test_mmbt.TestMMBTConfig" name="test_mmbt_from_params" time="0.010" /><testcase classname="tests.models.test_mmbt.TestMMBTConfig" name="test_mmbt_pretrained" time="0.028" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_finetune_bert_base" time="10.069" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_finetune_roberta_base" time="14.830" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_finetune_xlmr_base" time="20.031" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_load_save_finetune_model" time="11.555" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmf_from_params_encoder_factory" time="0.003"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmf_from_params_encoder_factory&gt;
+
+    def test_mmf_from_params_encoder_factory(self):
+        modalities_config = [
+            MMFTransformerModalityConfig(
+                type="image",
+                key="image",
+                embedding_dim=256,
+                position_dim=1,
+                segment_id=0,
+                encoder=ImageEncoderFactory.Config(type=ImageEncoderTypes.identity),
+            ),
+            MMFTransformerModalityConfig(
+                type="text",
+                key="text",
+                embedding_dim=756,
+                position_dim=512,
+                segment_id=0,
+                encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+            ),
+        ]
+&gt;       mmft = MMFTransformer.from_params(modalities=modalities_config, num_labels=2)
+
+tests/models/test_mmf_transformer.py:123:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/models/base_model.py:94: in from_params
+    return cls(OmegaConf.structured(cls.Config(**kwargs)))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmft_from_build_model" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmft_from_build_model&gt;
+
+    def test_mmft_from_build_model(self):
+        modalities_config = [
+            MMFTransformerModalityConfig(
+                type="image",
+                key="image",
+                embedding_dim=256,
+                position_dim=1,
+                segment_id=0,
+                encoder=ImageEncoderFactory.Config(
+                    type=ImageEncoderTypes.resnet152,
+                    params=ResNet152ImageEncoder.Config(pretrained=False),
+                ),
+            ),
+            MMFTransformerModalityConfig(
+                type="text",
+                key="text",
+                embedding_dim=756,
+                position_dim=512,
+                segment_id=1,
+                encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+            ),
+        ]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+&gt;       mmft = build_model(config)
+
+tests/models/test_mmf_transformer.py:159:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/utils/build.py:69: in build_model
+    config = OmegaConf.structured(config)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmft_from_params" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmft_from_params&gt;
+
+    def test_mmft_from_params(self):
+        modalities_config = [
+            MMFTransformerModalityConfig(
+                type="image",
+                key="image",
+                embedding_dim=256,
+                position_dim=1,
+                segment_id=0,
+                encoder=IdentityEncoder.Config(),
+            ),
+            MMFTransformerModalityConfig(
+                type="text",
+                key="text",
+                embedding_dim=768,
+                position_dim=512,
+                segment_id=1,
+                encoder=IdentityEncoder.Config(),
+            ),
+        ]
+&gt;       mmft = MMFTransformer.from_params(modalities=modalities_config, num_labels=2)
+
+tests/models/test_mmf_transformer.py:95:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/models/base_model.py:94: in from_params
+    return cls(OmegaConf.structured(cls.Config(**kwargs)))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmft_pretrained" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmft_pretrained&gt;
+
+    def test_mmft_pretrained(self):
+&gt;       mmft = MMFTransformer.from_params(num_labels=2)
+
+tests/models/test_mmf_transformer.py:133:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/models/base_model.py:94: in from_params
+    return cls(OmegaConf.structured(cls.Config(**kwargs)))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_finetune_model" time="9.717" /><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_load_save_finetune_model" time="14.567" /><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_load_save_pretrain_model" time="25.540" /><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_pretrained_model" time="9.157" /><testcase classname="tests.models.test_visual_bert.TestVisualBertTorchscript" name="test_finetune_model" time="4.073" /><testcase classname="tests.models.test_visual_bert.TestVisualBertTorchscript" name="test_load_save_finetune_model" time="7.450" /><testcase classname="tests.models.test_visual_bert.TestVisualBertPretraining" name="test_pretrained_model" time="6.898" /><testcase classname="tests.models.interfaces.test_interfaces.TestModelInterfaces" name="test_mmbt_hm_interface" time="41.397" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_finetune_faster_rcnn_fpn_fc7" time="0.891" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_identity" time="0.023" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_multimodal_encoder_base" time="6.774" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_resnet152_image_encoder" time="1.515" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_text_embedding_encoder" time="0.028" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_transformer_encoder" time="5.169" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_BlockFusion" time="0.020" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_BlockTucker" time="0.015" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_ConcatMLP" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_LinearSum" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MCB" time="0.004" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MFB" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MFH" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MLB" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_Mutan" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_Tucker" time="0.006" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_bert_classifier_head" time="0.007" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_conv_net" time="0.037" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_flatten" time="0.001" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_mlp" time="0.003" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_unflatten" time="0.001" /><testcase classname="tests.modules.test_losses.TestModuleLosses" name="test_caption_cross_entropy" time="0.005" /><testcase classname="tests.modules.test_losses.TestModuleLosses" name="test_mmf_loss" time="0.005" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_binary_ap" time="0.002" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_binary_f1" time="0.002" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_caption_bleu4" time="0.421" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_macro_ap" time="0.006" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_macro_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_macro_roc_auc" time="0.007" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_micro_ap" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_micro_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_micro_roc_auc" time="0.004" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_multilabel_macro_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_multilabel_micro_f1" time="0.005" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_1" time="0.022" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_10" time="0.021" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_5" time="0.021" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_precision_k" time="0.003" /><testcase classname="tests.modules.test_optimizers.TestOptimizers" name="test_build_optimizer_custom_model" time="10.179" /><testcase classname="tests.modules.test_optimizers.TestOptimizers" name="test_build_optimizer_simple_model" time="0.002" /><testcase classname="tests.trainers.test_device.TestDevice" name="test_current_device" time="0.002" /><testcase classname="tests.trainers.test_fp16.TestFp16" name="test_fp16_values" time="0.184" /><testcase classname="tests.trainers.test_fp16.TestFp16" name="test_fp16_works" time="0.166" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_epoch_over_updates" time="0.168" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_fractional_epoch" time="0.167" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_correct_final_iteration" time="0.167" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_num_remaining_updates_greater_than_update_frequency" time="0.637" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_reporting" time="0.160" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_same_model_params" time="0.329" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_updates" time="0.163" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_test_end" time="0.009" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_train_start" time="0.005" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_update_end" time="0.005" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_validation_start" time="0.005" /><testcase classname="tests.trainers.callbacks.test_lr_scheduler.TestLogisticsCallback" name="test_on_update_end" time="0.004" /><testcase classname="tests.trainers.lightning.test_grad_accumulate.TestLightningTrainerGradAccumulate" name="test_grad_accumulate" time="0.488" /><testcase classname="tests.trainers.lightning.test_grad_clipping.TestLightningTrainerGradClipping" name="test_grad_clipping_and_parity_to_mmf" time="0.593" /><testcase classname="tests.trainers.lightning.test_logging.TestLightningTrainerLogging" name="test_tensorboard_logging_parity" time="1.674" /><testcase classname="tests.trainers.lightning.test_loop_conditions.TestLightningTrainer" name="test_epoch_over_updates" time="0.180" /><testcase classname="tests.trainers.lightning.test_loop_conditions.TestLightningTrainer" name="test_fractional_epoch" time="0.180" /><testcase classname="tests.trainers.lightning.test_loop_conditions.TestLightningTrainer" name="test_updates" time="0.178" /><testcase classname="tests.trainers.lightning.test_loss.TestLightningTrainerLoss" name="test_loss_computation_parity_with_mmf_trainer" time="0.497" /><testcase classname="tests.trainers.lightning.test_lr_schedule.TestLightningTrainerLRSchedule" name="test_lr_schedule" time="0.382" /><testcase classname="tests.trainers.lightning.test_lr_schedule.TestLightningTrainerLRSchedule" name="test_lr_schedule_compared_to_mmf_is_same" time="0.585" /><testcase classname="tests.trainers.lightning.test_validation.TestLightningTrainerValidation" name="test_validation" time="0.629" /><testcase classname="tests.trainers.lightning.test_validation.TestLightningTrainerValidation" name="test_validation_parity" time="1.061" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_checkpoint_scaler_loading" time="0.050" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_finalize_and_restore_from_it" time="0.045" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_finalize_and_resume_file" time="0.022" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_max_to_keep" time="0.073" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_pretrained_load" time="0.031" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_resets" time="0.066" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_save_and_load_state_dict" time="0.061" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_save_config" time="0.029" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_zoo_load" time="0.024" /><testcase classname="tests.utils.test_configuration.TestUtilsConfiguration" name="test_config_overrides" time="0.477" /><testcase classname="tests.utils.test_configuration.TestUtilsConfiguration" name="test_get_zoo_config" time="5.685" /><testcase classname="tests.utils.test_distributed.TestUtilsDistributed" name="test_object_byte_tensor_conversion" time="0.001" /><testcase classname="tests.utils.test_download.TestUtilsDownload" name="test_built" time="0.001" /><testcase classname="tests.utils.test_download.TestUtilsDownload" name="test_download_file_class" time="9.260" /><testcase classname="tests.utils.test_download.TestUtilsDownload" name="test_mark_done" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_copy" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_exists" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_mkdirs" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_open" time="0.001" /><testcase classname="tests.utils.test_general.TestUtilsGeneral" name="test_dict_to_string" time="0.001" /><testcase classname="tests.utils.test_general.TestUtilsGeneral" name="test_get_overlap_score" time="0.001" /><testcase classname="tests.utils.test_logger.TestLogger" name="test_log_writer" time="0.179" /><testcase classname="tests.utils.test_logger.TestLogger" name="test_logger_files" time="0.001" /><testcase classname="tests.utils.test_quality_checks.TestQualityChecks" name="test_init_files_present" time="0.040" /><testcase classname="tests.utils.test_quality_checks.TestQualityChecks" name="test_no_empty_folders" time="0.039" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_generate_ngrams" time="0.276" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_generate_ngrams_range" time="0.273" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_nucleus_sampling" time="0.286" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_tokenize" time="0.269" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_vocab_from_text" time="0.417" /><testcase classname="tests.utils.test_text.TestUtilsTextBeamSearch" name="test_beam_search" time="0.503" /><testcase classname="tests.utils.test_timer.TestUtilsTimer" name="test_get_current" time="0.001" /><testcase classname="tests.utils.test_timer.TestUtilsTimer" name="test_get_time_since_start" time="2.003" /><testcase classname="tests.utils.test_timer.TestUtilsTimer" name="test_reset" time="2.003" /></testsuite></testsuites>

--- a/artifacts/junit-ubuntu-latest-python3.6.xml
+++ b/artifacts/junit-ubuntu-latest-python3.6.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="0" failures="4" skipped="0" tests="144" time="337.913" timestamp="2021-02-10T02:06:09.084974" hostname="devfair0152"><testcase classname="tests.common.test_batch_collator.TestBatchCollator" name="test_call" time="0.003" /><testcase classname="tests.common.test_sample.TestSample" name="test_sample_working" time="0.001" /><testcase classname="tests.common.test_sample.TestSampleList" name="test_pin_memory" time="1.880" /><testcase classname="tests.common.test_sample.TestSampleList" name="test_to_dict" time="0.002" /><testcase classname="tests.common.test_sample.TestFunctions" name="test_to_device" time="0.003" /><testcase classname="tests.configs.test_configs_for_keys.TestConfigsForKeys" name="test_dataset_configs_for_keys" time="6.182" /><testcase classname="tests.configs.test_configs_for_keys.TestConfigsForKeys" name="test_model_configs_for_keys" time="4.334" /><testcase classname="tests.configs.test_zoo_urls.TestConfigsForKeys" name="test_sha256sums" time="1.670" /><testcase classname="tests.configs.test_zoo_urls.TestConfigsForKeys" name="test_zoos" time="54.115" /><testcase classname="tests.datasets.test_base_dataset.TestBaseDataset" name="test_init_processors" time="0.248" /><testcase classname="tests.datasets.test_mmf_dataset_builder.TestMMFDatasetBuilder" name="test_train_split_alignment" time="0.012" /><testcase classname="tests.datasets.test_mmf_dataset_builder.TestMMFDatasetBuilder" name="test_train_split_len" time="0.006" /><testcase classname="tests.datasets.test_mmf_dataset_builder.TestMMFDatasetBuilder" name="test_train_split_non_overlap" time="0.011" /><testcase classname="tests.datasets.test_multi_dataset_loader.TestMultiDatasetLoader" name="test_equal_sampling" time="0.154" /><testcase classname="tests.datasets.test_multi_dataset_loader.TestMultiDatasetLoader" name="test_proportional_sampling" time="0.189" /><testcase classname="tests.datasets.test_prediction_processors.TestDatasetProcessors" name="test_argmax_prediction_processor" time="0.001" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_caption_processor" time="0.018" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_evalai_answer_processor" time="0.001" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_multi_class_from_file" time="0.001" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_multi_hot_answer_from_vocab_processor" time="0.014" /><testcase classname="tests.datasets.test_processors.TestDatasetProcessors" name="test_transformer_bbox_processor" time="0.001" /><testcase classname="tests.models.test_cnn_lstm.TestModelCNNLSTM" name="test_forward" time="0.272" /><testcase classname="tests.models.test_mmbt.TestMMBTTorchscript" name="test_finetune_model" time="11.382" /><testcase classname="tests.models.test_mmbt.TestMMBTTorchscript" name="test_load_save_finetune_model" time="12.813" /><testcase classname="tests.models.test_mmbt.TestMMBTTorchscript" name="test_modal_end_token" time="6.974" /><testcase classname="tests.models.test_mmbt.TestMMBTConfig" name="test_mmbt_directly_from_config" time="0.007" /><testcase classname="tests.models.test_mmbt.TestMMBTConfig" name="test_mmbt_from_params" time="0.010" /><testcase classname="tests.models.test_mmbt.TestMMBTConfig" name="test_mmbt_pretrained" time="0.028" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_finetune_bert_base" time="9.890" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_finetune_roberta_base" time="14.538" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_finetune_xlmr_base" time="19.453" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerTorchscript" name="test_load_save_finetune_model" time="11.784" /><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmf_from_params_encoder_factory" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmf_from_params_encoder_factory&gt;
+
+    def test_mmf_from_params_encoder_factory(self):
+        modalities_config = [
+            MMFTransformerModalityConfig(
+                type="image",
+                key="image",
+                embedding_dim=256,
+                position_dim=1,
+                segment_id=0,
+                encoder=ImageEncoderFactory.Config(type=ImageEncoderTypes.identity),
+            ),
+            MMFTransformerModalityConfig(
+                type="text",
+                key="text",
+                embedding_dim=756,
+                position_dim=512,
+                segment_id=0,
+                encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+            ),
+        ]
+&gt;       mmft = MMFTransformer.from_params(modalities=modalities_config, num_labels=2)
+
+tests/models/test_mmf_transformer.py:123:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/models/base_model.py:94: in from_params
+    return cls(OmegaConf.structured(cls.Config(**kwargs)))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmft_from_build_model" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmft_from_build_model&gt;
+
+    def test_mmft_from_build_model(self):
+        modalities_config = [
+            MMFTransformerModalityConfig(
+                type="image",
+                key="image",
+                embedding_dim=256,
+                position_dim=1,
+                segment_id=0,
+                encoder=ImageEncoderFactory.Config(
+                    type=ImageEncoderTypes.resnet152,
+                    params=ResNet152ImageEncoder.Config(pretrained=False),
+                ),
+            ),
+            MMFTransformerModalityConfig(
+                type="text",
+                key="text",
+                embedding_dim=756,
+                position_dim=512,
+                segment_id=1,
+                encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+            ),
+        ]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+&gt;       mmft = build_model(config)
+
+tests/models/test_mmf_transformer.py:159:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/utils/build.py:69: in build_model
+    config = OmegaConf.structured(config)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmft_from_params" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmft_from_params&gt;
+
+    def test_mmft_from_params(self):
+        modalities_config = [
+            MMFTransformerModalityConfig(
+                type="image",
+                key="image",
+                embedding_dim=256,
+                position_dim=1,
+                segment_id=0,
+                encoder=IdentityEncoder.Config(),
+            ),
+            MMFTransformerModalityConfig(
+                type="text",
+                key="text",
+                embedding_dim=768,
+                position_dim=512,
+                segment_id=1,
+                encoder=IdentityEncoder.Config(),
+            ),
+        ]
+&gt;       mmft = MMFTransformer.from_params(modalities=modalities_config, num_labels=2)
+
+tests/models/test_mmf_transformer.py:95:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/models/base_model.py:94: in from_params
+    return cls(OmegaConf.structured(cls.Config(**kwargs)))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_mmf_transformer.TestMMFTransformerConfig" name="test_mmft_pretrained" time="0.002"><failure message="omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type&#10;&#09;full_key: modalities[0]&#10;&#09;reference_type=List[BaseTransformerModalityConfig]&#10;&#09;object_type=list">self = &lt;tests.models.test_mmf_transformer.TestMMFTransformerConfig testMethod=test_mmft_pretrained&gt;
+
+    def test_mmft_pretrained(self):
+&gt;       mmft = MMFTransformer.from_params(num_labels=2)
+
+tests/models/test_mmf_transformer.py:133:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+mmf/models/base_model.py:94: in from_params
+    return cls(OmegaConf.structured(cls.Config(**kwargs)))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:133: in structured
+    return OmegaConf.create(obj, parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:170: in create
+    return OmegaConf._create_impl(obj=obj, parent=parent)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:238: in _create_impl
+    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:214: in _create_impl
+    return DictConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:74: in __init__
+    self._set_value(content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/dictconfig.py:549: in _set_value
+    data = get_structured_config_data(value)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:233: in get_structured_config_data
+    return get_dataclass_data(obj)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:176: in get_dataclass_data
+    d[name] = _maybe_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:675: in _maybe_wrap
+    return _node_wrap(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/omegaconf.py:620: in _node_wrap
+    node = ListConfig(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:65: in __init__
+    format_and_raise(node=None, key=None, value=None, cause=ex, msg=str(ex))
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:522: in format_and_raise
+    raise_(ex, cause)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: in raise_
+    raise ex
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:63: in __init__
+    self._set_value(value=content)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:472: in _set_value
+    self.append(item)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/listconfig.py:182: in append
+    self._format_and_raise(key=index, value=item, cause=e)
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/base.py:95: in _format_and_raise
+    format_and_raise(
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:590: in format_and_raise
+    raise_(ex, cause)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+ex = UnsupportedValueType("Value 'Config' is not a supported primitive type\n\tfull_key: modalities[0]\n\treference_type=List[BaseTransformerModalityConfig]\n\tobject_type=list\n")
+cause = UnsupportedValueType("Value 'Config' is not a supported primitive type")
+
+    def raise_(ex: Exception, cause: Exception) -&gt; None:
+        # Set the environment variable OC_CAUSE=1 to get a stacktrace that includes the
+        # causing exception.
+        full_backtrace = "OC_CAUSE" in os.environ and os.environ["OC_CAUSE"] == "1"
+        if full_backtrace:
+            ex.__cause__ = cause
+        else:
+            ex.__cause__ = None
+&gt;       raise ex
+E       omegaconf.errors.UnsupportedValueType: Value 'Config' is not a supported primitive type
+E       	full_key: modalities[0]
+E       	reference_type=List[BaseTransformerModalityConfig]
+E       	object_type=list
+
+../../.conda/envs/mmf_4/lib/python3.8/site-packages/omegaconf/_utils.py:515: UnsupportedValueType</failure></testcase><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_finetune_model" time="9.613" /><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_load_save_finetune_model" time="17.534" /><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_load_save_pretrain_model" time="24.760" /><testcase classname="tests.models.test_vilbert.TestViLBertTorchscript" name="test_pretrained_model" time="9.146" /><testcase classname="tests.models.test_visual_bert.TestVisualBertTorchscript" name="test_finetune_model" time="4.006" /><testcase classname="tests.models.test_visual_bert.TestVisualBertTorchscript" name="test_load_save_finetune_model" time="7.488" /><testcase classname="tests.models.test_visual_bert.TestVisualBertPretraining" name="test_pretrained_model" time="6.798" /><testcase classname="tests.models.interfaces.test_interfaces.TestModelInterfaces" name="test_mmbt_hm_interface" time="39.070" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_finetune_faster_rcnn_fpn_fc7" time="0.646" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_identity" time="0.023" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_multimodal_encoder_base" time="6.504" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_resnet152_image_encoder" time="1.559" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_text_embedding_encoder" time="0.027" /><testcase classname="tests.modules.test_encoders.TestEncoders" name="test_transformer_encoder" time="4.921" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_BlockFusion" time="0.019" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_BlockTucker" time="0.017" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_ConcatMLP" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_LinearSum" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MCB" time="0.005" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MFB" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MFH" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_MLB" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_Mutan" time="0.002" /><testcase classname="tests.modules.test_fusions.TestModuleFusions" name="test_Tucker" time="0.008" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_bert_classifier_head" time="0.007" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_conv_net" time="0.036" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_flatten" time="0.001" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_mlp" time="0.003" /><testcase classname="tests.modules.test_layers.TestModuleLayers" name="test_unflatten" time="0.001" /><testcase classname="tests.modules.test_losses.TestModuleLosses" name="test_caption_cross_entropy" time="0.006" /><testcase classname="tests.modules.test_losses.TestModuleLosses" name="test_mmf_loss" time="0.004" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_binary_ap" time="0.002" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_binary_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_caption_bleu4" time="0.443" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_macro_ap" time="0.006" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_macro_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_macro_roc_auc" time="0.007" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_micro_ap" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_micro_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_micro_roc_auc" time="0.004" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_multilabel_macro_f1" time="0.003" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_multilabel_micro_f1" time="0.005" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_1" time="0.022" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_10" time="0.021" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_5" time="0.022" /><testcase classname="tests.modules.test_metrics.TestModuleMetrics" name="test_recall_at_precision_k" time="0.003" /><testcase classname="tests.modules.test_optimizers.TestOptimizers" name="test_build_optimizer_custom_model" time="10.024" /><testcase classname="tests.modules.test_optimizers.TestOptimizers" name="test_build_optimizer_simple_model" time="0.002" /><testcase classname="tests.trainers.test_device.TestDevice" name="test_current_device" time="0.002" /><testcase classname="tests.trainers.test_fp16.TestFp16" name="test_fp16_values" time="0.200" /><testcase classname="tests.trainers.test_fp16.TestFp16" name="test_fp16_works" time="0.193" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_epoch_over_updates" time="0.192" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_fractional_epoch" time="0.179" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_correct_final_iteration" time="0.197" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_num_remaining_updates_greater_than_update_frequency" time="0.702" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_reporting" time="0.178" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_update_frequency_same_model_params" time="0.367" /><testcase classname="tests.trainers.test_training_loop.TestTrainingLoop" name="test_updates" time="0.189" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_test_end" time="0.009" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_train_start" time="0.005" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_update_end" time="0.005" /><testcase classname="tests.trainers.callbacks.test_logistics.TestLogisticsCallback" name="test_on_validation_start" time="0.005" /><testcase classname="tests.trainers.callbacks.test_lr_scheduler.TestLogisticsCallback" name="test_on_update_end" time="0.004" /><testcase classname="tests.trainers.lightning.test_grad_accumulate.TestLightningTrainerGradAccumulate" name="test_grad_accumulate" time="0.539" /><testcase classname="tests.trainers.lightning.test_grad_clipping.TestLightningTrainerGradClipping" name="test_grad_clipping_and_parity_to_mmf" time="0.544" /><testcase classname="tests.trainers.lightning.test_logging.TestLightningTrainerLogging" name="test_tensorboard_logging_parity" time="1.823" /><testcase classname="tests.trainers.lightning.test_loop_conditions.TestLightningTrainer" name="test_epoch_over_updates" time="0.186" /><testcase classname="tests.trainers.lightning.test_loop_conditions.TestLightningTrainer" name="test_fractional_epoch" time="0.198" /><testcase classname="tests.trainers.lightning.test_loop_conditions.TestLightningTrainer" name="test_updates" time="0.188" /><testcase classname="tests.trainers.lightning.test_loss.TestLightningTrainerLoss" name="test_loss_computation_parity_with_mmf_trainer" time="0.534" /><testcase classname="tests.trainers.lightning.test_lr_schedule.TestLightningTrainerLRSchedule" name="test_lr_schedule" time="0.415" /><testcase classname="tests.trainers.lightning.test_lr_schedule.TestLightningTrainerLRSchedule" name="test_lr_schedule_compared_to_mmf_is_same" time="0.620" /><testcase classname="tests.trainers.lightning.test_validation.TestLightningTrainerValidation" name="test_validation" time="0.671" /><testcase classname="tests.trainers.lightning.test_validation.TestLightningTrainerValidation" name="test_validation_parity" time="1.115" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_checkpoint_scaler_loading" time="0.058" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_finalize_and_restore_from_it" time="0.045" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_finalize_and_resume_file" time="0.020" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_max_to_keep" time="0.072" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_pretrained_load" time="0.031" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_resets" time="0.064" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_save_and_load_state_dict" time="0.059" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_save_config" time="0.029" /><testcase classname="tests.utils.test_checkpoint.TestUtilsCheckpoint" name="test_zoo_load" time="0.022" /><testcase classname="tests.utils.test_configuration.TestUtilsConfiguration" name="test_config_overrides" time="0.488" /><testcase classname="tests.utils.test_configuration.TestUtilsConfiguration" name="test_get_zoo_config" time="5.667" /><testcase classname="tests.utils.test_distributed.TestUtilsDistributed" name="test_object_byte_tensor_conversion" time="0.001" /><testcase classname="tests.utils.test_download.TestUtilsDownload" name="test_built" time="0.001" /><testcase classname="tests.utils.test_download.TestUtilsDownload" name="test_download_file_class" time="8.840" /><testcase classname="tests.utils.test_download.TestUtilsDownload" name="test_mark_done" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_copy" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_exists" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_mkdirs" time="0.001" /><testcase classname="tests.utils.test_file_io.TestFileIO" name="test_file_io_open" time="0.001" /><testcase classname="tests.utils.test_general.TestUtilsGeneral" name="test_dict_to_string" time="0.001" /><testcase classname="tests.utils.test_general.TestUtilsGeneral" name="test_get_overlap_score" time="0.001" /><testcase classname="tests.utils.test_logger.TestLogger" name="test_log_writer" time="0.179" /><testcase classname="tests.utils.test_logger.TestLogger" name="test_logger_files" time="0.001" /><testcase classname="tests.utils.test_quality_checks.TestQualityChecks" name="test_init_files_present" time="0.059" /><testcase classname="tests.utils.test_quality_checks.TestQualityChecks" name="test_no_empty_folders" time="0.034" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_generate_ngrams" time="0.278" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_generate_ngrams_range" time="0.274" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_nucleus_sampling" time="0.291" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_tokenize" time="0.283" /><testcase classname="tests.utils.test_text.TestUtilsText" name="test_vocab_from_text" time="0.378" /><testcase classname="tests.utils.test_text.TestUtilsTextBeamSearch" name="test_beam_search" time="0.493" /><testcase classname="tests.utils.test_timer.TestUtilsTimer" name="test_get_current" time="0.001" /><testcase classname="tests.utils.test_timer.TestUtilsTimer" name="test_get_time_since_start" time="2.003" /><testcase classname="tests.utils.test_timer.TestUtilsTimer" name="test_reset" time="2.003" /></testsuite></testsuites>

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -157,7 +157,10 @@ trainer:
         accumulate_grad_batches: 1
         val_check_interval: 1000
         log_every_n_steps: 100
-        limit_val_batches: 5
+        logger: false
+        limit_val_batches: 1.0
+        # progress bar is turned off if want same logging format as `mmf_trainer`
+        progress_bar_refresh_rate: 0
 
 # Configuration for evaluation
 evaluation:

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -187,11 +187,7 @@ class BaseModel(pl.LightningModule):
         Returns:
             Dict: Dict containing loss.
         """
-        batch = self._ensure_sample_list(batch)
-        output = self(batch)
-        loss_dict = output["losses"]
-        output["loss"] = sum(loss.mean() for loss in loss_dict.values())
-        return output
+        return self._forward_lightning_step(batch, batch_idx)
 
     def validation_step(self, batch, batch_idx, *args, **kwargs):
         """Member function of PL modules. Used only when PL enabled.
@@ -205,9 +201,28 @@ class BaseModel(pl.LightningModule):
         Returns:
             Dict
         """
+        return self._forward_lightning_step(batch, batch_idx)
+
+    def test_step(self, batch, batch_idx, *args, **kwargs):
+        """Member function of PL modules. Used only when PL enabled.
+        To be implemented by child class. Takes in a ``SampleList``,
+        batch_idx and returns back a dict.
+
+        Args:
+            sample_list (SampleList): SampleList returned by the DataLoader for
+            current iteration
+
+        Returns:
+            Dict
+        """
+        return self._forward_lightning_step(batch, batch_idx)
+
+    def _forward_lightning_step(self, batch, batch_idx):
         batch = self._ensure_sample_list(batch)
         output = self(batch)
-        # TODO: @sash Implementation coming soon! (next PR)
+        loss_dict = output["losses"]
+        output["loss"] = sum(loss.mean() for loss in loss_dict.values())
+        output["input_batch"] = batch
         return output
 
     def configure_optimizers(self):

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -1,12 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import logging
-import time
 
 import torch
 from mmf.trainers.callbacks.base import Callback
 from mmf.utils.configuration import get_mmf_env
-from mmf.utils.distributed import is_master
-from mmf.utils.logger import TensorboardLogger, log_progress, setup_output_folder
+from mmf.utils.logger import (
+    TensorboardLogger,
+    calculate_time_left,
+    setup_output_folder,
+    summarize_report,
+)
 from mmf.utils.timer import Timer
 
 
@@ -74,11 +77,25 @@ class LogisticsCallback(Callback):
                 ),
                 "time": self.train_timer.get_time_since_start(),
                 "time_since_start": self.total_timer.get_time_since_start(),
-                "eta": self._calculate_time_left(),
+                "eta": calculate_time_left(
+                    max_updates=self.trainer.max_updates,
+                    num_updates=self.trainer.num_updates,
+                    timer=self.train_timer,
+                    num_snapshot_iterations=self.snapshot_iterations,
+                    log_interval=self.log_interval,
+                    eval_interval=self.evaluation_interval,
+                ),
             }
         )
         self.train_timer.reset()
-        self._summarize_report(kwargs["meter"], extra=extra)
+        summarize_report(
+            current_iteration=self.trainer.current_iteration,
+            num_updates=self.trainer.num_updates,
+            max_updates=self.trainer.max_updates,
+            meter=kwargs["meter"],
+            extra=extra,
+            tb_writer=self.tb_writer,
+        )
 
     def on_validation_start(self, **kwargs):
         self.snapshot_timer.reset()
@@ -93,47 +110,25 @@ class LogisticsCallback(Callback):
         }
         extra.update(self.trainer.early_stop_callback.early_stopping.get_info())
         self.train_timer.reset()
-        self._summarize_report(kwargs["meter"], extra=extra)
+        summarize_report(
+            current_iteration=self.trainer.current_iteration,
+            num_updates=self.trainer.num_updates,
+            max_updates=self.trainer.max_updates,
+            meter=kwargs["meter"],
+            extra=extra,
+            tb_writer=self.tb_writer,
+        )
 
     def on_test_end(self, **kwargs):
         prefix = "{}: full {}".format(
             kwargs["report"].dataset_name, kwargs["report"].dataset_type
         )
-        self._summarize_report(kwargs["meter"], prefix)
+        summarize_report(
+            current_iteration=self.trainer.current_iteration,
+            num_updates=self.trainer.num_updates,
+            max_updates=self.trainer.max_updates,
+            meter=kwargs["meter"],
+            should_print=prefix,
+            tb_writer=self.tb_writer,
+        )
         logger.info(f"Finished run in {self.total_timer.get_time_since_start()}")
-
-    def _summarize_report(self, meter, should_print=True, extra=None):
-        if extra is None:
-            extra = {}
-        if not is_master():
-            return
-
-        if self.training_config.tensorboard:
-            scalar_dict = meter.get_scalar_dict()
-            self.tb_writer.add_scalars(scalar_dict, self.trainer.current_iteration)
-
-        if not should_print:
-            return
-        log_dict = {}
-        if hasattr(self.trainer, "num_updates") and hasattr(
-            self.trainer, "max_updates"
-        ):
-            log_dict.update(
-                {"progress": f"{self.trainer.num_updates}/{self.trainer.max_updates}"}
-            )
-        log_dict.update(meter.get_log_dict())
-        log_dict.update(extra)
-
-        log_progress(log_dict)
-
-    def _calculate_time_left(self):
-        time_taken_for_log = time.time() * 1000 - self.train_timer.start
-        iterations_left = self.trainer.max_updates - self.trainer.num_updates
-        num_logs_left = iterations_left / self.log_interval
-        time_left = num_logs_left * time_taken_for_log
-
-        snapshot_iteration = self.snapshot_iterations / self.log_interval
-        snapshot_iteration *= iterations_left / self.evaluation_interval
-        time_left += snapshot_iteration * time_taken_for_log
-
-        return self.train_timer.get_time_hhmmss(gap=time_left)

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -43,6 +43,7 @@ class TrainerEvaluationLoopMixin(ABC):
                     break
 
             combined_report.metrics = self.metrics(combined_report, combined_report)
+
             self.update_meter(combined_report, meter, eval_mode=True)
 
             # enable train mode again

--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -1,10 +1,16 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import logging
-from typing import Any, List
+from typing import Any, Dict, List
 
+import torch
+from mmf.common.meter import Meter
 from mmf.common.registry import registry
+from mmf.common.report import Report
 from mmf.common.sample import SampleList
+from mmf.trainers.core.reporting import TrainerReportingMixin
+from mmf.utils.logger import calculate_time_left, summarize_report
+from mmf.utils.timer import Timer
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks.base import Callback
 
@@ -12,13 +18,24 @@ from pytorch_lightning.callbacks.base import Callback
 logger = logging.getLogger(__name__)
 
 
-class LightningLoopCallback(Callback):
+class LightningLoopCallback(Callback, TrainerReportingMixin):
     def __init__(self, lightning_trainer: Any):
         super().__init__()
         self.lightning_trainer = lightning_trainer
+        self.trainer_config = lightning_trainer.trainer_config
+        self.training_config = lightning_trainer.training_config
+
+        # for logging
+        self.total_timer = Timer()
+        self.snapshot_iterations = len(lightning_trainer.data_module.val_loader)
+        self.snapshot_iterations //= self.training_config.batch_size
 
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):
         registry.register("current_epoch", trainer.current_epoch)
+        self.train_combined_report = None
+
+        self.train_timer = Timer()
+        self.snapshot_timer = Timer()
 
     def on_train_batch_end(
         self,
@@ -32,9 +49,37 @@ class LightningLoopCallback(Callback):
         # prepare the next batch
         self.lightning_trainer.data_module.train_loader.change_dataloader()
 
+        # aggregate train combined_report
+        step_output = outputs[0][0]["extra"]
+        self.train_combined_report = self._update_and_create_report(
+            step_output, batch_idx, self.train_combined_report
+        )
+
+        # log
+        if (trainer.global_step + 1) % self.trainer_config.log_every_n_steps == 0:
+            self._train_log(trainer)
+
+        # save checkpoints - TODO: @sash
+
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule):
-        # TODO: @sash next PR
-        pass
+        # Only do when run_type has train as it shouldn't happen on validation and
+        # inference runs. Inference will take care of this anyways. Also, don't run
+        # if current iteration is divisble by snapshot interval as it will just
+        # be a repeat
+        if (
+            "train" in self.lightning_trainer.run_type
+            and trainer.global_step % self.trainer_config.val_check_interval != 0
+        ):
+            logger.info("Stepping into final validation check")
+            # Pytorch Lightning upgrades PR4945 and PR4948 will be enabled in 1.2
+            # TODO: perform final validation check
+
+    # Validation Callbacks
+    def on_validation_start(self, trainer: Trainer, pl_module: LightningModule):
+        logger.info("Evaluation time. Running on full validation set...")
+        self.snapshot_timer.reset()
+        self.val_meter = Meter()
+        self.val_combined_report = None
 
     def on_validation_batch_end(
         self,
@@ -47,3 +92,134 @@ class LightningLoopCallback(Callback):
     ):
         # prepare the next batch
         self.lightning_trainer.data_module.val_loader.change_dataloader()
+
+        # aggregate val_combined_report
+        self.val_combined_report = self._update_and_create_report(
+            outputs, batch_idx, self.val_combined_report, update_meter=self.val_meter
+        )
+        self.val_combined_report.metrics = self.lightning_trainer.metrics(
+            self.val_combined_report, self.val_combined_report
+        )
+        self.update_meter(self.val_combined_report, self.val_meter, eval_mode=True)
+
+    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule):
+        iterations = self._get_iterations_for_logging(trainer)
+        current_epochs = self._get_current_epoch_for_logging(trainer)
+        num_updates = self._get_num_updates_for_logging(trainer)
+        extra = {
+            "num_updates": num_updates,
+            "epoch": current_epochs,
+            "iterations": iterations,
+            "max_updates": trainer.max_steps,
+            "val_time": self.snapshot_timer.get_time_since_start(),
+        }
+        # TODO: @sash populate early stop info for logging (next mvp)
+        # extra.update(self.trainer.early_stop_callback.early_stopping.get_info())
+        self.train_timer.reset()
+        summarize_report(
+            current_iteration=iterations,
+            num_updates=num_updates,
+            max_updates=trainer.max_steps,
+            meter=self.val_meter,
+            extra=extra,
+            tb_writer=self.lightning_trainer.tb_writer,
+        )
+
+    def _update_and_create_report(
+        self,
+        step_output: Dict,
+        batch_idx: int,
+        combined_report: Report = None,
+        update_meter: Meter = None,
+    ):
+        input_batch = step_output["input_batch"]
+        report = Report(input_batch, step_output)
+
+        if update_meter:
+            self.update_meter(report, update_meter)
+
+        should_accumulate = not (
+            batch_idx % self.trainer_config.accumulate_grad_batches == 0
+        )
+
+        final_report = report
+        if should_accumulate and combined_report is not None:
+            combined_report.accumulate_tensor_fields_and_loss(
+                report, self.lightning_trainer.metrics.required_params
+            )
+            combined_report.batch_size += report.batch_size
+            final_report = combined_report
+
+        return final_report
+
+    def get_optimizer(self, trainer: Trainer):
+        assert (
+            len(trainer.optimizers) == 1
+        ), "mmf lightning_trainer supports 1 optimizer per model for now."
+        optimizer = trainer.optimizers[0]
+        return optimizer
+
+    def _save_checkpoint(self, trainer: Trainer):
+        logger.info("Checkpoint time. Saving a checkpoint.")
+        return
+        # TODO: sash Needs implementation - next mvp
+
+    def _get_current_epoch_for_logging(self, trainer: Trainer):
+        return trainer.current_epoch + 1
+
+    def _get_iterations_for_logging(self, trainer: Trainer):
+        return trainer.batch_idx + 1
+
+    def _get_num_updates_for_logging(self, trainer: Trainer):
+        return trainer.global_step + 1
+
+    def _train_log(self, trainer: Trainer):
+        if self.training_config.evaluate_metrics:
+            self.train_combined_report.metrics = self.lightning_trainer.metrics(
+                self.train_combined_report, self.train_combined_report
+            )
+        self.update_meter(self.train_combined_report, self.meter)
+
+        extra = {}
+        if "cuda" in str(trainer.model.device):
+            extra["max mem"] = torch.cuda.max_memory_allocated() / 1024
+            extra["max mem"] //= 1024
+
+        if self.training_config.experiment_name:
+            extra["experiment"] = self.training_config.experiment_name
+
+        optimizer = self.get_optimizer(trainer)
+        num_updates = self._get_num_updates_for_logging(trainer)
+        current_iteration = self._get_iterations_for_logging(trainer)
+        extra.update(
+            {
+                "epoch": self._get_current_epoch_for_logging(trainer),
+                "iterations": current_iteration,
+                "num_updates": num_updates,
+                "max_updates": trainer.max_steps,
+                "lr": "{:.5f}".format(optimizer.param_groups[0]["lr"]).rstrip("0"),
+                "ups": "{:.2f}".format(
+                    self.trainer_config.log_every_n_steps
+                    / self.train_timer.unix_time_since_start()
+                ),
+                "time": self.train_timer.get_time_since_start(),
+                "time_since_start": self.total_timer.get_time_since_start(),
+                "eta": calculate_time_left(
+                    max_updates=trainer.max_steps,
+                    num_updates=num_updates,
+                    timer=self.train_timer,
+                    num_snapshot_iterations=self.snapshot_iterations,
+                    log_interval=self.trainer_config.log_every_n_steps,
+                    eval_interval=self.trainer_config.val_check_interval,
+                ),
+            }
+        )
+        self.train_timer.reset()
+        summarize_report(
+            current_iteration=current_iteration,
+            num_updates=num_updates,
+            max_updates=trainer.max_steps,
+            meter=self.meter,
+            extra=extra,
+            tb_writer=self.lightning_trainer.tb_writer,
+        )

--- a/mmf/utils/flow.py
+++ b/mmf/utils/flow.py
@@ -1,0 +1,52 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import math
+import warnings
+from typing import Any, Dict
+
+import torch
+
+
+def get_max_updates(config_max_updates, config_max_epochs, train_loader, update_freq):
+    if config_max_updates is None and config_max_epochs is None:
+        raise ValueError("Neither max_updates nor max_epochs is specified.")
+
+    if isinstance(train_loader.current_dataset, torch.utils.data.IterableDataset):
+        warnings.warn(
+            "max_epochs not supported for Iterable datasets. Falling back "
+            + "to max_updates."
+        )
+        return config_max_updates, config_max_epochs
+
+    if config_max_updates is not None and config_max_epochs is not None:
+        warnings.warn(
+            "Both max_updates and max_epochs are specified. "
+            + f"Favoring max_epochs: {config_max_epochs}"
+        )
+
+    if config_max_epochs is not None:
+        max_updates = math.ceil(len(train_loader) / update_freq) * config_max_epochs
+        max_epochs = config_max_epochs
+    else:
+        max_updates = config_max_updates
+        max_epochs = max_updates / len(train_loader)
+
+    return max_updates, max_epochs
+
+
+def extract_loss(report: Dict[str, Any], loss_divisor: int) -> torch.Tensor:
+    loss_dict = report.losses
+    assert len(loss_dict) != 0, (
+        "Model returned an empty loss dict. "
+        "Did you forget to (i) define losses in your model configuration or"
+        "(ii) return losses dict from your model?"
+    )
+
+    # Since losses are batch averaged in MMF, this makes sure the
+    # scaling is right.
+    for key, value in loss_dict.items():
+        value = value.mean() / loss_divisor
+        report.losses[key] = value
+
+    loss = sum(loss.mean() for loss in loss_dict.values())
+    return loss

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -3,9 +3,7 @@
 import collections
 import gc
 import logging
-import math
 import os
-import warnings
 from bisect import bisect
 
 import torch
@@ -289,33 +287,6 @@ def get_sizes_list(dim, chunks):
         assert sum(sizes_list) == dim
         assert min(sizes_list) > 0
     return sizes_list
-
-
-def get_max_updates(config_max_updates, config_max_epochs, train_loader, update_freq):
-    if config_max_updates is None and config_max_epochs is None:
-        raise ValueError("Neither max_updates nor max_epochs is specified.")
-
-    if isinstance(train_loader.current_dataset, torch.utils.data.IterableDataset):
-        warnings.warn(
-            "max_epochs not supported for Iterable datasets. Falling back "
-            + "to max_updates."
-        )
-        return config_max_updates, config_max_epochs
-
-    if config_max_updates is not None and config_max_epochs is not None:
-        warnings.warn(
-            "Both max_updates and max_epochs are specified. "
-            + f"Favoring max_epochs: {config_max_epochs}"
-        )
-
-    if config_max_epochs is not None:
-        max_updates = math.ceil(len(train_loader) / update_freq) * config_max_epochs
-        max_epochs = config_max_epochs
-    else:
-        max_updates = config_max_updates
-        max_epochs = max_updates / len(train_loader)
-
-    return max_updates, max_epochs
 
 
 def get_chunks(x, sizes):

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+import time
 from typing import Any, Dict, Union
 
 from mmf.common.registry import registry
@@ -202,6 +203,56 @@ def _find_caller():
                 mod_name = "mmf"
             return mod_name, (code.co_filename, frame.f_lineno, code.co_name)
         frame = frame.f_back
+
+
+def summarize_report(
+    current_iteration,
+    num_updates,
+    max_updates,
+    meter,
+    should_print=True,
+    extra=None,
+    tb_writer=None,
+):
+    if extra is None:
+        extra = {}
+    if not is_master():
+        return
+
+    if tb_writer:
+        scalar_dict = meter.get_scalar_dict()
+        tb_writer.add_scalars(scalar_dict, current_iteration)
+
+    if not should_print:
+        return
+    log_dict = {}
+    if num_updates is not None and max_updates is not None:
+        log_dict.update({"progress": f"{num_updates}/{max_updates}"})
+
+    log_dict.update(meter.get_log_dict())
+    log_dict.update(extra)
+
+    log_progress(log_dict)
+
+
+def calculate_time_left(
+    max_updates,
+    num_updates,
+    timer,
+    num_snapshot_iterations,
+    log_interval,
+    eval_interval,
+):
+    time_taken_for_log = time.time() * 1000 - timer.start
+    iterations_left = max_updates - num_updates
+    num_logs_left = iterations_left / log_interval
+    time_left = num_logs_left * time_taken_for_log
+
+    snapshot_iteration = num_snapshot_iterations / log_interval
+    snapshot_iteration *= iterations_left / eval_interval
+    time_left += snapshot_iteration * time_taken_for_log
+
+    return timer.get_time_hhmmss(gap=time_left)
 
 
 def log_progress(info: Union[Dict, Any], log_format="simple"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,7 +124,13 @@ class SimpleModel(torch.nn.Module):
         batch = prepared_batch[DATA_ITEM_KEY]
         output = self.linear(batch)
         loss = torch.nn.MSELoss()(-1 * output, batch)
-        return {"losses": {"loss": loss}, "logits": output, "input_batch": input_sample}
+        return {
+            "losses": {"loss": loss},
+            "logits": output,
+            "input_batch": input_sample,
+            "dataset_type": "dummpy_dataset_type",
+            "dataset_name": "dummpy_dataset_name",
+        }
 
 
 class SimpleLightningModel(pl.LightningModule):
@@ -137,6 +143,12 @@ class SimpleLightningModel(pl.LightningModule):
         return self.model(prepared_batch)
 
     def training_step(self, batch, batch_idx, *args, **kwargs):
+        return self._forward_step(batch, batch_idx, *args, **kwargs)
+
+    def validation_step(self, batch, batch_idx, *args, **kwargs):
+        return self._forward_step(batch, batch_idx, *args, **kwargs)
+
+    def _forward_step(self, batch, batch_idx, *args, **kwargs):
         output = self(batch)
         output["loss"] = output["losses"]["loss"]
         return output

--- a/tests/trainers/lightning/lightning_trainer_mock.py
+++ b/tests/trainers/lightning/lightning_trainer_mock.py
@@ -21,6 +21,7 @@ class LightningTrainerMock(LightningTrainer):
         lr_scheduler=False,
         gradient_clip_val=0.0,
         precision=32,
+        **kwargs,
     ):
         self.config = config
         self._callbacks = None
@@ -29,15 +30,27 @@ class LightningTrainerMock(LightningTrainer):
 
         # data
         self.data_module = MagicMock()
-        dataset = NumbersDataset(num_data_size)
+        train_dataset = NumbersDataset(num_data_size)
+        val_dataset = NumbersDataset(num_data_size)
+
         self.data_module.train_loader = torch.utils.data.DataLoader(
-            dataset=dataset,
+            dataset=train_dataset,
             batch_size=batch_size,
             shuffle=False,
             num_workers=1,
             drop_last=False,
         )
-        self.data_module.train_loader.current_dataset = MagicMock(return_value=dataset)
+        self.data_module.train_loader.change_dataloader = MagicMock(return_value=None)
+        self.data_module.val_loader = torch.utils.data.DataLoader(
+            dataset=val_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=1,
+            drop_last=False,
+        )
+        self.data_module.val_loader.change_dataloader = MagicMock(return_value=None)
+        self.data_module.train_loader.current_dataset = train_dataset
+        self.data_module.val_loader.current_dataset = val_dataset
 
         # settings
         trainer_config = self.config.trainer.params
@@ -48,5 +61,11 @@ class LightningTrainerMock(LightningTrainer):
         trainer_config.gradient_clip_val = gradient_clip_val
         trainer_config.precision = precision
 
+        for key, value in kwargs.items():
+            trainer_config[key] = value
+
         self.trainer_config = trainer_config
+        self.training_config = self.config.training
+        self.training_config.batch_size = batch_size
+        self.run_type = self.config.run_type
         self.config.training.lr_scheduler = lr_scheduler

--- a/tests/trainers/lightning/test_logging.py
+++ b/tests/trainers/lightning/test_logging.py
@@ -1,0 +1,72 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mmf.trainers.callbacks.logistics import LogisticsCallback
+from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
+from tests.trainers.lightning.test_utils import (
+    get_lightning_trainer,
+    get_mmf_trainer,
+    run_lightning_trainer_with_callback,
+)
+
+
+class TestLightningTrainerLogging(unittest.TestCase):
+    def setUp(self):
+        self.mmf_tensorboard_logs = []
+        self.lightning_tensorboard_logs = []
+
+    @patch("mmf.utils.logger.setup_output_folder")
+    @patch("torch.utils.tensorboard.SummaryWriter")
+    def test_tensorboard_logging_parity(self, summary_writer, setup_output_folder):
+        # mmf trainer
+        mmf_trainer = get_mmf_trainer(
+            max_updates=8,
+            batch_size=2,
+            max_epochs=None,
+            evaluation_interval=3,
+            mock_functions=False,
+            tensorboard=True,
+        )
+
+        def _add_scalars_mmf(log_dict, iteration):
+            self.mmf_tensorboard_logs.append({iteration: log_dict})
+
+        mmf_trainer.load_metrics()
+        logistics_callback = LogisticsCallback(mmf_trainer.config, mmf_trainer)
+        logistics_callback.snapshot_timer = MagicMock(return_value=None)
+        logistics_callback.train_timer = MagicMock(return_value=None)
+        logistics_callback.tb_writer.add_scalars = _add_scalars_mmf
+        mmf_trainer.logistics_callback = logistics_callback
+        mmf_trainer.callbacks = [logistics_callback]
+        mmf_trainer.early_stop_callback = MagicMock(return_value=None)
+        mmf_trainer.training_loop()
+
+        # lightning_trainer
+        trainer = get_lightning_trainer(
+            max_steps=8,
+            batch_size=2,
+            prepare_trainer=False,
+            val_check_interval=3,
+            tensorboard=True,
+        )
+
+        def _add_scalars_lightning(log_dict, iteration):
+            self.lightning_tensorboard_logs.append({iteration: log_dict})
+
+        def _on_fit_start_callback():
+            trainer.tb_writer.add_scalars = _add_scalars_lightning
+
+        callback = LightningLoopCallback(trainer)
+        run_lightning_trainer_with_callback(
+            trainer, callback, on_fit_start_callback=_on_fit_start_callback
+        )
+
+        self.assertEqual(
+            len(self.mmf_tensorboard_logs) - 1, len(self.lightning_tensorboard_logs)
+        )
+        for mmf, lightning in zip(
+            self.mmf_tensorboard_logs, self.lightning_tensorboard_logs
+        ):
+            self.assertDictEqual(mmf, lightning)

--- a/tests/trainers/lightning/test_utils.py
+++ b/tests/trainers/lightning/test_utils.py
@@ -12,33 +12,40 @@ def get_trainer_config():
     return OmegaConf.create(
         {
             "distributed": {},
-            "run_type": "train",
+            "run_type": "train_inference",
             "training": {
                 "trainer": "lightning",
                 "detect_anomaly": False,
                 "evaluation_interval": 4,
-                "log_interval": 2,
+                "log_interval": 100,
                 "update_frequency": 1,
                 "fp16": False,
+                "batch_size": 1,
                 "lr_scheduler": False,
+                "tensorboard": False,
             },
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {
                 "type": "warmup_linear",
                 "params": {"num_warmup_steps": 8, "num_training_steps": 8},
             },
+            "evaluation": {"metrics": []},
             "trainer": {
                 "type": "lightning",
                 "params": {
-                    "gpus": 0 if torch.cuda.is_available() else None,
+                    "gpus": [0] if torch.cuda.is_available() else None,
                     "num_nodes": 1,
-                    "precision": 32,
+                    "gradient_clip_val": 0.0,
+                    "checkpoint_callback": False,
                     "deterministic": True,
                     "benchmark": False,
-                    "gradient_clip_val": 0.0,
+                    "accumulate_grad_batches": 1,
+                    "log_every_n_steps": 100,
+                    "limit_val_batches": 1.0,
+                    "progress_bar_refresh_rate": 0,
+                    "precision": 32,
                     "val_check_interval": 4,
-                    "log_every_n_steps": 2,
-                    "checkpoint_callback": False,
+                    "num_sanity_val_steps": 0,
                 },
             },
         }
@@ -55,10 +62,15 @@ def get_lightning_trainer(
     lr_scheduler=False,
     gradient_clip_val=0.0,
     precision=32,
+    prepare_trainer=True,
+    tensorboard=False,
+    **kwargs,
 ):
     torch.random.manual_seed(2)
+    trainer_config = get_trainer_config()
+    trainer_config.training.tensorboard = tensorboard
     trainer = LightningTrainerMock(
-        config=get_trainer_config(),
+        config=trainer_config,
         max_steps=max_steps,
         max_epochs=max_epochs,
         callback=callback,
@@ -67,10 +79,12 @@ def get_lightning_trainer(
         lr_scheduler=lr_scheduler,
         gradient_clip_val=gradient_clip_val,
         precision=precision,
+        **kwargs,
     )
     trainer.model = SimpleLightningModel(model_size, config=trainer.config)
     trainer.model.train()
-    prepare_lightning_trainer(trainer)
+    if prepare_trainer:
+        prepare_lightning_trainer(trainer)
     return trainer
 
 
@@ -83,11 +97,16 @@ def get_mmf_trainer(
     fp16=False,
     scheduler_config=None,
     grad_clipping_config=None,
+    evaluation_interval=4,
+    batch_size=1,
+    mock_functions=True,
+    tensorboard=False,
 ):
     torch.random.manual_seed(2)
     model = SimpleModel(model_size)
     model.train()
     trainer_config = get_trainer_config()
+    trainer_config.training.evaluation_interval = evaluation_interval
     optimizer = build_optimizer(model, trainer_config)
     trainer = TrainerTrainingLoopMock(
         num_data_size,
@@ -95,11 +114,15 @@ def get_mmf_trainer(
         max_epochs,
         config=trainer_config,
         optimizer=optimizer,
-        on_update_end_fn=on_update_end_fn,
         fp16=fp16,
         scheduler_config=scheduler_config,
         grad_clipping_config=grad_clipping_config,
+        batch_size=batch_size,
+        mock_functions=mock_functions,
+        tensorboard=tensorboard,
     )
+    if on_update_end_fn:
+        trainer.on_update_end = on_update_end_fn
     model.to(trainer.device)
     trainer.model = model
     return trainer
@@ -108,4 +131,22 @@ def get_mmf_trainer(
 def prepare_lightning_trainer(trainer):
     trainer.configure_device()
     trainer._calculate_max_updates()
+    trainer.load_metrics()
+    trainer._load_loggers()
     trainer._load_trainer()
+
+
+def run_lightning_trainer_with_callback(trainer, callback, on_fit_start_callback=None):
+    callback.lightning_trainer = trainer
+    callback.trainer_config = trainer.trainer_config
+    callback.training_config = trainer.training_config
+    trainer._callbacks = [callback]
+
+    prepare_lightning_trainer(trainer)
+    if on_fit_start_callback:
+        on_fit_start_callback()
+    trainer.trainer.fit(
+        trainer.model,
+        train_dataloader=trainer.data_module.train_loader,
+        val_dataloaders=trainer.data_module.val_loader,
+    )

--- a/tests/trainers/lightning/test_validation.py
+++ b/tests/trainers/lightning/test_validation.py
@@ -1,0 +1,78 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mmf.trainers.callbacks.logistics import LogisticsCallback
+from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
+from tests.trainers.lightning.test_utils import (
+    get_lightning_trainer,
+    get_mmf_trainer,
+    run_lightning_trainer_with_callback,
+)
+
+
+class TestLightningTrainerValidation(unittest.TestCase):
+    def setUp(self):
+        self.ground_truths = [
+            {
+                "current_iteration": 3,
+                "num_updates": 3,
+                "max_updates": 8,
+                "avg_loss": 9705.2953125,
+            },
+            {
+                "current_iteration": 6,
+                "num_updates": 6,
+                "max_updates": 8,
+                "avg_loss": 9703.29765625,
+            },
+            # TODO: @sash, add one last validation when training is done
+        ]
+
+    @patch("mmf.trainers.lightning_core.loop_callback.summarize_report")
+    def test_validation(self, summarize_report_fn):
+        trainer = get_lightning_trainer(
+            max_steps=8, batch_size=2, prepare_trainer=False, val_check_interval=3
+        )
+        callback = LightningLoopCallback(trainer)
+        run_lightning_trainer_with_callback(trainer, callback)
+        calls = summarize_report_fn.call_args_list
+
+        self.assertEqual(len(self.ground_truths), len(calls))
+        for (args, kwargs), gt in zip(calls, self.ground_truths):
+            for key, value in gt.items():
+                if key == "avg_loss":
+                    self.assertEqual(kwargs["meter"].loss.avg, value)
+                else:
+                    self.assertEqual(kwargs[key], value)
+
+    @patch("mmf.trainers.callbacks.logistics.summarize_report")
+    def test_validation_parity(self, summarize_report_fn):
+        mmf_trainer = get_mmf_trainer(
+            max_updates=8,
+            batch_size=2,
+            max_epochs=None,
+            evaluation_interval=3,
+            mock_functions=False,
+        )
+        mmf_trainer.load_metrics()
+        logistics_callback = LogisticsCallback(mmf_trainer.config, mmf_trainer)
+        logistics_callback.snapshot_timer = MagicMock(return_value=None)
+        logistics_callback.train_timer = MagicMock(return_value=None)
+        mmf_trainer.logistics_callback = logistics_callback
+        mmf_trainer.callbacks.append(logistics_callback)
+        mmf_trainer.early_stop_callback = MagicMock(return_value=None)
+        mmf_trainer.training_loop()
+
+        calls = summarize_report_fn.call_args_list
+        self.assertEqual(3, len(calls))
+        calls = calls[:2]
+
+        self.assertEqual(len(self.ground_truths), len(calls))
+        for (args, kwargs), gt in zip(calls, self.ground_truths):
+            for key, value in gt.items():
+                if key == "avg_loss":
+                    self.assertEqual(kwargs["meter"].loss.avg, value)
+                else:
+                    self.assertEqual(kwargs[key], value)

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -23,23 +23,45 @@ class TrainerTrainingLoopMock(MMFTrainer):
         update_frequency=1,
         batch_size=1,
         fp16=False,
-        on_update_end_fn=None,
         scheduler_config=None,
         grad_clipping_config=None,
+        mock_functions=True,
+        tensorboard=False,
     ):
         if config is None:
-            self.training_config = OmegaConf.create(
+            self.config = OmegaConf.create(
                 {
-                    "detect_anomaly": False,
-                    "evaluation_interval": 10000,
-                    "update_frequency": update_frequency,
-                    "fp16": fp16,
-                    "batch_size": batch_size,
+                    "training": {
+                        "detect_anomaly": False,
+                        "evaluation_interval": 10000,
+                        "update_frequency": update_frequency,
+                        "fp16": fp16,
+                        "batch_size": batch_size,
+                        "tensorboard": tensorboard,
+                    }
                 }
             )
+            self.training_config = self.config.training
         else:
             self.training_config = config.training
+            self.training_config.batch_size = batch_size
+            self.training_config.fp16 = fp16
+            self.training_config.update_frequency = update_frequency
+            self.training_config.tensorboard = tensorboard
             self.config = config
+
+        if mock_functions:
+            self.on_update_end = MagicMock(return_value=None)
+            self.on_batch_start = MagicMock(return_value=None)
+            self.on_update_start = MagicMock(return_value=None)
+            self.logistics_callback = MagicMock(return_value=None)
+            self.logistics_callback.log_interval = MagicMock(return_value=None)
+            self.after_training_loop = MagicMock(return_value=None)
+            self.on_validation_start = MagicMock(return_value=None)
+            self.evaluation_loop = MagicMock(return_value=(None, None))
+            self.on_validation_end = MagicMock(return_value=None)
+            self.metrics = MagicMock(return_value=None)
+            self.early_stop_callback = MagicMock(return_value=None)
 
         if max_updates is not None:
             self.training_config["max_updates"] = max_updates
@@ -68,11 +90,7 @@ class TrainerTrainingLoopMock(MMFTrainer):
             config.scheduler = scheduler_config
             self.lr_scheduler_callback = LRSchedulerCallback(config, self)
             self.callbacks.append(self.lr_scheduler_callback)
-            on_update_end_fn = (
-                on_update_end_fn
-                if on_update_end_fn
-                else self.lr_scheduler_callback.on_update_end
-            )
+            self.on_update_end = self.lr_scheduler_callback.on_update_end
 
         if grad_clipping_config:
             self.training_config.clip_gradients = True
@@ -81,32 +99,30 @@ class TrainerTrainingLoopMock(MMFTrainer):
             ]
             self.training_config.clip_norm_mode = grad_clipping_config["clip_norm_mode"]
 
-        dataset = NumbersDataset(num_train_data)
+        train_dataset = NumbersDataset(num_train_data)
+        val_dataset = NumbersDataset(num_train_data)
         self.train_loader = torch.utils.data.DataLoader(
-            dataset=dataset,
-            batch_size=batch_size,
+            dataset=train_dataset,
+            batch_size=self.training_config.batch_size,
             shuffle=False,
             num_workers=1,
             drop_last=False,
         )
-        self.train_loader.current_dataset = dataset
-        self.on_batch_start = MagicMock(return_value=None)
-        self.on_update_start = MagicMock(return_value=None)
-        self.logistics_callback = MagicMock(return_value=None)
-        self.logistics_callback.log_interval = MagicMock(return_value=None)
-        self.on_batch_end = MagicMock(return_value=None)
-        self.on_update_end = (
-            on_update_end_fn if on_update_end_fn else MagicMock(return_value=None)
+        self.train_loader.current_dataset = train_dataset
+        self.val_loader = torch.utils.data.DataLoader(
+            dataset=val_dataset,
+            batch_size=self.training_config.batch_size,
+            shuffle=False,
+            num_workers=1,
+            drop_last=False,
         )
+        self.val_loader.current_dataset = val_dataset
+        self.val_dataset = val_dataset
+
         self.meter = Meter()
-        self.after_training_loop = MagicMock(return_value=None)
-        self.on_validation_start = MagicMock(return_value=None)
-        self.evaluation_loop = MagicMock(return_value=(None, None))
         self.scaler = torch.cuda.amp.GradScaler(enabled=False)
-        self.val_loader = MagicMock(return_value=None)
-        self.early_stop_callback = MagicMock(return_value=None)
-        self.on_validation_end = MagicMock(return_value=None)
-        self.metrics = MagicMock(return_value=None)
+
+        self.run_type = self.config.get("run_type", "train")
 
 
 class TestTrainingLoop(unittest.TestCase):
@@ -195,8 +211,9 @@ class TestTrainingLoop(unittest.TestCase):
             optimizer=opt,
             update_frequency=update_frequency,
             batch_size=batch_size,
-            on_update_end_fn=on_update_end_fn,
         )
+        if on_update_end_fn:
+            trainer.on_update_end = on_update_end_fn
         model.to(trainer.device)
         trainer.model = model
         trainer.training_loop()

--- a/tests/utils/test_quality_checks.py
+++ b/tests/utils/test_quality_checks.py
@@ -20,7 +20,7 @@ def walk_and_assert_init(folder):
 
 
 def walk_and_assert_not_empty(folder):
-    for _, subfolders, files in os.walk(folder):
+    for dummys, subfolders, files in os.walk(folder):
         assert len(files) > 0 or len(subfolders) > 0, f"Folder {folder} is empty"
 
 


### PR DESCRIPTION
- [x] MVP 1. Evaluation and Logging - Eval accuracy parity between mmf_trainer and lightning_trainer
  -  [X] Validation at the right frequency and at the end (also calculate the right metrics)
  -  [X] Do logging (same logging format with slight difference is ok)
- [x] Tests - tests only done for pytorch lightning integration
  - [X] test logging values are the same as `mmf_trainer`'s logging values
  - [X] test eval values are the same as `mmf_trainer`'s eval values
  - [x] test tensorboard logging the same as `mmf_trainer`'s
- [ ] Blocked:
  - [ ] One Epoch Evaluation Run after train: [PR4945](https://github.com/PyTorchLightning/pytorch-lightning/pull/4945/files) and [PR4948](https://github.com/PyTorchLightning/pytorch-lightning/pull/4948/files) 
