### PR TITLE
[fix] Improvement to VocabDict loader

### DIFF
--- a/mmf/utils/text.py
+++ b/mmf/utils/text.py
@@ -110,7 +110,7 @@ class VocabDict:
     UNK_INDEX = 3
 
     def __init__(self, vocab_file, data_dir=None):
-        if not os.path.isabs(vocab_file) and data_dir is not None:
+        if not PathManager.exists(vocab_file) and data_dir is not None:
             vocab_file = get_absolute_path(os.path.join(data_dir, vocab_file))
 
         if not PathManager.exists(vocab_file):


### PR DESCRIPTION
Summary: Upstream callers to VocabDict tend to pass `data_dir` which leads to inadverently concating it with the vocab_file path. We now skip this step if the path already exists

Differential Revision: D26601097

