### PR TITLE
[fix] length for multi dataset loader; max_epochs; eta

### DIFF
--- a/mmf/datasets/multi_dataset_loader.py
+++ b/mmf/datasets/multi_dataset_loader.py
@@ -10,6 +10,7 @@ import numpy as np
 from mmf.utils.build import build_dataloader_and_sampler, build_dataset
 from mmf.utils.distributed import (
     broadcast_scalar,
+    get_world_size,
     is_dist_initialized,
     is_master,
     is_xla,
@@ -214,7 +215,9 @@ class MultiDatasetLoader:
 
     def __len__(self):
         # Since, this is iterator, we need to return total length == number of batches
-        batch_size = get_batch_size()
+        # and as get_batch_size returns per GPU batch size, it needs to be multiplied
+        # by world size
+        batch_size = get_batch_size() * get_world_size()
         # Changed the length to accomadate drop_last == True
         # drop_last is required if the batch is split into multiple cores
         # some of the cores may not have enough examples.

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -32,8 +32,8 @@ class LogisticsCallback(Callback):
         self.checkpoint_interval = self.training_config.checkpoint_interval
 
         # Total iterations for snapshot
-        self.snapshot_iterations = len(self.trainer.val_dataset)
-        self.snapshot_iterations //= self.training_config.batch_size
+        # len would be number of batches per GPU == max updates
+        self.snapshot_iterations = len(self.trainer.val_loader)
 
         self.tb_writer = None
 

--- a/tests/trainers/callbacks/test_logistics.py
+++ b/tests/trainers/callbacks/test_logistics.py
@@ -76,7 +76,7 @@ class TestLogisticsCallback(unittest.TestCase):
         self.report.dataset_type = "test"
 
         self.trainer.model = SimpleModule()
-        self.trainer.val_dataset = NumbersDataset()
+        self.trainer.val_loader = NumbersDataset()
 
         self.trainer.optimizer = torch.optim.Adam(
             self.trainer.model.parameters(), lr=1e-01


### PR DESCRIPTION
The calculation of length for multidataloader used get_batch_size to
divide total dataset length which is incorrect as get_batch_size is per
device rather than global batch size. This PR fixes it and fixes
snapshot interval calculation as well. This in turn:
- Fixes max_epochs support
- ETA
- All other things dependent on this

Test Plan:
Tested locally with MVLT runs


