### PR TITLE
[refactor,tests,fix] Clean up and fix a bug in MMFT; add extensive tests

### DIFF
--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -142,10 +142,6 @@ class HuggingfaceEmbeddings(nn.Module):
         ):
             modality_name = self.modality_keys[idx]
             total_embedding = token_emb(tokens_ids[modality_name])
-            # In case of direct features, there might be only two dims, B X D
-            # Convert them B X 1 X D.
-            if total_embedding.dim() == 2:
-                total_embedding = total_embedding.unsqueeze(dim=1)
 
             if modality_name in position_ids:
                 total_embedding += pos_emb(position_ids[modality_name])

--- a/tests/models/test_mmf_transformer.py
+++ b/tests/models/test_mmf_transformer.py
@@ -3,8 +3,11 @@
 import unittest
 
 import tests.test_utils as test_utils
+import torch
+from mmf.common.sample import SampleList
 from mmf.models.mmf_transformer import MMFTransformer, MMFTransformerModalityConfig
 from mmf.modules.encoders import (
+    EncoderFactory,
     IdentityEncoder,
     ImageEncoderFactory,
     ImageEncoderTypes,
@@ -158,3 +161,269 @@ class TestMMFTransformerConfig(unittest.TestCase):
         config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
         mmft = build_model(config)
         self.assertIsNotNone(mmft)
+
+
+class TestMMFTransformer(unittest.TestCase):
+    def setUp(self):
+        test_utils.setup_proxy()
+        setup_imports()
+        self._image_modality_config = MMFTransformerModalityConfig(
+            type="image",
+            key="image",
+            embedding_dim=256,
+            position_dim=1,
+            segment_id=0,
+            encoder=ImageEncoderFactory.Config(type=ImageEncoderTypes.identity),
+        )
+        self._text_modality_config = MMFTransformerModalityConfig(
+            type="text",
+            key="text",
+            embedding_dim=756,
+            position_dim=128,
+            segment_id=1,
+            encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+        )
+
+    def test_one_dim_feature_preprocessing(self):
+        modalities_config = [self._image_modality_config, self._text_modality_config]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+        mmft = build_model(config)
+
+        sample_list = SampleList()
+        sample_list.image = torch.rand(2, 256)
+        sample_list.text = torch.randint(0, 512, (2, 128))
+
+        transformer_input = mmft.preprocess_sample(sample_list)
+        input_ids = transformer_input.input_ids
+        self.assertEqual(input_ids["image"].dim(), 3)
+        self.assertEqual(list(input_ids["image"].size()), [2, 1, 256])
+
+        self.assertEqual(input_ids["text"].dim(), 2)
+        self.assertEqual(list(input_ids["text"].size()), [2, 128])
+
+        position_ids = transformer_input.position_ids
+        test_utils.compare_tensors(position_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(
+            position_ids["text"], torch.arange(0, 128).unsqueeze(0).expand((2, 128))
+        )
+
+        masks = transformer_input.masks
+        masks = mmft._infer_masks(sample_list, input_ids)
+        test_utils.compare_tensors(masks["image"], torch.tensor([[1], [1]]))
+        test_utils.compare_tensors(masks["text"], torch.ones((2, 128)).long())
+
+        segment_ids = transformer_input.segment_ids
+        test_utils.compare_tensors(segment_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(segment_ids["text"], torch.ones((2, 128)).long())
+
+        mlm_labels_list = transformer_input.mlm_labels_list
+        test_utils.compare_tensors(
+            torch.cat(mlm_labels_list, dim=-1),
+            torch.full((2, 129), dtype=torch.long, fill_value=-1),
+        )
+
+    def test_stacked_feature_preprocessing(self):
+        self._text_modality_config.key = "body"
+        second_text_modality_config = MMFTransformerModalityConfig(
+            type="text",
+            key="ocr",
+            embedding_dim=756,
+            position_dim=128,
+            segment_id=2,
+            encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+        )
+
+        modalities_config = [
+            self._image_modality_config,
+            self._text_modality_config,
+            second_text_modality_config,
+        ]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+        mmft = build_model(config)
+
+        sample_list = SampleList()
+        sample_list.image = torch.rand(2, 256)
+        # In stacked case, input_ids should represent all texts
+        sample_list.input_ids = torch.randint(0, 512, (2, 2, 128))
+        sample_list.lm_label_ids = torch.randint(-1, 30522, (2, 2, 128))
+        lm_labels_sum = sample_list.lm_label_ids.sum().item()
+
+        transformer_input = mmft.preprocess_sample(sample_list)
+        self._compare_processed_for_multimodality(transformer_input, lm_labels_sum)
+
+    def test_modality_key_preprocessing(self):
+        self._text_modality_config.key = "body"
+        second_text_modality_config = MMFTransformerModalityConfig(
+            type="text",
+            key="ocr",
+            embedding_dim=756,
+            position_dim=128,
+            segment_id=2,
+            encoder=TextEncoderFactory.Config(type=TextEncoderTypes.identity),
+        )
+
+        modalities_config = [
+            self._image_modality_config,
+            self._text_modality_config,
+            second_text_modality_config,
+        ]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+        mmft = build_model(config)
+
+        sample_list = SampleList()
+        sample_list.image = torch.rand(2, 256)
+        sample_list.body = torch.randint(0, 512, (2, 128))
+        sample_list.ocr = torch.randint(0, 512, (2, 128))
+        sample_list.lm_label_ids = torch.randint(-1, 30522, (2, 128))
+        lm_labels_sum = sample_list.lm_label_ids.sum().item() * 2
+
+        transformer_input = mmft.preprocess_sample(sample_list)
+        self._compare_processed_for_multimodality(transformer_input, lm_labels_sum)
+
+    def _compare_processed_for_multimodality(self, transformer_input, lm_labels_sum=0):
+        input_ids = transformer_input.input_ids
+        self.assertEqual(input_ids["image"].dim(), 3)
+        self.assertEqual(list(input_ids["image"].size()), [2, 1, 256])
+
+        self.assertEqual(input_ids["body"].dim(), 2)
+        self.assertEqual(list(input_ids["body"].size()), [2, 128])
+
+        self.assertEqual(input_ids["ocr"].dim(), 2)
+        self.assertEqual(list(input_ids["ocr"].size()), [2, 128])
+
+        # Test specific modality keys case
+        # Test encoder with resnet
+        # Test input_mask case, test modality_mask case
+
+        position_ids = transformer_input.position_ids
+        test_utils.compare_tensors(position_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(
+            position_ids["body"], torch.arange(0, 128).unsqueeze(0).expand((2, 128))
+        )
+        test_utils.compare_tensors(
+            position_ids["ocr"], torch.arange(0, 128).unsqueeze(0).expand((2, 128))
+        )
+
+        masks = transformer_input.masks
+        test_utils.compare_tensors(masks["image"], torch.tensor([[1], [1]]))
+        test_utils.compare_tensors(masks["body"], torch.ones((2, 128)).long())
+        test_utils.compare_tensors(masks["ocr"], torch.ones((2, 128)).long())
+
+        segment_ids = transformer_input.segment_ids
+        test_utils.compare_tensors(segment_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(segment_ids["body"], torch.ones((2, 128)).long())
+        test_utils.compare_tensors(
+            segment_ids["ocr"],
+            torch.full((2, 128), dtype=torch.long, fill_value=2).long(),
+        )
+
+        mlm_labels_list = transformer_input.mlm_labels_list
+        self.assertEqual(list(torch.cat(mlm_labels_list, dim=-1).size()), [2, 257])
+        # -2 is for image negative labels
+        self.assertEqual(
+            torch.cat(mlm_labels_list, dim=-1).sum().item(), lm_labels_sum - 2
+        )
+
+    def test_custom_feature_and_mask_preprocessing(self):
+        extra_modality = MMFTransformerModalityConfig(
+            type="my_random_feature",
+            key="my_random_feature",
+            embedding_dim=128,
+            position_dim=4,
+            segment_id=3,
+            encoder=EncoderFactory.Config(type="identity"),
+        )
+
+        modalities_config = [
+            self._image_modality_config,
+            self._text_modality_config,
+            extra_modality,
+        ]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+        mmft = build_model(config)
+
+        sample_list = SampleList()
+        sample_list.image = torch.rand(2, 256)
+        sample_list.text = torch.randint(0, 512, (2, 128))
+        sample_list.text_mask = torch.ones(2, 128)
+        sample_list.text_mask[:, 70:] = 0
+        sample_list.my_random_feature = torch.rand(2, 4, 128)
+        sample_list.my_random_feature_mask = torch.ones(2, 4)
+        sample_list.my_random_feature_mask[:, 3:] = 0
+
+        transformer_input = mmft.preprocess_sample(sample_list)
+        input_ids = transformer_input.input_ids
+        self.assertEqual(input_ids["image"].dim(), 3)
+        self.assertEqual(list(input_ids["image"].size()), [2, 1, 256])
+
+        self.assertEqual(input_ids["text"].dim(), 2)
+        self.assertEqual(list(input_ids["text"].size()), [2, 128])
+
+        self.assertEqual(input_ids["my_random_feature"].dim(), 3)
+        self.assertEqual(list(input_ids["my_random_feature"].size()), [2, 4, 128])
+
+        position_ids = transformer_input.position_ids
+        test_utils.compare_tensors(position_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(
+            position_ids["text"], torch.arange(0, 128).unsqueeze(0).expand((2, 128))
+        )
+        test_utils.compare_tensors(
+            position_ids["my_random_feature"],
+            torch.arange(0, 4).unsqueeze(0).expand((2, 4)),
+        )
+
+        masks = transformer_input.masks
+        test_utils.compare_tensors(masks["image"], torch.tensor([[1], [1]]))
+        self.assertEqual(masks["text"].sum().item(), 140)
+        self.assertEqual(masks["my_random_feature"].sum().item(), 6)
+
+        segment_ids = transformer_input.segment_ids
+        test_utils.compare_tensors(segment_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(segment_ids["text"], torch.ones((2, 128)).long())
+        test_utils.compare_tensors(
+            segment_ids["my_random_feature"],
+            torch.full((2, 4), dtype=torch.long, fill_value=3).long(),
+        )
+
+    def test_preprocessing_with_resnet_encoder(self):
+        self._image_modality_config = MMFTransformerModalityConfig(
+            type="image",
+            key="image",
+            embedding_dim=2048,
+            position_dim=1,
+            segment_id=0,
+            encoder=ImageEncoderFactory.Config(
+                type=ImageEncoderTypes.resnet152,
+                params=ResNet152ImageEncoder.Config(pretrained=False),
+            ),
+        )
+        modalities_config = [self._image_modality_config, self._text_modality_config]
+        config = MMFTransformer.Config(modalities=modalities_config, num_labels=2)
+        mmft = build_model(config)
+
+        sample_list = SampleList()
+        sample_list.image = torch.rand(2, 3, 224, 224)
+        sample_list.text = torch.randint(0, 512, (2, 128))
+
+        transformer_input = mmft.preprocess_sample(sample_list)
+
+        input_ids = transformer_input.input_ids
+        self.assertEqual(input_ids["image"].dim(), 3)
+        self.assertEqual(list(input_ids["image"].size()), [2, 1, 2048])
+
+        self.assertEqual(input_ids["text"].dim(), 2)
+        self.assertEqual(list(input_ids["text"].size()), [2, 128])
+
+        position_ids = transformer_input.position_ids
+        test_utils.compare_tensors(position_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(
+            position_ids["text"], torch.arange(0, 128).unsqueeze(0).expand((2, 128))
+        )
+
+        masks = transformer_input.masks
+        test_utils.compare_tensors(masks["image"], torch.tensor([[1], [1]]))
+        test_utils.compare_tensors(masks["text"], torch.ones((2, 128)).long())
+
+        segment_ids = transformer_input.segment_ids
+        test_utils.compare_tensors(segment_ids["image"], torch.tensor([[0], [0]]))
+        test_utils.compare_tensors(segment_ids["text"], torch.ones((2, 128)).long())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -161,6 +161,7 @@ def setup_proxy():
         os.getenv("SANDCASTLE") == "1"
         or os.getenv("TW_JOB_USER") == "sandcastle"
         or socket.gethostname().startswith("dev")
+        or "fbinfra" in socket.gethostname()
     ):
         os.environ["HTTPS_PROXY"] = "http://fwdproxy:8080"
         os.environ["HTTP_PROXY"] = "http://fwdproxy:8080"


### PR DESCRIPTION
The diff address a bug that was introduced in text position ids by a
recent change in #760. The fix is to actually make single feature dim
modalities B X 1 X D before passing to backend instead of making
multiple assumption in backend layer which tend to be conflicting with
text input ids. This also adds some comments to better explain stack
version of text.

The PR also refactors MMFT to be more readble and reduce cyclomatic
complexity.

Finally, this PR adds extensive tests to make sure a change like #760
doesn't break MMFT again.

Test Plan:
Adds extensive tests for MMFT

Differential Revision: D26410408

