### PR TITLE
[feat] Inference API

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -56,3 +56,17 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ coding=utf-8
+ Copyright 2018, Antonio Mendoza Hao Tan, Mohit Bansal
+ Adapted From Facebook Inc, Detectron2
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.import copy

--- a/mmf/datasets/processors/__init__.py
+++ b/mmf/datasets/processors/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 from mmf.datasets.processors.bert_processors import MaskedTokenProcessor
+from mmf.datasets.processors.frcnn_processor import FRCNNPreprocess
 from mmf.datasets.processors.image_processors import TorchvisionTransforms
+from mmf.datasets.processors.prediction_processors import ArgMaxPredictionProcessor
 from mmf.datasets.processors.processors import (
     BaseProcessor,
     BBoxProcessor,
@@ -33,4 +35,6 @@ __all__ = [
     "CaptionProcessor",
     "MaskedTokenProcessor",
     "TorchvisionTransforms",
+    "FRCNNPreprocess",
+    "ArgMaxPredictionProcessor",
 ]

--- a/mmf/datasets/processors/frcnn_processor.py
+++ b/mmf/datasets/processors/frcnn_processor.py
@@ -1,0 +1,186 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+ coding=utf-8
+ Copyright 2018, Antonio Mendoza Hao Tan, Mohit Bansal
+ Adapted From Facebook Inc, Detectron2
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.import copy
+ """
+import os
+import sys
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import omegaconf
+import torch
+import torch.nn.functional as F
+from mmf.common.registry import registry
+from mmf.datasets.processors.processors import BaseProcessor
+from mmf.utils.download import get_image_from_url
+from PIL import Image
+
+
+class ResizeShortestEdge:
+    def __init__(self, short_edge_length: List[int], max_size: int = sys.maxsize):
+        """
+        Args:
+            short_edge_length (list[min, max])
+            max_size (int): maximum allowed longest edge length.
+        """
+        self.interp_method = "bilinear"
+        self.max_size = max_size
+        self.short_edge_length = short_edge_length
+
+    def __call__(self, imgs: List[torch.Tensor]):
+        img_augs = []
+        for img in imgs:
+            h, w = img.shape[:2]
+            # later: provide list and randomly choose index for resize
+            size = np.random.randint(
+                self.short_edge_length[0], self.short_edge_length[1] + 1
+            )
+            if size == 0:
+                return img
+            scale = size * 1.0 / min(h, w)
+            if h < w:
+                newh, neww = size, scale * w
+            else:
+                newh, neww = scale * h, size
+            if max(newh, neww) > self.max_size:
+                scale = self.max_size * 1.0 / max(newh, neww)
+                newh = newh * scale
+                neww = neww * scale
+            neww = int(neww + 0.5)
+            newh = int(newh + 0.5)
+
+            if img.dtype == np.uint8:
+                pil_image = Image.fromarray(img)
+                pil_image = pil_image.resize((neww, newh), Image.BILINEAR)
+                img = np.asarray(pil_image)
+            else:
+                img = img.permute(2, 0, 1).unsqueeze(0)  # 3, 0, 1)  # hw(c) -> nchw
+                img = F.interpolate(
+                    img, (newh, neww), mode=self.interp_method, align_corners=False
+                ).squeeze(0)
+            img_augs.append(img)
+
+        return img_augs
+
+
+@registry.register_processor("frcnn_preprocess")
+class FRCNNPreprocess(BaseProcessor):
+    @dataclass
+    class FRCNNPreprocessConfig:
+        model: omegaconf.DictConfig = omegaconf.MISSING
+        input: omegaconf.DictConfig = omegaconf.MISSING
+        size_divisibility: int = 0
+        pad_value: float = 0
+
+    def __init__(self, config: FRCNNPreprocessConfig, *args, **kwargs):
+        config_input = config.get("input", None)
+        assert config_input is not None
+        min_size_test = config_input.get("min_size_test", 800)
+        max_size_test = config_input.get("max_size_test", 1333)
+        self.aug = ResizeShortestEdge([min_size_test, min_size_test], max_size_test)
+        self.input_format = config_input.get("format", "BGR")
+        self.size_divisibility = config.get("size_divisibility", 0)
+        self.pad_value = config.get("pad_value", 0)
+        self.max_image_size = max_size_test
+        config_model = config.get("model", None)
+        assert config_model is not None
+        self.device = config_model.get("device", "cpu")
+        config_pixel_std = config_model.get("pixel_std", [1.0, 1.0, 1.0])
+        self.pixel_std = (
+            torch.tensor(config_pixel_std)
+            .to(self.device)
+            .view(len(config_pixel_std), 1, 1)
+        )
+        config_pixel_mean = config_model.get(
+            "pixel_mean", [102.9801, 115.9465, 122.7717]
+        )
+        self.pixel_mean = (
+            torch.tensor(config_pixel_mean)
+            .to(self.device)
+            .view(len(config_pixel_std), 1, 1)
+        )
+        self.normalizer = lambda x: (x - self.pixel_mean) / self.pixel_std
+
+    def pad(self, images: List[torch.Tensor]):
+        max_size = tuple(max(s) for s in zip(*[img.shape for img in images]))
+        image_sizes = [im.shape[-2:] for im in images]
+        images = [
+            F.pad(
+                im,
+                [0, max_size[-1] - size[1], 0, max_size[-2] - size[0]],
+                value=self.pad_value,
+            )
+            for size, im in zip(image_sizes, images)
+        ]
+
+        return torch.stack(images), torch.tensor(image_sizes)
+
+    def __call__(self, images: torch.Tensor, single_image: bool = False):
+        """
+        Takes images of variable sizes, returns preprocessed
+        version based on config sizing, etc.
+        """
+        with torch.no_grad():
+            if not isinstance(images, list):
+                images = [images]
+            if single_image:
+                assert len(images) == 1
+            for i in range(len(images)):
+                if isinstance(images[i], torch.Tensor):
+                    images.insert(i, images.pop(i).to(self.device).float())
+                elif not isinstance(images[i], torch.Tensor):
+                    images.insert(
+                        i,
+                        torch.as_tensor(
+                            img_tensorize(images.pop(i), input_format=self.input_format)
+                        )
+                        .to(self.device)
+                        .float(),
+                    )
+            # resize smallest edge
+            raw_sizes = torch.tensor([im.shape[:2] for im in images])
+            images = self.aug(images)
+
+            # flip rgb to bgr
+            for idx in range(len(images)):
+                images[idx] = torch.flip(images[idx], [0])
+            # transpose images and convert to torch tensors
+            # images = [torch.as_tensor(i.astype("float32"))
+            # .permute(2, 0, 1).to(self.device) for i in images]
+            # now normalize before pad to avoid useless arithmetic
+            images = [self.normalizer(x) for x in images]
+            # now pad them to do the following operations
+            images, sizes = self.pad(images)
+            # Normalize
+
+            if self.size_divisibility > 0:
+                raise NotImplementedError()
+            # pad
+            scales_yx = torch.true_divide(raw_sizes, sizes)
+            if single_image:
+                return images[0], sizes[0], scales_yx[0]
+            else:
+                return images, sizes, scales_yx
+
+
+def img_tensorize(im: str):
+    assert isinstance(im, str)
+    if os.path.isfile(im):
+        img = np.array(Image.open(im))
+    else:
+        img = get_image_from_url(im)
+        assert img is not None, f"could not connect to: {im}"
+    return img

--- a/mmf/models/__init__.py
+++ b/mmf/models/__init__.py
@@ -8,6 +8,7 @@ from .lorra import LoRRA
 from .top_down_bottom_up import TopDownBottomUp
 from .butd import BUTD
 from .mmbt import MMBT, MMBTForClassification, MMBTForPreTraining
+from .mmf_transformer import MMFTransformer
 from .cnn_lstm import CNNLSTM
 from .m4c import M4C
 from .m4c_captioner import M4CCaptioner
@@ -34,6 +35,7 @@ __all__ = [
     "M4C",
     "M4CCaptioner",
     "MMBT",
+    "MMFTransformer",
     "VisualBERT",
     "ViLBERT",
     "UnimodalBase",

--- a/mmf/models/frcnn.py
+++ b/mmf/models/frcnn.py
@@ -1,0 +1,263 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+ coding=utf-8
+ Copyright 2018, Antonio Mendoza Hao Tan, Mohit Bansal
+ Adapted From Facebook Inc, Detectron2 && Huggingface Co.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.import copy
+ """
+
+from typing import List
+
+import omegaconf
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+try:
+    from detectron2.layers.batch_norm import get_norm
+    from detectron2.layers.wrappers import Conv2d
+    from detectron2.modeling import ShapeSpec
+    from detectron2.modeling.backbone.resnet import BottleneckBlock, ResNet
+    from detectron2.modeling.proposal_generator.rpn import RPN, StandardRPNHead
+    from detectron2.modeling.roi_heads.roi_heads import Res5ROIHeads
+    from detectron2.structures.image_list import ImageList
+except ImportError:
+    pass
+
+
+def build_backbone(config: omegaconf.DictConfig):
+    """
+    Difference between this and the build_backbone provided
+    by detectron2 is as follows:
+    - Different stem, include caffe_maxpool
+    - Number of blocks is different, unconfigurable in detectron
+    - Freeze-at operates differently in detectron
+    """
+    input_shape = ShapeSpec(channels=len(config.MODEL.PIXEL_MEAN))
+    norm = config.MODEL.RESNETS.NORM
+    stem = BasicStem(
+        in_channels=input_shape.channels,
+        out_channels=config.MODEL.RESNETS.STEM_OUT_CHANNELS,
+        norm=norm,
+        caffe_maxpool=config.MODEL.MAX_POOL,
+    )
+    freeze_at = config.MODEL.BACKBONE.FREEZE_AT
+
+    if freeze_at >= 1:
+        for p in stem.parameters():
+            p.requires_grad = False
+
+    out_features = config.MODEL.RESNETS.OUT_FEATURES
+    depth = config.MODEL.RESNETS.DEPTH
+    num_groups = config.MODEL.RESNETS.NUM_GROUPS
+    width_per_group = config.MODEL.RESNETS.WIDTH_PER_GROUP
+    bottleneck_channels = num_groups * width_per_group
+    in_channels = config.MODEL.RESNETS.STEM_OUT_CHANNELS
+    out_channels = config.MODEL.RESNETS.RES2_OUT_CHANNELS
+    stride_in_1x1 = config.MODEL.RESNETS.STRIDE_IN_1X1
+    res5_dilation = config.MODEL.RESNETS.RES5_DILATION
+    assert res5_dilation in {1, 2}, f"res5_dilation cannot be {res5_dilation}."
+
+    num_blocks_per_stage = {50: [3, 4, 6, 3], 101: [3, 4, 23, 3], 152: [3, 8, 36, 3]}[
+        depth
+    ]
+
+    stages = []
+    out_stage_idx = [
+        {"res2": 2, "res3": 3, "res4": 4, "res5": 5}[f] for f in out_features
+    ]
+    max_stage_idx = max(out_stage_idx)
+    for idx, stage_idx in enumerate(range(2, max_stage_idx + 1)):
+        dilation = res5_dilation if stage_idx == 5 else 1
+        first_stride = 1 if idx == 0 or (stage_idx == 5 and dilation == 2) else 2
+        stage_kargs = {
+            "num_blocks": num_blocks_per_stage[idx],
+            "stride_per_block": [first_stride] + [1] * (num_blocks_per_stage[idx] - 1),
+            "in_channels": in_channels,
+            "bottleneck_channels": bottleneck_channels,
+            "out_channels": out_channels,
+            "num_groups": num_groups,
+            "norm": norm,
+            "stride_in_1x1": stride_in_1x1,
+            "dilation": dilation,
+        }
+
+        stage_kargs["block_class"] = BottleneckBlock
+        blocks = ResNet.make_stage(**stage_kargs)
+        in_channels = out_channels
+        out_channels *= 2
+        bottleneck_channels *= 2
+
+        stages.append(blocks)
+
+    return ResNet(stem, stages, out_features=out_features, freeze_at=-1)
+
+
+class BasicStem(nn.Module):
+    """
+    The differences between this and detectron:
+    - The forward method uses caffe_maxpool
+      this is not configurable in detectron
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 64,
+        norm: str = "BN",
+        caffe_maxpool: bool = False,
+    ):
+        super().__init__()
+        self.conv1 = Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=7,
+            stride=2,
+            padding=3,
+            bias=False,
+            norm=get_norm(norm, out_channels),
+        )
+        self.caffe_maxpool = caffe_maxpool
+        # use pad 1 instead of pad zero
+
+    def forward(self, x: torch.Tensor):
+        x = self.conv1(x)
+        x = F.relu_(x)
+        if self.caffe_maxpool:
+            x = F.max_pool2d(x, kernel_size=3, stride=2, padding=0, ceil_mode=True)
+        else:
+            x = F.max_pool2d(x, kernel_size=3, stride=2, padding=1)
+        return x
+
+    @property
+    def out_channels(self):
+        return self.conv1.out_channels
+
+    @property
+    def stride(self):
+        return 4  # = stride 2 conv -> stride 2 max pool
+
+
+class GeneralizedRCNN(nn.Module):
+    def __init__(self, config: omegaconf.DictConfig):
+        super().__init__()
+        self.device = torch.device(config.MODEL.DEVICE)
+        self.backbone = build_backbone(config)
+        self.proposal_generator = RPN(config, self.backbone.output_shape())
+        self._fix_proposal_generator(config)
+        self.roi_heads = Res5ROIHeads(config, self.backbone.output_shape())
+        self._fix_res5_block(config)
+        self.to(self.device)
+
+    def _fix_proposal_generator(self, config: omegaconf.DictConfig):
+        in_channels = [
+            val.channels for key, val in self.backbone.output_shape().items()
+        ]
+        assert len(set(in_channels)) == 1, "Each level must have the same channel!"
+        in_channels = in_channels[0]
+        if config.MODEL.PROPOSAL_GENERATOR.HIDDEN_CHANNELS == -1:
+            hid_channels = in_channels
+        else:
+            hid_channels = config.MODEL.PROPOSAL_GENERATOR.HIDDEN_CHANNELS
+        self.proposal_generator.rpn_head.conv = nn.Conv2d(
+            in_channels, hid_channels, kernel_size=3, stride=1, padding=1
+        )
+        shape = self.backbone.output_shape()
+        features = config.MODEL.RPN.IN_FEATURES
+        example_head = StandardRPNHead.from_config(config, [shape[f] for f in features])
+        num_cell_anchors = example_head["num_anchors"]
+        box_dim = example_head["box_dim"]
+        self.proposal_generator.rpn_head.objectness_logits = nn.Conv2d(
+            hid_channels, num_cell_anchors, kernel_size=1, stride=1
+        )
+        self.proposal_generator.rpn_head.anchor_deltas = nn.Conv2d(
+            hid_channels, num_cell_anchors * box_dim, kernel_size=1, stride=1
+        )
+
+    def _fix_res5_block(self, config: omegaconf.DictConfig):
+        res5_halve = config.MODEL.ROI_BOX_HEAD.RES5HALVE
+        if not res5_halve:
+            """
+            Modifications for VG in RoI heads:
+            1. Change the stride of conv1 and shortcut in Res5.Block1 from 2 to 1
+            2. Modifying all conv2 with (padding: 1 --> 2) and (dilation: 1 --> 2)
+            """
+            self.roi_heads.res5[0].conv1.stride = (1, 1)
+            self.roi_heads.res5[0].shortcut.stride = (1, 1)
+            for i in range(3):
+                self.roi_heads.res5[i].conv2.padding = (2, 2)
+                self.roi_heads.res5[i].conv2.dilation = (2, 2)
+
+    def forward_for_roi_head(self, features: List, proposal_boxes: List):
+        box_features = self.roi_heads._shared_roi_transform(features, proposal_boxes)
+        feature_pooled = box_features.mean(dim=[2, 3])  # pooled to 1x1
+        return feature_pooled
+
+    def forward(
+        self,
+        images: torch.Tensor,
+        image_shapes: torch.Tensor,
+        gt_boxes: torch.Tensor = None,
+        proposals: torch.Tensor = None,
+        scales_yx: torch.Tensor = None,
+        **kwargs,
+    ):
+        """
+        kwargs:
+            max_detections (int), return_tensors {"np", "pt", None}, padding {None,
+            "max_detections"}, pad_value (int), location = {"cuda", "cpu"}
+        """
+        if self.training:
+            raise NotImplementedError()
+        return self.inference(
+            images=images,
+            image_shapes=image_shapes,
+            gt_boxes=gt_boxes,
+            proposals=proposals,
+            scales_yx=scales_yx,
+            **kwargs,
+        )
+
+    @torch.no_grad()
+    def inference(
+        self,
+        images: torch.Tensor,
+        image_shapes: torch.Tensor,
+        gt_boxes: torch.Tensor = None,
+        proposals: torch.Tensor = None,
+        scales_yx: torch.Tensor = None,
+        **kwargs,
+    ):
+        # run images through backbone
+        features = self.backbone(images)
+
+        image_list = ImageList(images, image_shapes)
+
+        # generate proposals if none are available
+        if proposals is None:
+            proposal_boxes, _ = self.proposal_generator(image_list, features, gt_boxes)
+        else:
+            assert proposals is not None
+
+        proposal_boxes = [proposal_boxes[0].get_fields()["proposal_boxes"]]
+
+        feature_pooled = self.forward_for_roi_head([features["res4"]], proposal_boxes)
+
+        preds_per_image = [p.size(0) for p in [proposal_boxes[0].tensor]]
+
+        roi_features = feature_pooled.split(preds_per_image, dim=0)
+
+        return roi_features

--- a/mmf/utils/features/visualizing_image.py
+++ b/mmf/utils/features/visualizing_image.py
@@ -26,7 +26,7 @@ import numpy as np
 import requests
 import torch
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from mmf.utils.download import get_image_from_url
+from mmf.datasets.processors.frcnn_processor import img_tensorize
 from PIL import Image
 
 
@@ -51,16 +51,6 @@ def get_data(query: str, delim: str = ","):
                 data = data.split("\n")
         req.close()
     return data
-
-
-def img_tensorize(im: str):
-    assert isinstance(im, str)
-    if os.path.isfile(im):
-        img = np.array(Image.open(im))
-    else:
-        img = get_image_from_url(im)
-        assert img is not None, f"could not connect to: {im}"
-    return img
 
 
 class SingleImageViz:

--- a/mmf/utils/inference.py
+++ b/mmf/utils/inference.py
@@ -1,0 +1,76 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import numpy as np
+import requests
+import torch
+from mmf.common.report import Report
+from mmf.common.sample import Sample, SampleList
+from mmf.utils.build import build_encoder, build_model, build_processors
+from mmf.utils.checkpoint import load_pretrained_model
+from mmf.utils.general import get_current_device
+from omegaconf import OmegaConf
+from PIL import Image
+
+
+class Inference:
+    def __init__(self, checkpoint_path: str = None):
+        self.checkpoint = checkpoint_path
+        assert self.checkpoint is not None
+        self.processor, self.feature_extractor, self.model = self._build_model()
+
+    def _build_model(self):
+        self.model_items = load_pretrained_model(self.checkpoint)
+        self.config = OmegaConf.create(self.model_items["full_config"])
+        dataset_name = list(self.config.dataset_config.keys())[0]
+        processor = build_processors(
+            self.config.dataset_config[dataset_name].processors
+        )
+        feature_extractor = build_encoder(
+            self.model_items["config"].image_feature_encodings
+        )
+        ckpt = self.model_items["checkpoint"]
+        model = build_model(self.model_items["config"])
+        model.load_state_dict(ckpt)
+
+        return processor, feature_extractor, model
+
+    def forward(self, image_path: str, text: dict, image_format: str = "path"):
+        text_output = self.processor["text_processor"](text)
+        if image_format == "path":
+            img = np.array(Image.open(image_path))
+        elif image_format == "url":
+            img = np.array(Image.open(requests.get(image_path, stream=True).raw))
+        img = torch.as_tensor(img)
+
+        if self.model_items["config"].image_feature_encodings.type == "frcnn":
+            max_detect = self.model_items[
+                "config"
+            ].image_feature_encodings.params.max_detections
+            image_preprocessed, sizes, scales_yx = self.processor["image_processor"](
+                img
+            )
+            image_output = self.feature_extractor(
+                image_preprocessed,
+                sizes=sizes,
+                scales_yx=scales_yx,
+                padding=None,
+                max_detections=max_detect,
+                return_tensors="pt",
+            )
+            image_output = image_output[0]
+        else:
+            image_preprocessed = self.processor["image_processor"](img)
+            image_output = self.feature_extractor(image_preprocessed)
+
+        sample = Sample(text_output)
+        sample.image_feature_0 = image_output
+        sample_list = SampleList([sample])
+        sample_list = sample_list.to(get_current_device())
+        self.model = self.model.to(get_current_device())
+        output = self.model(sample_list)
+        sample_list.id = [sample_list.input_ids[0][0]]
+        report = Report(sample_list, output)
+        answers = self.processor["output_processor"](report)
+        answer = self.processor["answer_processor"].idx2word(answers[0]["answer"])
+
+        return answer

--- a/mmf/utils/visualize.py
+++ b/mmf/utils/visualize.py
@@ -5,7 +5,8 @@ from typing import Any, List, Optional, Tuple
 import numpy as np
 import torch
 import torchvision
-from mmf.utils.features.visualizing_image import SingleImageViz, img_tensorize
+from mmf.datasets.processors.frcnn_processor import img_tensorize
+from mmf.utils.features.visualizing_image import SingleImageViz
 from PIL import Image
 
 

--- a/tools/scripts/features/frcnn/frcnn_utils.py
+++ b/tools/scripts/features/frcnn/frcnn_utils.py
@@ -22,18 +22,15 @@ import pickle as pkl
 import shutil
 import tarfile
 from collections import OrderedDict
-from io import BytesIO
 from pathlib import Path
 from urllib.parse import urlparse
 from zipfile import ZipFile, is_zipfile
 
-import cv2
 import numpy as np
 import requests
 from filelock import FileLock
 from mmf.utils.configuration import get_mmf_cache_dir
 from omegaconf import OmegaConf
-from PIL import Image
 
 
 mmf_cache_home = get_mmf_cache_dir()
@@ -315,22 +312,3 @@ def get_data(query, delim=","):
                 data = data.split("\n")
         req.close()
     return data
-
-
-def get_image_from_url(url):
-    response = requests.get(url)
-    img = np.array(Image.open(BytesIO(response.content)))
-    return img
-
-
-def img_tensorize(im, input_format="RGB"):
-    assert isinstance(im, str)
-    if os.path.isfile(im):
-        img = cv2.imread(im)
-    else:
-        img = get_image_from_url(im)
-        assert img is not None, f"could not connect to: {im}"
-    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    if input_format == "RGB":
-        img = img[:, :, ::-1]
-    return img


### PR DESCRIPTION
Added an API to run inference in these
use cases:
- region features -> mmft
- region features -> visual_bert

Based on configs, some are provided here,
users can run inference on various
trained models with something as simple
as an image URL and a text query.

Would love for people to take a look and provide
feedback about my coding style and design choices.

If you want to run it on your own you can pull and run 
```
from mmf.utils.inference import Inference

if __name__ == "__main__":
    inference = Inference(checkpoint_path="/checkpoint/brettallen/visualbert")
    answer = inference.forward(
        "http://i.imgur.com/1IWZX69.jpg",
        {"text": "what type of shoes is the woman in pink wearing"},
        image_format="url",
    )
    print(answer)
```