### PR TITLE
[feat] Add MLM pretraining head for MMF Transformer

### DIFF
--- a/mmf/datasets/processors/bert_processors.py
+++ b/mmf/datasets/processors/bert_processors.py
@@ -184,6 +184,7 @@ class MultiSentenceBertTokenizer(BertTokenizer):
     def __init__(self, config, *args, **kwargs):
         super().__init__(config, *args, **kwargs)
         self.fusion_strategy = config.get("fusion", "concat")
+        self._probability = config.get("mask_probability", 0)
         self.tokenizer = super().__call__
 
     def __call__(self, item):

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -15,7 +15,11 @@ from mmf.modules.encoders import ResNet152ImageEncoder
 from mmf.utils.build import build_encoder
 from omegaconf import MISSING, OmegaConf
 from torch import Tensor, nn
-from transformers.modeling_bert import BertPooler, BertPredictionHeadTransform
+from transformers.modeling_bert import (
+    BertOnlyMLMHead,
+    BertPooler,
+    BertPredictionHeadTransform,
+)
 
 
 @dataclass
@@ -29,7 +33,11 @@ class MMFTransformerBackendConfig(BaseTransformerBackendConfig):
 
 
 class MMFTransformerInput(BaseTransformerInput):
-    pass
+    input_ids: Dict[str, Tensor]  # dict of input ids for all modalities
+    position_ids: Dict[str, Tensor]  # dict of position ids for all modalities
+    segment_ids: Dict[str, Tensor]  # dict of segment/token type ids for all modalities
+    masks: Dict[str, Tensor]  # dict of masks for all modalities
+    mlm_labels_list: List[Tensor]  # list of text token masks for all modalities
 
 
 # Can be used with mmft or mmf_transformer
@@ -82,6 +90,7 @@ class MMFTransformer(BaseTransformer):
     def __init__(self, config: BaseTransformer.Config, *args, **kwargs):
         super().__init__(config)
         self.num_labels = self.config.num_labels
+        self.training_head_type = self.config.training_head_type
         self.modality_keys: List = []
         self.modality_type: List = []
         self.modality_segments: List = []
@@ -131,12 +140,20 @@ class MMFTransformer(BaseTransformer):
         hidden output to classification labels.
         """
         transformer_config = self.backend.get_config()
-        self.pooler = BertPooler(transformer_config)
-        self.classifier = nn.Sequential(
-            nn.Dropout(transformer_config.hidden_dropout_prob),
-            BertPredictionHeadTransform(transformer_config),
-            nn.Linear(transformer_config.hidden_size, self.config.num_labels),
-        )
+        if self.config.training_head_type == "classification":
+            self.pooler = BertPooler(transformer_config)
+            self.classifier = nn.Sequential(
+                nn.Dropout(transformer_config.hidden_dropout_prob),
+                BertPredictionHeadTransform(transformer_config),
+                nn.Linear(transformer_config.hidden_size, self.config.num_labels),
+            )
+        elif self.config.training_head_type == "pretraining":
+            self.cls = BertOnlyMLMHead(transformer_config)
+            self.vocab_size = transformer_config.vocab_size
+
+    def build_losses(self):
+        if self.config.training_head_type == "pretraining":
+            self.ce_loss = nn.CrossEntropyLoss(ignore_index=-1)
 
     def preprocess_sample(self, sample_list: Dict[str, Tensor]) -> BaseTransformerInput:
         """Preprocess the sample list elements and form a BaseTransformerInput
@@ -257,33 +274,88 @@ class MMFTransformer(BaseTransformer):
             if masks[modality].dim() == 1:
                 masks[modality] = masks[modality].unsqueeze(dim=1)
 
-        return MMFTransformerInput(input_ids, position_ids, segment_ids, masks)
+        # MLM Labels
+        mlm_labels: Dict[str, Tensor] = {}
+        for idx, modality in enumerate(self.modality_keys):
+            if self.modality_type[idx] == "text" and "lm_label_ids" in sample_list:
+                if sample_list["lm_label_ids"].dim() > 2:
+                    mlm_labels[modality] = sample_list["lm_label_ids"][:, idx]
+                else:
+                    mlm_labels[modality] = sample_list["lm_label_ids"]
+            else:
+                mlm_labels[modality] = torch.full(
+                    input_ids[modality].size()[:-1],
+                    fill_value=-1,
+                    dtype=torch.long,
+                    device=input_ids[modality].device,
+                )
+
+        mlm_labels_list = []
+        for modality in self.modality_keys:
+            mlm_labels_list.append(mlm_labels[modality])
+
+        return MMFTransformerInput(
+            input_ids, position_ids, segment_ids, masks, mlm_labels_list
+        )
 
     def forward(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
         # Sample preprocess
-        output = self.preprocess_sample(sample_list)
+        processed_sample_list = self.preprocess_sample(sample_list)
 
         # Arrange masks in a list
         masks = []
         for modality in self.modality_keys:
-            masks.append(output.masks[modality])
+            masks.append(processed_sample_list.masks[modality])
 
         # Call transformer backend
-        sequence_output, _ = self.backend(
-            output.input_ids, output.position_ids, output.segment_ids, masks
+        sequence_output, encoded_layers = self.backend(
+            processed_sample_list.input_ids,
+            processed_sample_list.position_ids,
+            processed_sample_list.segment_ids,
+            masks,
         )
 
         # Transformer Heads
-        pooled_output = self.pooler(sequence_output)
-        head_output = self.classifier(pooled_output)
 
-        # Postprocess outputs
-        return self.postprocess_output(head_output)
+        output_dict = {}
+        if self.training_head_type == "classification":
+            pooled_output = self.pooler(sequence_output)
+            prediction = self.classifier(pooled_output)
+            output_dict = self.postprocess_output(prediction, processed_sample_list)
+        elif not torch.jit.is_scripting() and self.training_head_type == "pretraining":
+            if not torch.jit.is_scripting():
+                prediction_score = self.cls(sequence_output)
+                output_dict = self.postprocess_output(
+                    prediction_score, processed_sample_list
+                )
+            else:
+                raise AssertionError(
+                    "MMF Tranformer : Torchscript is not supported for pretraining mode."
+                )
 
-    def postprocess_output(self, output: Tensor) -> Dict[str, Tensor]:
+        return output_dict
+
+    def postprocess_output(
+        self, prediction: Tensor, processed_sample_list: MMFTransformerInput
+    ) -> Dict[str, Tensor]:
         """Postprocess the output from the classifier head and reshape it.
         This will be used to calculate losses and metrics in mmf.
         """
         output_dict = {}
-        output_dict["scores"] = output.contiguous().view(-1, self.num_labels)
+        if self.training_head_type == "classification":
+            output_dict["scores"] = prediction.contiguous().view(-1, self.num_labels)
+        elif self.training_head_type == "pretraining":
+            if not torch.jit.is_scripting():
+                output_dict["logits"] = prediction
+                masked_labels = torch.cat(processed_sample_list.mlm_labels_list, dim=-1)
+                masked_lm_loss = self.ce_loss(
+                    prediction.contiguous().view(-1, self.vocab_size),
+                    masked_labels.contiguous().view(-1),
+                )
+                output_dict["losses"] = {}
+                output_dict["losses"]["masked_lm_loss"] = masked_lm_loss
+            else:
+                raise AssertionError(
+                    "MMF Transformer pretraining mode cannot be scripted"
+                )
         return output_dict

--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -17,6 +17,7 @@ class BaseTransformerInput(NamedTuple):
     position_ids: Dict[str, Tensor]  # dict of position ids for all modalities
     segment_ids: Dict[str, Tensor]  # dict of segment/token type ids for all modalities
     masks: Dict[str, Tensor]  # dict of masks for all modalities
+    mlm_labels_list: List[Tensor]  # list of text token masks for all modalities
 
 
 @dataclass


### PR DESCRIPTION
Summary:
1. Adds a MLM pretraining head for MMF Transformer model
1. Fixes `MultiSentenceBertTokenizer` to also support multisentence masking
1. Adds `mlm_labels_list` preprocessing
1. Adds pretraining head specific postprocessing

Note : This is not the best way we can add pretraining losses and heads, but we should tackle it properly when we start working on Pretraining Schemes support for MMFT and other models.

Facebook :
1. Fixes dataset filtering to support the case when no `set_name_mapping` is available for a dataset
1. Fixes `FeaturesWithTextBatchProcessor` when no labels are available for a dataset
1. Fixes `MultiSentenceSPMTokenizer` to also support multisentence masking

Reviewed By: apsdehal

Differential Revision: D26270908

