### PR TITLE
[feat] Add VISSL dataset, model wrapper, ViT and DeiT (#144)

### DIFF
--- a/mmf/modules/metrics.py
+++ b/mmf/modules/metrics.py
@@ -235,8 +235,10 @@ class Accuracy(BaseMetric):
     **Key:** ``accuracy``
     """
 
-    def __init__(self):
+    def __init__(self, score_key="scores"):
         super().__init__("accuracy")
+        self.score_key = score_key
+        self.required_params = [score_key, "targets"]
 
     def calculate(self, sample_list, model_output, *args, **kwargs):
         """Calculate accuracy and return it back.
@@ -250,7 +252,7 @@ class Accuracy(BaseMetric):
             torch.FloatTensor: accuracy.
 
         """
-        output = model_output["scores"]
+        output = model_output[self.score_key]
         expected = sample_list["targets"]
 
         assert (

--- a/mmf/utils/env.py
+++ b/mmf/utils/env.py
@@ -123,6 +123,8 @@ def setup_imports():
     datasets_pattern = os.path.join(datasets_folder, "**", "*.py")
     model_folder = os.path.join(root_folder, "models")
     model_pattern = os.path.join(model_folder, "**", "*.py")
+    module_folder = os.path.join(root_folder, "modules")
+    module_pattern = os.path.join(module_folder, "**", "*.py")
 
     importlib.import_module("mmf.common.meter")
 
@@ -130,6 +132,7 @@ def setup_imports():
         glob.glob(datasets_pattern, recursive=True)
         + glob.glob(model_pattern, recursive=True)
         + glob.glob(trainer_pattern, recursive=True)
+        + glob.glob(module_pattern, recursive=True)
     )
 
     for f in files:


### PR DESCRIPTION
Summary:
Load VISSL datasets, models, and ViT in MMF
- The ImageNet and other VISSL dataset can be loaded using VISSLImageDataset class in MMF.
- The VISSL models can be loaded using VISSLModelWrapper class in MMF (including VISSL losses).
- (by Vedanuj) Added ViT and DeiT into VISSL

Training a linear probing experiments (verified against VISSL commit `48b2984111c474a0da63c9c228b10281a0dbe737`):
```
python mmf_cli/run.py \
    config=projects/vissl_package_tests/eval_resnet_8gpu_transfer_in1k_linear.yaml \
    datasets=vissl_image \
    model=vissl_model_wrapper \
    run_type=train_val \
    env.save_dir=./save/eval_resnet_8gpu_transfer_in1k_linear/ \
model_config.vissl_model_wrapper.vissl_config.MODEL.WEIGHTS_INIT.PARAMS_FILE=/private/home/ronghanghu/workspace/vissl/zoo_models/swav_in1k_rn50_100ep_swav_8node_resnet_27_07_20.7e6fc6bf_model_final_checkpoint_phase99.torch
```

Pull Request resolved: https://github.com/fairinternal/mmf-internal/pull/144

Differential Revision: D26863613

Pulled By: ronghanghu

