### PR TITLE
[fix] Don't show warning for missing is_xla in registry

### DIFF
--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -42,7 +42,7 @@ def synchronize(message="sync-workers"):
 
 
 def is_xla():
-    return registry.get("is_xla")
+    return registry.get("is_xla", no_warning=True)
 
 
 def get_rank():


### PR DESCRIPTION
Summary: The warning is plaguing the logs and should not be explicitly registered. This diff fixes that.

Differential Revision: D26480670

