### PR TITLE
[fix] Fix iopath get_local_path related checkpoint issues

### DIFF
--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -431,7 +431,8 @@ class Checkpoint:
         # Backwards compatibility to Pythia
         _hack_imports()
 
-        local_path = PathManager.get_local_path(file)
+        # Force get_local_path to always redownload checkpoints
+        local_path = PathManager.get_local_path(file, force=True)
         with PathManager.open(local_path, "rb") as f:
             if "cuda" in str(self.device):
                 return torch.load(f, map_location=self.device)
@@ -441,15 +442,15 @@ class Checkpoint:
     def _get_vcs_fields(self):
         """Returns a dict with git fields of the current repository
 
-           To reproduce an experiment directly from a checkpoint
+        To reproduce an experiment directly from a checkpoint
 
-           1) Export `config` key as a yaml
-           2) Clone repository and checkout at given commit on given branch
-           3) Any local change (diff) while running the experiment is stored
-              in the value with key `git/diff`, output the diff to a `path.diff`
-              file and apply the patch to the current state by simply
+        1) Export `config` key as a yaml
+        2) Clone repository and checkout at given commit on given branch
+        3) Any local change (diff) while running the experiment is stored
+           in the value with key `git/diff`, output the diff to a `path.diff`
+           file and apply the patch to the current state by simply
 
-                           `patch -p0 < path.diff`
+                        `patch -p0 < path.diff`
         """
 
         return {

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ sklearn==0.0
 omegaconf==2.0.6
 lmdb==0.98
 termcolor==1.1.0
-iopath==0.1.3
+iopath==0.1.7
 pytorch_lightning==1.1.6
 datasets==1.2.1
 matplotlib==3.3.4


### PR DESCRIPTION
Summary: Adds force=True for downloading manifold checkpoints so that we do not load cahced versions of the checkpoints like best.ckpt or current.ckpt

Differential Revision: D27130415

