### PR TITLE
[feat] PL mvp1: validation + logging

### DIFF
--- a/mmf/common/meter.py
+++ b/mmf/common/meter.py
@@ -145,3 +145,7 @@ class Meter:
                 loss_str.append(f"{name}: {meter.global_avg:.4f}")
 
         return self.delimiter.join(loss_str)
+
+    def reset(self):
+        del self.meters
+        self.meters = defaultdict(SmoothedValue)

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -147,7 +147,7 @@ trainer:
     # https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-class-api
     type: lightning
     params:
-        gpus: null
+        gpus: 1
         num_nodes: 1
         precision: 32
         deterministic: false
@@ -156,12 +156,14 @@ trainer:
         max_epochs: null
         gradient_clip_val: 0.0
         num_sanity_val_steps: 0
-        automatic_optimization: true # only True is supported for now
         checkpoint_callback: false
         accumulate_grad_batches: 1
         val_check_interval: 1000
         log_every_n_steps: 100
-        limit_val_batches: 5
+        logger: false
+        limit_val_batches: 1.0
+        # progress bar is turned off if want same logging format as `mmf_trainer`
+        progress_bar_refresh_rate: 0
 
 # Configuration for evaluation
 evaluation:

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -49,6 +49,7 @@ from typing import List, Optional, Union
 
 import pytorch_lightning as pl
 from mmf.common.registry import registry
+from mmf.common.report import Report
 from mmf.common.sample import SampleList, to_device
 from mmf.modules.losses import LossConfig, Losses
 from mmf.utils.checkpoint import load_pretrained_model
@@ -118,6 +119,12 @@ class BaseModel(pl.LightningModule):
             "Build method not implemented in the child model class."
         )
 
+    def build_meters(self, run_type):
+        from mmf.utils.build import build_meters
+
+        """Function only used in lightning setting"""
+        self.train_meter, self.val_meter, self.test_meter = build_meters(run_type)
+
     def init_losses(self):
         """Initializes loss for the model based ``losses`` key. Automatically called by
         MMF internally after building the model.
@@ -175,7 +182,7 @@ class BaseModel(pl.LightningModule):
             "Forward of the child model class needs to be implemented."
         )
 
-    def training_step(self, batch, batch_idx, *args, **kwargs):
+    def training_step(self, batch: SampleList, batch_idx: int, *args, **kwargs):
         """Member function of PL modules. Used only when PL enabled.
         To be implemented by child class. Takes in a ``SampleList``,
         batch_idx and returns back a dict.
@@ -187,13 +194,12 @@ class BaseModel(pl.LightningModule):
         Returns:
             Dict: Dict containing loss.
         """
-        batch = self._ensure_sample_list(batch)
-        output = self(batch)
-        loss_dict = output["losses"]
-        output["loss"] = sum(loss.mean() for loss in loss_dict.values())
+        output = self._forward_lightning_step(batch, batch_idx)
+        report = Report(batch, output)
+        self.train_meter.update_from_report(report)
         return output
 
-    def validation_step(self, batch, batch_idx, *args, **kwargs):
+    def validation_step(self, batch: SampleList, batch_idx: int, *args, **kwargs):
         """Member function of PL modules. Used only when PL enabled.
         To be implemented by child class. Takes in a ``SampleList``,
         batch_idx and returns back a dict.
@@ -205,9 +211,31 @@ class BaseModel(pl.LightningModule):
         Returns:
             Dict
         """
+        output = self._forward_lightning_step(batch, batch_idx)
+        report = Report(batch, output)
+        self.val_meter.update_from_report(report)
+        report.metrics = self.metrics(report, report)
+        return output
+
+    def test_step(self, batch: SampleList, batch_idx: int, *args, **kwargs):
+        """Member function of PL modules. Used only when PL enabled.
+        To be implemented by child class. Takes in a ``SampleList``,
+        batch_idx and returns back a dict.
+
+        Args:
+            sample_list (SampleList): SampleList returned by the DataLoader for
+            current iteration
+
+        Returns:
+            Dict
+        """
+        return self._forward_lightning_step(batch, batch_idx)
+
+    def _forward_lightning_step(self, batch, batch_idx):
         batch = self._ensure_sample_list(batch)
         output = self(batch)
-        # TODO: @sash Implementation coming soon! (next PR)
+        loss_dict = output["losses"]
+        output["loss"] = sum(loss.mean() for loss in loss_dict.values())
         return output
 
     def configure_optimizers(self):

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -27,7 +27,6 @@ class TrainerEvaluationLoopMixin(ABC):
         with torch.no_grad():
             self.model.eval()
             disable_tqdm = not use_tqdm or not is_master()
-
             while reporter.next_dataset(flush_report=False):
                 dataloader = reporter.get_dataloader()
                 combined_report = None

--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -1,10 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import logging
-from typing import Any, List
+from typing import Any, Dict, List
 
+import torch
+from mmf.common.meter import Meter
 from mmf.common.registry import registry
+from mmf.common.report import Report
 from mmf.common.sample import SampleList
+from mmf.utils.logger import calculate_time_left, summarize_report
+from mmf.utils.timer import Timer
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks.base import Callback
 
@@ -16,9 +21,21 @@ class LightningLoopCallback(Callback):
     def __init__(self, lightning_trainer: Any):
         super().__init__()
         self.lightning_trainer = lightning_trainer
+        # this is lightning trainer's config
+        self.trainer_config = lightning_trainer.trainer_config
+        # training config configures training parameters.
+        self.training_config = lightning_trainer.training_config
+        self.run_type = lightning_trainer.run_type
+
+        # for logging
+        self.total_timer = Timer()
+        self.snapshot_timer = Timer()
+        self.snapshot_iterations = len(self.lightning_trainer.val_loader)
+        self.train_timer = Timer()
 
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):
         registry.register("current_epoch", trainer.current_epoch)
+        self.train_combined_report = None
 
     def on_train_batch_end(
         self,
@@ -32,9 +49,36 @@ class LightningLoopCallback(Callback):
         # prepare the next batch
         self.lightning_trainer.data_module.train_loader.change_dataloader()
 
+        # aggregate train combined_report
+        self.train_combined_report = self._update_and_create_report(
+            SampleList(batch), batch_idx, outputs, pl_module, self.train_combined_report
+        )
+
+        # log
+        if (trainer.global_step + 1) % self.trainer_config.log_every_n_steps == 0:
+            self._train_log(trainer, pl_module)
+
+        # save checkpoints - TODO: @sash
+
     def on_train_end(self, trainer: Trainer, pl_module: LightningModule):
-        # TODO: @sash next PR
-        pass
+        # Only do when run_type has train as it shouldn't happen on validation and
+        # inference runs. Inference will take care of this anyways. Also, don't run
+        # if current iteration is divisble by snapshot interval as it will just
+        # be a repeat
+        if (
+            "train" in self.run_type
+            and trainer.global_step % self.trainer_config.val_check_interval != 0
+        ):
+            logger.info("Stepping into final validation check")
+            # Pytorch Lightning upgrades PR4945 and PR4948 will be enabled in 1.2
+            # TODO: perform final validation check
+
+    # Validation Callbacks
+    def on_validation_start(self, trainer: Trainer, pl_module: LightningModule):
+        logger.info("Evaluation time. Running on full validation set...")
+        self.snapshot_timer.reset()
+        self.val_combined_report = None
+        pl_module.val_meter.reset()
 
     def on_validation_batch_end(
         self,
@@ -47,3 +91,143 @@ class LightningLoopCallback(Callback):
     ):
         # prepare the next batch
         self.lightning_trainer.data_module.val_loader.change_dataloader()
+
+        # aggregate val_combined_report
+        self.val_combined_report = self._update_and_create_report(
+            batch,
+            batch_idx,
+            outputs,
+            pl_module,
+            self.val_combined_report,
+            update_meter=pl_module.val_meter,
+        )
+        self.val_combined_report.metrics = pl_module.metrics(
+            self.val_combined_report, self.val_combined_report
+        )
+        pl_module.val_meter.update_from_report(
+            self.val_combined_report, should_update_loss=False
+        )
+
+    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule):
+        iterations = self._get_iterations_for_logging(trainer)
+        current_epochs = self._get_current_epoch_for_logging(trainer)
+        num_updates = self._get_num_updates_for_logging(trainer)
+        extra = {
+            "num_updates": num_updates,
+            "epoch": current_epochs,
+            "iterations": iterations,
+            "max_updates": trainer.max_steps,
+            "val_time": self.snapshot_timer.get_time_since_start(),
+        }
+        # TODO: @sash populate early stop info for logging (next mvp)
+        # extra.update(self.trainer.early_stop_callback.early_stopping.get_info())
+        self.train_timer.reset()
+        summarize_report(
+            current_iteration=iterations,
+            num_updates=num_updates,
+            max_updates=trainer.max_steps,
+            meter=pl_module.val_meter,
+            extra=extra,
+            tb_writer=self.lightning_trainer.tb_writer,
+        )
+
+    def _update_and_create_report(
+        self,
+        batch: Dict,
+        batch_idx: int,
+        step_output: Dict,
+        pl_module: LightningModule,
+        combined_report: Report = None,
+        update_meter: Meter = None,
+    ):
+        report = Report(batch, step_output)
+
+        if update_meter:
+            update_meter.update_from_report(report)
+
+        should_accumulate = not (
+            batch_idx % self.trainer_config.accumulate_grad_batches == 0
+        )
+
+        final_report = report
+        if should_accumulate and combined_report is not None:
+            combined_report.accumulate_tensor_fields_and_loss(
+                report, pl_module.metrics.required_params
+            )
+            combined_report.batch_size += report.batch_size
+            final_report = combined_report
+
+        return final_report
+
+    def get_optimizer(self, trainer: Trainer):
+        assert (
+            len(trainer.optimizers) == 1
+        ), "mmf lightning_trainer supports 1 optimizer per model for now."
+        optimizer = trainer.optimizers[0]
+        return optimizer
+
+    def _save_checkpoint(self, trainer: Trainer):
+        logger.info("Checkpoint time. Saving a checkpoint.")
+        return
+        # TODO: sash Needs implementation - next mvp
+
+    def _get_current_epoch_for_logging(self, trainer: Trainer):
+        return trainer.current_epoch + 1
+
+    def _get_iterations_for_logging(self, trainer: Trainer):
+        return trainer.batch_idx + 1
+
+    def _get_num_updates_for_logging(self, trainer: Trainer):
+        return trainer.global_step + 1
+
+    def _train_log(self, trainer: Trainer, pl_module: LightningModule):
+        if self.training_config.evaluate_metrics:
+            self.train_combined_report.metrics = pl_module.metrics(
+                self.train_combined_report, self.train_combined_report
+            )
+
+        pl_module.train_meter.update_from_report(self.train_combined_report)
+
+        extra = {}
+        if "cuda" in str(trainer.model.device):
+            extra["max mem"] = torch.cuda.max_memory_allocated() / 1024
+            extra["max mem"] //= 1024
+
+        if self.training_config.experiment_name:
+            extra["experiment"] = self.training_config.experiment_name
+
+        optimizer = self.get_optimizer(trainer)
+        num_updates = self._get_num_updates_for_logging(trainer)
+        current_iteration = self._get_iterations_for_logging(trainer)
+        extra.update(
+            {
+                "epoch": self._get_current_epoch_for_logging(trainer),
+                "iterations": current_iteration,
+                "num_updates": num_updates,
+                "max_updates": trainer.max_steps,
+                "lr": "{:.5f}".format(optimizer.param_groups[0]["lr"]).rstrip("0"),
+                "ups": "{:.2f}".format(
+                    self.trainer_config.log_every_n_steps
+                    / self.train_timer.unix_time_since_start()
+                ),
+                "time": self.train_timer.get_time_since_start(),
+                "time_since_start": self.total_timer.get_time_since_start(),
+                "eta": calculate_time_left(
+                    max_updates=trainer.max_steps,
+                    num_updates=num_updates,
+                    timer=self.train_timer,
+                    num_snapshot_iterations=self.snapshot_iterations,
+                    log_interval=self.trainer_config.log_every_n_steps,
+                    eval_interval=self.trainer_config.val_check_interval,
+                ),
+            }
+        )
+        self.train_timer.reset()
+        summarize_report(
+            current_iteration=current_iteration,
+            num_updates=num_updates,
+            max_updates=trainer.max_steps,
+            meter=pl_module.train_meter,
+            extra=extra,
+            tb_writer=self.lightning_trainer.tb_writer,
+        )

--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -9,7 +9,9 @@ from mmf.modules.metrics import Metrics
 from mmf.trainers.base_trainer import BaseTrainer
 from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
 from mmf.utils.build import build_model
+from mmf.utils.configuration import get_mmf_env
 from mmf.utils.general import get_max_updates, print_model_parameters
+from mmf.utils.logger import TensorboardLogger, setup_output_folder
 from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning import Trainer, seed_everything
 
@@ -22,11 +24,13 @@ class LightningTrainer(BaseTrainer):
     def __init__(self, config: DictConfig):
         super().__init__(config)
         self.trainer = None
+        self.trainer_config = self.config.trainer.params
+        self.data_module = None
 
     def load(self):
         super().load()
-        self.trainer_config = self.config.trainer.params
         self._calculate_max_updates()
+        self._load_loggers()
         self._load_trainer()
 
     def _load_trainer(self):
@@ -38,9 +42,9 @@ class LightningTrainer(BaseTrainer):
 
         lightning_params_dict = OmegaConf.to_container(lightning_params, resolve=True)
         self.trainer = Trainer(
-            logger=False,
             callbacks=self._callbacks,
             max_steps=self._max_updates,
+            default_root_dir=get_mmf_env(key="log_dir"),
             **lightning_params_dict
         )
 
@@ -50,6 +54,17 @@ class LightningTrainer(BaseTrainer):
     def configure_seed(self) -> None:
         seed = self.config.training.seed
         seed_everything(seed)
+
+    def _load_loggers(self) -> None:
+        self.tb_writer = None
+        if self.training_config.tensorboard:
+            # TODO: @sash PL logger upgrade
+            log_dir = setup_output_folder(folder_only=True)
+            env_tb_logdir = get_mmf_env(key="tensorboard_logdir")
+            if env_tb_logdir:
+                log_dir = env_tb_logdir
+
+            self.tb_writer = TensorboardLogger(log_dir)
 
     def load_datasets(self) -> None:
         logger.info("Loading datasets")
@@ -71,6 +86,7 @@ class LightningTrainer(BaseTrainer):
 
         self.model = build_model(attributes)
         self.model.is_pl_enabled = True
+        self.model.build_meters(self.run_type)
 
     def load_optimizer(self) -> None:
         logger.info("Loading optimizer: noop for lightning")
@@ -78,8 +94,8 @@ class LightningTrainer(BaseTrainer):
     def load_metrics(self) -> None:
         logger.info("Loading metrics")
         metrics = self.config.evaluation.get("metrics", [])
-        self.metrics = Metrics(metrics)
-        self.metrics_params = self.metrics.required_params
+        # moved metrics into the model object
+        self.model.metrics = Metrics(metrics)
 
     def configure_callbacks(self) -> None:
         self._callbacks = [LightningLoopCallback(self)]
@@ -90,6 +106,11 @@ class LightningTrainer(BaseTrainer):
         print_model_parameters(self.model)
 
         logger.info("Starting training...")
+
+        if "train" not in self.run_type:
+            self.inference()
+            return
+
         self.trainer.fit(self.model, self.data_module)
         # TODO: Look for a better way to hook this
         self.data_module.teardown()

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import mmf
 import pytorch_lightning as pl
 import torch
+from mmf.common.meter import Meter
 from mmf.common.registry import registry
 from mmf.datasets.iteration_strategies import (
     ConstantIterationStrategy,
@@ -544,3 +545,18 @@ def build_iteration_strategy(
             )
         else:
             return iteration_strategy_class(config, dataloaders, *args, **kwargs)
+
+
+def build_meters(run_type: str) -> List[Meter]:
+    train_meter, val_meter, test_meter = None, None, None
+    if "train" in run_type:
+        train_meter = Meter()
+        # val_meter used for validation after training loop
+        val_meter = Meter()
+    elif "val" in run_type or "inference" in run_type:
+        val_meter = Meter()
+
+    if "test" in run_type:
+        test_meter = Meter()
+
+    return train_meter, val_meter, test_meter

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -368,6 +368,24 @@ def get_max_updates(config_max_updates, config_max_epochs, train_loader, update_
     return max_updates, max_epochs
 
 
+def extract_loss(report: Dict[str, Any], loss_divisor: int) -> torch.Tensor:
+    loss_dict = report.losses
+    assert len(loss_dict) != 0, (
+        "Model returned an empty loss dict. "
+        "Did you forget to (i) define losses in your model configuration or"
+        "(ii) return losses dict from your model?"
+    )
+
+    # Since losses are batch averaged in MMF, this makes sure the
+    # scaling is right.
+    for key, value in loss_dict.items():
+        value = value.mean() / loss_divisor
+        report.losses[key] = value
+
+    loss = sum(loss.mean() for loss in loss_dict.values())
+    return loss
+
+
 def get_chunks(x, sizes):
     out = []
     begin = 0

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -6,11 +6,12 @@ import json
 import logging
 import os
 import sys
+import time
 from typing import Any, Dict, Union
 
 from mmf.common.registry import registry
 from mmf.utils.configuration import get_mmf_env
-from mmf.utils.distributed import get_rank, is_master
+from mmf.utils.distributed import get_rank, is_master, is_xla
 from mmf.utils.file_io import PathManager
 from mmf.utils.timer import Timer
 from termcolor import colored
@@ -199,6 +200,56 @@ def _find_caller():
                 mod_name = "mmf"
             return mod_name, (code.co_filename, frame.f_lineno, code.co_name)
         frame = frame.f_back
+
+
+def summarize_report(
+    current_iteration,
+    num_updates,
+    max_updates,
+    meter,
+    should_print=True,
+    extra=None,
+    tb_writer=None,
+):
+    if extra is None:
+        extra = {}
+    if not is_master() and not is_xla():
+        return
+
+    if tb_writer:
+        scalar_dict = meter.get_scalar_dict()
+        tb_writer.add_scalars(scalar_dict, current_iteration)
+
+    if not should_print:
+        return
+    log_dict = {}
+    if num_updates is not None and max_updates is not None:
+        log_dict.update({"progress": f"{num_updates}/{max_updates}"})
+
+    log_dict.update(meter.get_log_dict())
+    log_dict.update(extra)
+
+    log_progress(log_dict)
+
+
+def calculate_time_left(
+    max_updates,
+    num_updates,
+    timer,
+    num_snapshot_iterations,
+    log_interval,
+    eval_interval,
+):
+    time_taken_for_log = time.time() * 1000 - timer.start
+    iterations_left = max_updates - num_updates
+    num_logs_left = iterations_left / log_interval
+    time_left = num_logs_left * time_taken_for_log
+
+    snapshot_iteration = num_snapshot_iterations / log_interval
+    snapshot_iteration *= iterations_left / eval_interval
+    time_left += snapshot_iteration * time_taken_for_log
+
+    return timer.get_time_hhmmss(gap=time_left)
 
 
 def log_progress(info: Union[Dict, Any], log_format="simple"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ omegaconf==2.0.6
 lmdb==0.98
 termcolor==1.1.0
 iopath==0.1.7
-pytorch_lightning==1.2.7
 datasets==1.2.1
 matplotlib==3.3.4
 pycocotools==2.0.2
 ftfy==5.8
+pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@7a48db5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,7 +180,13 @@ class SimpleModel(BaseModel):
         batch = prepared_batch[self.data_item_key]
         output = self.classifier(batch)
         loss = torch.nn.MSELoss()(-1 * output, batch)
-        return {"losses": {"loss": loss}, "logits": output, "input_batch": input_sample}
+        return {
+            "losses": {"loss": loss},
+            "logits": output,
+            "input_batch": input_sample,
+            "dataset_type": "dummy_dataset_type",
+            "dataset_name": "dummy_dataset_name",
+        }
 
 
 class SimpleLightningModel(SimpleModel):
@@ -188,7 +194,18 @@ class SimpleLightningModel(SimpleModel):
         super().__init__(config)
         self.trainer_config = trainer_config
 
+    def build_meters(self, run_type):
+        from mmf.utils.build import build_meters
+
+        self.train_meter, self.val_meter, self.test_meter = build_meters(run_type)
+
     def training_step(self, batch, batch_idx, *args, **kwargs):
+        return self._forward_step(batch, batch_idx, *args, **kwargs)
+
+    def validation_step(self, batch, batch_idx, *args, **kwargs):
+        return self._forward_step(batch, batch_idx, *args, **kwargs)
+
+    def _forward_step(self, batch, batch_idx, *args, **kwargs):
         output = self(batch)
         output["loss"] = output["losses"]["loss"]
         return output

--- a/tests/trainers/lightning/lightning_trainer_mock.py
+++ b/tests/trainers/lightning/lightning_trainer_mock.py
@@ -18,6 +18,7 @@ class LightningTrainerMock(LightningTrainer):
         lr_scheduler=False,
         gradient_clip_val=0.0,
         precision=32,
+        **kwargs
     ):
         self.config = config
         self._callbacks = None
@@ -38,7 +39,13 @@ class LightningTrainerMock(LightningTrainer):
         trainer_config.gradient_clip_val = gradient_clip_val
         trainer_config.precision = precision
 
+        for key, value in kwargs.items():
+            trainer_config[key] = value
+
         self.trainer_config = trainer_config
+        self.training_config = self.config.training
+        self.training_config.batch_size = batch_size
+        self.run_type = self.config.get("run_type", "train")
         self.config.training.lr_scheduler = lr_scheduler
         registry.register("config", self.config)
 

--- a/tests/trainers/lightning/test_grad_accumulate.py
+++ b/tests/trainers/lightning/test_grad_accumulate.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
+from unittest.mock import patch
 
 import torch
 from tests.trainers.test_utils import get_lightning_trainer
@@ -8,17 +9,18 @@ from tests.trainers.test_utils import get_lightning_trainer
 
 class TestLightningTrainerGradAccumulate(unittest.TestCase):
     def test_grad_accumulate(self):
-        trainer1 = get_lightning_trainer(
-            accumulate_grad_batches=2, max_steps=2, batch_size=3
-        )
-        trainer1.trainer.fit(trainer1.model, trainer1.data_module.train_loader)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer1 = get_lightning_trainer(
+                accumulate_grad_batches=2, max_steps=2, batch_size=3
+            )
+            trainer1.trainer.fit(trainer1.model, trainer1.data_module.train_loader)
 
-        trainer2 = get_lightning_trainer(
-            accumulate_grad_batches=1, max_steps=2, batch_size=6
-        )
-        trainer2.trainer.fit(trainer2.model, trainer2.data_module.train_loader)
+            trainer2 = get_lightning_trainer(
+                accumulate_grad_batches=1, max_steps=2, batch_size=6
+            )
+            trainer2.trainer.fit(trainer2.model, trainer2.data_module.train_loader)
 
-        for param1, param2 in zip(
-            trainer1.model.parameters(), trainer2.model.parameters()
-        ):
-            self.assertTrue(torch.allclose(param1, param2))
+            for param1, param2 in zip(
+                trainer1.model.parameters(), trainer2.model.parameters()
+            ):
+                self.assertTrue(torch.allclose(param1, param2))

--- a/tests/trainers/lightning/test_grad_clipping.py
+++ b/tests/trainers/lightning/test_grad_clipping.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from mmf.utils.general import clip_gradients
@@ -47,13 +47,14 @@ class TestLightningTrainerGradClipping(unittest.TestCase, Callback):
         mmf_trainer._finish_update = _finish_update
         mmf_trainer.training_loop()
 
-        trainer = get_lightning_trainer(
-            max_steps=5,
-            max_epochs=None,
-            gradient_clip_val=self.grad_clip_magnitude,
-            callback=self,
-        )
-        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer = get_lightning_trainer(
+                max_steps=5,
+                max_epochs=None,
+                gradient_clip_val=self.grad_clip_magnitude,
+                callback=self,
+            )
+            trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
 
     def on_after_backward(self, trainer, pl_module):
         for param in pl_module.parameters():

--- a/tests/trainers/lightning/test_logging.py
+++ b/tests/trainers/lightning/test_logging.py
@@ -1,0 +1,89 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from mmf.trainers.callbacks.logistics import LogisticsCallback
+from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
+from mmf.utils.timer import Timer
+from tests.trainers.test_utils import (
+    get_lightning_trainer,
+    get_mmf_trainer,
+    run_lightning_trainer_with_callback,
+)
+
+
+class TestLightningTrainerLogging(unittest.TestCase):
+    def setUp(self):
+        self.mmf_tensorboard_logs = []
+        self.lightning_tensorboard_logs = []
+
+    @patch("mmf.common.test_reporter.PathManager.mkdirs")
+    @patch("mmf.trainers.callbacks.logistics.setup_output_folder", return_value="logs")
+    @patch("mmf.trainers.lightning_trainer.setup_output_folder", return_value="logs")
+    @patch("mmf.utils.logger.setup_output_folder", return_value="logs")
+    @patch("torch.utils.tensorboard.SummaryWriter")
+    @patch("mmf.trainers.callbacks.logistics.get_mmf_env", return_value="logs")
+    @patch("mmf.common.test_reporter.get_mmf_env", return_value="logs")
+    @patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value="logs")
+    def test_tensorboard_logging_parity(
+        self,
+        summary_writer,
+        mmf,
+        lightning,
+        logistics,
+        logistics_logs,
+        report_logs,
+        trainer_logs,
+        mkdirs,
+    ):
+        # mmf trainer
+        mmf_trainer = get_mmf_trainer(
+            max_updates=8,
+            batch_size=2,
+            max_epochs=None,
+            log_interval=3,
+            tensorboard=True,
+        )
+
+        def _add_scalars_mmf(log_dict, iteration):
+            self.mmf_tensorboard_logs.append({iteration: log_dict})
+
+        mmf_trainer.load_metrics()
+        logistics_callback = LogisticsCallback(mmf_trainer.config, mmf_trainer)
+        logistics_callback.snapshot_timer = MagicMock(return_value=None)
+        logistics_callback.train_timer = Timer()
+        logistics_callback.tb_writer.add_scalars = _add_scalars_mmf
+        mmf_trainer.logistics_callback = logistics_callback
+        mmf_trainer.callbacks = [logistics_callback]
+        mmf_trainer.early_stop_callback = MagicMock(return_value=None)
+        mmf_trainer.on_update_end = logistics_callback.on_update_end
+        mmf_trainer.training_loop()
+
+        # lightning_trainer
+        trainer = get_lightning_trainer(
+            max_steps=8,
+            batch_size=2,
+            prepare_trainer=False,
+            log_every_n_steps=3,
+            val_check_interval=9,
+            tensorboard=True,
+        )
+
+        def _add_scalars_lightning(log_dict, iteration):
+            self.lightning_tensorboard_logs.append({iteration: log_dict})
+
+        def _on_fit_start_callback():
+            trainer.tb_writer.add_scalars = _add_scalars_lightning
+
+        callback = LightningLoopCallback(trainer)
+        run_lightning_trainer_with_callback(
+            trainer, callback, on_fit_start_callback=_on_fit_start_callback
+        )
+        self.assertEqual(
+            len(self.mmf_tensorboard_logs), len(self.lightning_tensorboard_logs)
+        )
+        for mmf, lightning in zip(
+            self.mmf_tensorboard_logs, self.lightning_tensorboard_logs
+        ):
+            self.assertDictEqual(mmf, lightning)

--- a/tests/trainers/lightning/test_loop_conditions.py
+++ b/tests/trainers/lightning/test_loop_conditions.py
@@ -1,34 +1,38 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
+from unittest.mock import patch
 
 from tests.trainers.test_utils import get_lightning_trainer
 
 
 class TestLightningTrainer(unittest.TestCase):
     def test_epoch_over_updates(self):
-        trainer = get_lightning_trainer(max_steps=2, max_epochs=0.04)
-        self.assertEqual(trainer._max_updates, 4)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer = get_lightning_trainer(max_steps=2, max_epochs=0.04)
+            self.assertEqual(trainer._max_updates, 4)
 
-        self._check_values(trainer, 0, 0)
-        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
-        self._check_values(trainer, 4, 0)
+            self._check_values(trainer, 0, 0)
+            trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+            self._check_values(trainer, 4, 0)
 
     def test_fractional_epoch(self):
-        trainer = get_lightning_trainer(max_steps=None, max_epochs=0.04)
-        self.assertEqual(trainer._max_updates, 4)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer = get_lightning_trainer(max_steps=None, max_epochs=0.04)
+            self.assertEqual(trainer._max_updates, 4)
 
-        self._check_values(trainer, 0, 0)
-        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
-        self._check_values(trainer, 4, 0)
+            self._check_values(trainer, 0, 0)
+            trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+            self._check_values(trainer, 4, 0)
 
     def test_updates(self):
-        trainer = get_lightning_trainer(max_steps=2, max_epochs=None)
-        self.assertEqual(trainer._max_updates, 2)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer = get_lightning_trainer(max_steps=2, max_epochs=None)
+            self.assertEqual(trainer._max_updates, 2)
 
-        self._check_values(trainer, 0, 0)
-        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
-        self._check_values(trainer, 2, 0)
+            self._check_values(trainer, 0, 0)
+            trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+            self._check_values(trainer, 2, 0)
 
     def _check_values(self, trainer, current_iteration, current_epoch):
         self.assertEqual(trainer.trainer.global_step, current_iteration)

--- a/tests/trainers/lightning/test_loss.py
+++ b/tests/trainers/lightning/test_loss.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from mmf.common.report import Report
 from pytorch_lightning.callbacks.base import Callback
@@ -25,8 +25,9 @@ class TestLightningTrainerLoss(unittest.TestCase, Callback):
         mmf_trainer.training_loop()
 
         # compute lightning_trainer training losses
-        trainer = get_lightning_trainer(callback=self, max_steps=5)
-        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer = get_lightning_trainer(callback=self, max_steps=5)
+            trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
 
     def on_train_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx

--- a/tests/trainers/lightning/test_lr_schedule.py
+++ b/tests/trainers/lightning/test_lr_schedule.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from tests.trainers.test_utils import (
@@ -13,16 +13,17 @@ from tests.trainers.test_utils import (
 
 class TestLightningTrainerLRSchedule(unittest.TestCase):
     def test_lr_schedule(self):
-        # note, be aware some of the logic also is in the SimpleLightningModel
-        trainer1 = get_lightning_trainer(max_steps=8, lr_scheduler=True)
-        trainer1.trainer.fit(trainer1.model, trainer1.data_module.train_loader)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            # note, be aware some of the logic also is in the SimpleLightningModel
+            trainer1 = get_lightning_trainer(max_steps=8, lr_scheduler=True)
+            trainer1.trainer.fit(trainer1.model, trainer1.data_module.train_loader)
 
-        trainer2 = get_lightning_trainer(max_steps=8)
-        trainer2.trainer.fit(trainer2.model, trainer2.data_module.train_loader)
+            trainer2 = get_lightning_trainer(max_steps=8)
+            trainer2.trainer.fit(trainer2.model, trainer2.data_module.train_loader)
 
-        last_model_param1 = list(trainer1.model.parameters())[-1]
-        last_model_param2 = list(trainer2.model.parameters())[-1]
-        self.assertFalse(torch.allclose(last_model_param1, last_model_param2))
+            last_model_param1 = list(trainer1.model.parameters())[-1]
+            last_model_param2 = list(trainer2.model.parameters())[-1]
+            self.assertFalse(torch.allclose(last_model_param1, last_model_param2))
 
     def test_lr_schedule_compared_to_mmf_is_same(self):
         trainer_config = get_trainer_config()
@@ -32,10 +33,11 @@ class TestLightningTrainerLRSchedule(unittest.TestCase):
         mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
         mmf_trainer.training_loop()
 
-        trainer = get_lightning_trainer(max_steps=8, lr_scheduler=True)
-        trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
+        with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
+            trainer = get_lightning_trainer(max_steps=8, lr_scheduler=True)
+            trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
 
-        mmf_trainer.model.to(trainer.model.device)
-        last_model_param1 = list(mmf_trainer.model.parameters())[-1]
-        last_model_param2 = list(trainer.model.parameters())[-1]
-        self.assertTrue(torch.allclose(last_model_param1, last_model_param2))
+            mmf_trainer.model.to(trainer.model.device)
+            last_model_param1 = list(mmf_trainer.model.parameters())[-1]
+            last_model_param2 = list(trainer.model.parameters())[-1]
+            self.assertTrue(torch.allclose(last_model_param1, last_model_param2))

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -12,7 +12,7 @@ def get_trainer_config():
     return OmegaConf.create(
         {
             "distributed": {},
-            "run_type": "train",
+            "run_type": "train_val",
             "training": {
                 "trainer": "lightning",
                 "detect_anomaly": False,
@@ -20,8 +20,9 @@ def get_trainer_config():
                 "log_interval": 2,
                 "update_frequency": 1,
                 "fp16": False,
-                "lr_scheduler": False,
                 "batch_size": 1,
+                "lr_scheduler": False,
+                "tensorboard": False,
             },
             "evaluation": {"use_cpu": False},
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
@@ -29,18 +30,24 @@ def get_trainer_config():
                 "type": "warmup_linear",
                 "params": {"num_warmup_steps": 8, "num_training_steps": 8},
             },
+            "evaluation": {"metrics": []},
             "trainer": {
                 "type": "lightning",
                 "params": {
-                    "gpus": 0 if torch.cuda.is_available() else None,
+                    "gpus": 1 if torch.cuda.is_available() else 0,
                     "num_nodes": 1,
-                    "precision": 32,
+                    "checkpoint_callback": False,
                     "deterministic": True,
                     "benchmark": False,
                     "gradient_clip_val": 0.0,
-                    "val_check_interval": 1,
+                    "val_check_interval": 4,
                     "log_every_n_steps": 2,
-                    "checkpoint_callback": False,
+                    "progress_bar_refresh_rate": 0,
+                    "accumulate_grad_batches": 1,
+                    "precision": 32,
+                    "num_sanity_val_steps": 0,
+                    "limit_val_batches": 5,
+                    "logger": False,
                 },
             },
         }
@@ -57,10 +64,15 @@ def get_lightning_trainer(
     lr_scheduler=False,
     gradient_clip_val=0.0,
     precision=32,
+    prepare_trainer=True,
+    tensorboard=False,
+    **kwargs,
 ):
     torch.random.manual_seed(2)
+    trainer_config = get_trainer_config()
+    trainer_config.training.tensorboard = tensorboard
     trainer = LightningTrainerMock(
-        config=get_trainer_config(),
+        config=trainer_config,
         max_steps=max_steps,
         max_epochs=max_epochs,
         callback=callback,
@@ -69,14 +81,17 @@ def get_lightning_trainer(
         lr_scheduler=lr_scheduler,
         gradient_clip_val=gradient_clip_val,
         precision=precision,
+        **kwargs,
     )
     trainer.model = SimpleLightningModel(
         {"in_dim": model_size}, trainer_config=trainer.config
     )
     trainer.model.build()
     trainer.model.train()
+    trainer.model.build_meters(trainer.run_type)
     trainer.model.is_pl_enabled = True
-    prepare_lightning_trainer(trainer)
+    if prepare_trainer:
+        prepare_lightning_trainer(trainer)
     return trainer
 
 
@@ -89,12 +104,18 @@ def get_mmf_trainer(
     fp16=False,
     scheduler_config=None,
     grad_clipping_config=None,
+    evaluation_interval=4,
+    log_interval=1,
+    batch_size=1,
+    tensorboard=False,
 ):
     torch.random.manual_seed(2)
     model = SimpleModel({"in_dim": model_size})
     model.build()
     model.train()
     trainer_config = get_trainer_config()
+    trainer_config.training.evaluation_interval = evaluation_interval
+    trainer_config.training.log_interval = log_interval
     optimizer = build_optimizer(model, trainer_config)
     trainer = TrainerTrainingLoopMock(
         num_data_size,
@@ -102,10 +123,12 @@ def get_mmf_trainer(
         max_epochs,
         config=trainer_config,
         optimizer=optimizer,
-        on_update_end_fn=on_update_end_fn,
         fp16=fp16,
+        on_update_end_fn=on_update_end_fn,
         scheduler_config=scheduler_config,
         grad_clipping_config=grad_clipping_config,
+        batch_size=batch_size,
+        tensorboard=tensorboard,
     )
     trainer.load_datasets()
     model.to(trainer.device)
@@ -116,4 +139,23 @@ def get_mmf_trainer(
 def prepare_lightning_trainer(trainer):
     trainer.configure_device()
     trainer._calculate_max_updates()
+    trainer.load_metrics()
+    trainer._load_loggers()
     trainer._load_trainer()
+
+
+def run_lightning_trainer_with_callback(trainer, callback, on_fit_start_callback=None):
+    callback.lightning_trainer = trainer
+    callback.trainer_config = trainer.trainer_config
+    callback.training_config = trainer.training_config
+    trainer._callbacks = [callback]
+
+    prepare_lightning_trainer(trainer)
+    if on_fit_start_callback:
+        on_fit_start_callback()
+
+    trainer.trainer.fit(
+        trainer.model,
+        train_dataloader=trainer.train_loader,
+        val_dataloaders=trainer.val_loader,
+    )


### PR DESCRIPTION
- [x] MVP 1. Evaluation and Logging - Eval accuracy parity between mmf_trainer and lightning_trainer
  -  [X] Validation at the right frequency and at the end (also calculate the right metrics)
  -  [X] Do logging (same logging format with slight difference is ok)
- [x] Tests - tests only done for pytorch lightning integration
  - [X] test logging values are the same as `mmf_trainer`'s logging values
  - [X] test eval values are the same as `mmf_trainer`'s eval values
  - [x] test tensorboard logging the same as `mmf_trainer`'s
- [ ] Blocked:
  - [ ] One Epoch Evaluation Run after train: [PR4945](https://github.com/PyTorchLightning/pytorch-lightning/pull/4945/files) and [PR4948](https://github.com/PyTorchLightning/pytorch-lightning/pull/4948/files) 
