### PR TITLE
[refactor] Collator samplelist conversion logic for more control

### DIFF
--- a/mmf/common/batch_collator.py
+++ b/mmf/common/batch_collator.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from mmf.common.sample import SampleList
+from mmf.common.sample import convert_batch_to_sample_list
 
 
 class BatchCollator:
@@ -8,24 +8,7 @@ class BatchCollator:
         self._dataset_type = dataset_type
 
     def __call__(self, batch):
-        # Create and return sample list with proper name
-        # and type set if it is already not a sample list
-        # (case of batched iterators)
-        sample_list = batch
-        if (
-            # Check if batch is a list before checking batch[0]
-            # or len as sometimes batch is already SampleList
-            isinstance(batch, list)
-            and len(batch) == 1
-            and isinstance(batch[0], SampleList)
-        ):
-            sample_list = batch[0]
-        elif not isinstance(batch, SampleList):
-            sample_list = SampleList(batch)
-
-        if sample_list._get_tensor_field() is None:
-            sample_list = SampleList(sample_list.to_dict())
-
+        sample_list = convert_batch_to_sample_list(batch)
         sample_list.dataset_name = self._dataset_name
         sample_list.dataset_type = self._dataset_type
         return sample_list

--- a/mmf/common/sample.py
+++ b/mmf/common/sample.py
@@ -14,7 +14,7 @@ attributes from ``Sample`` while taking care of properly batching things.
 import collections
 import warnings
 from collections import OrderedDict
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Union
 
 import torch
 
@@ -386,13 +386,47 @@ class SampleList(OrderedDict):
         return sample_dict
 
 
+def convert_batch_to_sample_list(
+    batch: Union[SampleList, Dict[str, Any]]
+) -> SampleList:
+    # Create and return sample list with proper name
+    # and type set if it is already not a sample list
+    # (case of batched iterators)
+    sample_list = batch
+    if (
+        # Check if batch is a list before checking batch[0]
+        # or len as sometimes batch is already SampleList
+        isinstance(batch, list)
+        and len(batch) == 1
+        and isinstance(batch[0], SampleList)
+    ):
+        sample_list = batch[0]
+    elif not isinstance(batch, SampleList):
+        sample_list = SampleList(batch)
+
+    if sample_list._get_tensor_field() is None:
+        sample_list = SampleList(sample_list.to_dict())
+
+    return sample_list
+
+
 device_type = Union[str, torch.device]
-sample_list_type = Type[SampleList]
 
 
 def to_device(
-    sample_list: sample_list_type, device: device_type = "cuda"
-) -> sample_list_type:
+    sample_list: Union[SampleList, Dict[str, Any]], device: device_type = "cuda"
+) -> SampleList:
+    if isinstance(sample_list, collections.Mapping):
+        sample_list = convert_batch_to_sample_list(sample_list)
+    # to_device is specifically for SampleList
+    # if user is passing something custom built
+    if not isinstance(sample_list, SampleList):
+        warnings.warn(
+            "You are not returning SampleList/Sample from your dataset. "
+            "MMF expects you to move your tensors to cuda yourself."
+        )
+        return sample_list
+
     if isinstance(device, str):
         device = torch.device(device)
 
@@ -402,17 +436,9 @@ def to_device(
     # is set to cuda but cuda is not available.
     if device.type == "cuda" and not torch.cuda.is_available():
         warnings.warn(
-            "Selected device is cuda, but it is NOT available!!!" "Falling back on cpu."
+            "Selected device is cuda, but it is NOT available!!! Falling back on cpu."
         )
         device = torch.device("cpu")
-    # to_device is specifically for SampleList
-    # if user is passing something custom built
-    if not isinstance(sample_list, SampleList):
-        warnings.warn(
-            "You are not returning SampleList/Sample from your dataset. "
-            "MMF expects you to move your tensors to cuda yourself."
-        )
-        return sample_list
 
     if sample_list.get_device() != device:
         sample_list = sample_list.to(device)

--- a/tests/trainers/lightning/test_utils.py
+++ b/tests/trainers/lightning/test_utils.py
@@ -74,6 +74,7 @@ def get_lightning_trainer(
     )
     trainer.model.build()
     trainer.model.train()
+    trainer.model.is_pl_enabled = True
     prepare_lightning_trainer(trainer)
     return trainer
 


### PR DESCRIPTION
Summary: This refactor allows us to use sample list conversion logic used in BatchCollator elsewhere as well.

Differential Revision: D27306252

