### PR TITLE
[fix,feat] Support more wider variety of user dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # are considered third party there
 known_third_party = [
     "PIL", "cv2", "demjson", "fairscale", "filelock", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "matplotlib",
-    "mmf", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
+    "mmf", "mmf_cli", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
     "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
     "torchtext", "torchvision", "tqdm", "transformers", "pytorch_lightning"
 ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,6 +50,15 @@ NETWORK_AVAILABLE = is_network_reachable()
 CUDA_AVAILBLE = torch.cuda.is_available()
 
 
+def is_fb():
+    return (
+        os.getenv("SANDCASTLE") == "1"
+        or os.getenv("TW_JOB_USER") == "sandcastle"
+        or socket.gethostname().startswith("dev")
+        or "fbinfra" in socket.gethostname()
+    )
+
+
 def skip_if_no_network(testfn, reason="Network is not available"):
     return unittest.skipUnless(NETWORK_AVAILABLE, reason)(testfn)
 
@@ -67,15 +76,7 @@ def skip_if_macos(testfn, reason="Doesn't run on MacOS"):
 
 
 def skip_if_non_fb(testfn, reason="Doesn't run on non FB infra"):
-    return unittest.skipUnless(
-        (
-            os.getenv("SANDCASTLE") == "1"
-            or os.getenv("TW_JOB_USER") == "sandcastle"
-            or socket.gethostname().startswith("dev")
-            or "fbinfra" in socket.gethostname()
-        ),
-        reason,
-    )(testfn)
+    return unittest.skipUnless(is_fb(), reason)(testfn)
 
 
 def compare_state_dicts(a, b):

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -3,18 +3,46 @@
 import contextlib
 import io
 import os
+import sys
 import unittest
 
+from mmf.common.registry import registry
+from mmf.utils.configuration import get_mmf_env
+from mmf.utils.env import import_user_module, setup_imports
 from mmf.utils.general import get_mmf_root
+from mmf_cli.run import run
 from tests.test_utils import make_temp_dir, search_log
 
-from mmf_cli.run import run
 
+class TestUtilsEnvE2E(unittest.TestCase):
+    def _delete_dirty_modules(self):
+        for key in list(sys.modules.keys()):
+            if key not in self._initial_modules:
+                del sys.modules[key]
 
-class TestUtilsEnv(unittest.TestCase):
-    def test_user_import(self):
+    def _sanitize_registry(self):
+        registry.mapping["builder_name_mapping"].pop("always_one", None)
+        registry.mapping["model_name_mapping"].pop("simple", None)
+        registry.unregister("__mmf_user_dir_imported__")
+
+    def _get_user_dir(self, abs_path=True):
+        if abs_path:
+            return os.path.join(get_mmf_root(), "..", "tests", "data", "user_dir")
+        else:
+            return os.path.join("tests", "data", "user_dir")
+
+    def setUp(self):
+        setup_imports()
+        self._initial_modules = set(sys.modules)
+        self._sanitize_registry()
+
+    def tearDown(self):
+        self._delete_dirty_modules()
+        self._sanitize_registry()
+
+    def test_user_import_e2e(self):
         MAX_UPDATES = 50
-        user_dir = os.path.join(get_mmf_root(), "..", "tests", "data", "user_dir")
+        user_dir = self._get_user_dir()
         with make_temp_dir() as temp_dir:
             opts = [
                 "model=simple",
@@ -48,3 +76,35 @@ class TestUtilsEnv(unittest.TestCase):
                 ],
             )
             self.assertEqual(float(log_line["test/always_one/accuracy"]), 1)
+
+    def test_import_user_module_from_directory_absolute(self, abs_path=True):
+        # Make sure the modules are not available first
+        self.assertIsNone(registry.get_builder_class("always_one"))
+        self.assertIsNone(registry.get_model_class("simple"))
+        self.assertFalse("mmf_user_dir" in sys.modules)
+
+        # Now, import and test
+        user_dir = self._get_user_dir(abs_path)
+        import_user_module(user_dir)
+        self.assertIsNotNone(registry.get_builder_class("always_one"))
+        self.assertIsNotNone(registry.get_model_class("simple"))
+        self.assertTrue("mmf_user_dir" in sys.modules)
+        self.assertTrue(user_dir in get_mmf_env("user_dir"))
+
+    def test_import_user_module_from_directory_relative(self):
+        self.test_import_user_module_from_directory_absolute(abs_path=False)
+        user_dir = self._get_user_dir(abs_path=False)
+        self.assertEqual(user_dir, get_mmf_env("user_dir"))
+
+    def test_import_user_module_from_file(self):
+        self.assertIsNone(registry.get_builder_class("always_one"))
+        self.assertIsNone(registry.get_model_class("simple"))
+
+        user_dir = self._get_user_dir()
+        user_file = os.path.join(user_dir, "models", "simple.py")
+        import_user_module(user_file)
+        # Only model should be found and build should be none
+        self.assertIsNone(registry.get_builder_class("always_one"))
+        self.assertIsNotNone(registry.get_model_class("simple"))
+        self.assertTrue("mmf_user_dir" in sys.modules)
+        self.assertTrue(user_dir in get_mmf_env("user_dir"))


### PR DESCRIPTION
Summary:
This PR handles some edge cases around user dirs which weren't handle before especially in cases where python files are compiled and moved to a different place. This different place can also have compile time generated modules which are not available directly to the original folder. The diff also handles support for specifying a python file as user dir input.

Lastly, this diff adds extensive test to cover and test various user dir configurations.

Reviewed By: vedanuj

Differential Revision: D26838780

