### PR TITLE
[refactor] Refactor output type of MMFT preprocess_output

### DIFF
--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -184,22 +184,24 @@ class BaseTransformer(BaseModel):
         # Tie weights if required
         self.tie_weights()
 
-    def preprocess_sample(self, sample_list: Dict[str, Any]) -> BaseTransformerInput:
+    def preprocess_sample(
+        self, sample_list: Dict[str, Any]
+    ) -> Dict[str, Dict[str, Tensor]]:
         """Preprocess the sample_list and returns input ids, position ids, segment or
         token type ids and masks for different modalities.
 
         Returns:
-            BaseTransformerInput: BaseTransformerInput containing input_ids,
-                position_ids, segment_ids, masks
+            Dict[str, Dict[str, Tensor]]: containing input_ids, position_ids,
+                segment_ids, masks
         """
         return
 
     def forward(self, sample_list: Dict[str, Any]) -> Dict[str, Tensor]:
         r"""Forward pass of the model. The input sample_list can be preprocessed using
-        the preprocess_sample method which expects to return a BaseTransformerInput
-        object. BaseTransformerInput contains different properties of the input
-        modalities and the masks. These can be used to generate embeddings for each
-        modality and also create attention mask.
+        the preprocess_sample method which expects to return a
+        Dict[str, Dict[str, Tensor]] object. It contains different properties of the
+        input modalities and the masks. These can be used to generate embeddings for
+        each modality and also create attention mask.
 
         Flow of how the forward pass can be implemented using various modules in
         BaseTransformer:


### PR DESCRIPTION
Summary:
- Refactors the output type to be Dict[str, Dict[str, Tensor]]
- Namedtuples cannot be inherited to include new fields easily
- Dataclasses are not scriptable

Differential Revision: D26479261

