### PR TITLE
[MMF] allow MMFT to have input without mlm labels

### DIFF
--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -155,8 +155,8 @@ class MMFTransformer(BaseTransformer):
         if self.config.training_head_type == "pretraining":
             self.ce_loss = nn.CrossEntropyLoss(ignore_index=-1)
 
-    def preprocess_sample(self, sample_list: Dict[str, Tensor]) -> BaseTransformerInput:
-        """Preprocess the sample list elements and form a BaseTransformerInput
+    def preprocess_sample(self, sample_list: Dict[str, Tensor]) -> MMFTransformerInput:
+        """Preprocess the sample list elements and form a MMFTransformerInput
         type object. This object standardizes how we represent multiple modalities.
         Check the definition of this dataclass in BaseTransformer.
         """

--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -17,7 +17,6 @@ class BaseTransformerInput(NamedTuple):
     position_ids: Dict[str, Tensor]  # dict of position ids for all modalities
     segment_ids: Dict[str, Tensor]  # dict of segment/token type ids for all modalities
     masks: Dict[str, Tensor]  # dict of masks for all modalities
-    mlm_labels_list: List[Tensor]  # list of text token masks for all modalities
 
 
 @dataclass


### PR DESCRIPTION
Summary:
As title, more flexible for use cases where mmft transformer is used as a module and pre-training is not necessarily required.
https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/aml/eccv/mcm/training/lib/transformer_mm.py?commit=5ee0cf6ca4989e30d0f688e6d1cfb4e3250cc76f&lines=24

Differential Revision: D26380500

