### PR TITLE
[feat,fix] Make some transformer head params optional; label key for MLM

### DIFF
--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -369,8 +369,8 @@ class BaseTransformerHead(nn.Module, ABC):
     def forward(
         self,
         sequence_output: Tensor,
-        encoded_layers: List[Tensor],
-        processed_sample_list: Dict[str, Dict[str, Tensor]],
+        encoded_layers: Optional[List[Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, Tensor]]] = None,
     ) -> Dict[str, Tensor]:
         """Forward for the head module.
 

--- a/mmf/models/transformers/heads/mlp.py
+++ b/mmf/models/transformers/heads/mlp.py
@@ -1,7 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# Copyright (c) Facebook, Inc. and its affiliates.
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import torch
 from mmf.common.registry import registry
@@ -37,8 +37,8 @@ class MLP(BaseTransformerHead):
     def forward(
         self,
         sequence_output: torch.Tensor,
-        encoded_layers: List[torch.Tensor],
-        processed_sample_list: Dict[str, Dict[str, torch.Tensor]],
+        encoded_layers: Optional[List[torch.Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, torch.Tensor]]] = None,
     ):
         assert (
             sequence_output.size()[-1] == self.hidden_size


### PR DESCRIPTION
This PR makes some QoL changes for transformer heads so that they can be
used at places other than MMFTransformer.

- Make encoder_layers and processed_sample_list options optional by
default
- Add label key option for mlm to allow direct fetching of maskedlabels
from sample list


Test Plan:
Tested with GUniT