### PR TITLE
[feat] Add batch_size_per_device training option

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -41,9 +41,13 @@ training:
     # Tensorboard control, by default tensorboard is disabled
     tensorboard: false
 
-    # Size of each batch. If distributed or data_parallel
+    # Size of the batch globally. If distributed or data_parallel
     # is used, this will be divided equally among GPUs
     batch_size: 512
+    # Size of the batch per GPU. Use this if you want to specify batch size
+    # per GPU instead of global batch size.
+    # Mutually exclusive with training.batch_size.
+    batch_size_per_device: null
     # Run update_frequency=K batches with batch_size=N, accumulate gradients, then do
     # one update (one optimizer step). The effect is a large effective batch size of
     # KxN (without incurring the memory overhead of setting batch_size to KxN).

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -253,8 +253,18 @@ def get_batch_size():
     from mmf.utils.configuration import get_global_config
 
     batch_size = get_global_config("training.batch_size")
-
     world_size = get_world_size()
+
+    batch_size_per_device = get_global_config("training.batch_size_per_device")
+
+    if batch_size_per_device is not None:
+        logger.info(
+            f"training.batch_size_per_device has been used as {batch_size_per_device} "
+            + "This will override training.batch_size and set the global batch size to "
+            + f"{batch_size_per_device} x {world_size} = "
+            + f"{batch_size_per_device * world_size}"
+        )
+        batch_size = batch_size_per_device * world_size
 
     if batch_size % world_size != 0:
         raise RuntimeError(

--- a/tests/trainers/lightning/test_utils.py
+++ b/tests/trainers/lightning/test_utils.py
@@ -21,6 +21,7 @@ def get_trainer_config():
                 "update_frequency": 1,
                 "fp16": False,
                 "lr_scheduler": False,
+                "batch_size": 1,
             },
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {


### PR DESCRIPTION
Summary: This will allow specifying batch size per device instead of default global batch size. If specified using `training.batch_size_per_device`, this will supersede the value specified in `training.batch_size` and information will be logged.

Differential Revision: D26480897

