### PR TITLE
[perf] use PathManager.get_local_path for loading checkpoint

### DIFF
--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -431,7 +431,8 @@ class Checkpoint:
         # Backwards compatibility to Pythia
         _hack_imports()
 
-        with PathManager.open(file, "rb") as f:
+        local_path = PathManager.get_local_path(file)
+        with PathManager.open(local_path, "rb") as f:
             if "cuda" in str(self.device):
                 return torch.load(f, map_location=self.device)
             else:


### PR DESCRIPTION
Summary: Switching to use PathManager.get_local_path instead of directly loading from Manifold to improve stability

Differential Revision: D26651178

