### PR TITLE
[feat] Inference CLI

### DIFF
--- a/mmf_cli/interactive.py
+++ b/mmf_cli/interactive.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3 -u
+# Copyright (c) Facebook, Inc. and its affiliates.
+import argparse
+import logging
+import typing
+
+from mmf.utils.configuration import _merge_with_dotlist
+from mmf.utils.flags import flags
+from mmf.utils.inference import Inference
+from mmf.utils.logger import setup_logger
+from omegaconf import OmegaConf
+
+
+def construct_config(opts: typing.List[str]):
+    config = OmegaConf.create({"checkpoint_path": ""})
+    return _merge_with_dotlist(config, opts)
+
+
+def interactive(opts: typing.Optional[typing.List[str]] = None):
+    """Inference runs inference on an image and text provided by the user.
+    You can optionally run inference programmatically by passing an optlist as opts.
+
+    Args:
+        opts (typing.Optional[typing.List[str]], optional): Optlist which can be used.
+            to override opts programmatically. For e.g. if you pass
+            opts = ["checkpoint_path=my/directory"], this will set the checkpoint.
+    """
+    if opts is None:
+        parser = flags.get_parser()
+        args = parser.parse_args()
+    else:
+        args = argparse.Namespace(config_override=None)
+        args.opts = opts
+
+    setup_logger()
+    logger = logging.getLogger("mmf_cli.interactive")
+
+    config = construct_config(args.opts)
+    inference = Inference(checkpoint_path=config.checkpoint_path)
+    logger.info("Enter 'exit' at any point to terminate.")
+    logger.info("Enter an image URL:")
+    image_url = input()
+    logger.info("Got image URL.")
+    logger.info("Enter text:")
+    text = input()
+    logger.info("Got text input.")
+    while text != "exit":
+        logger.info("Running inference on image and text input.")
+        answer = inference.forward(image_url, {"text": text}, image_format="url")
+        logger.info("Model response: " + answer)
+        logger.info(
+            f"Enter another image URL or leave it blank to continue using {image_url}:"
+        )
+        new_image_url = input()
+        if new_image_url != "":
+            image_url = new_image_url
+        if new_image_url == "exit":
+            break
+        logger.info("Enter another text input:")
+        text = input()
+
+
+if __name__ == "__main__":
+    interactive()

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ if __name__ == "__main__":
                 "mmf_run = mmf_cli.run:run",
                 "mmf_predict = mmf_cli.predict:predict",
                 "mmf_convert_hm = mmf_cli.hm_convert:main",
+                "mmf_interactive = mmf_cli.interactive:interactive",
             ]
         },
     )


### PR DESCRIPTION
Created script to allow users to run
inference using various models, text
inputs, and image inputs.

All that is required is using
mmf_inference and passing some
command line args.

Here is how you use it:
```
mmf_interactive checkpoint_path=/checkpoint/brettallen/mmft/model
```

This will initiate an interactive inference
script that will ask for image URL and text
input to run on. It will keep prompting the user
for more images and text until they say `exit`.

I also added the ability to just say `same` to use
the same image because I figured it was inconvenient
for the user to constantly have to copy over
the image URL every time they want to ask a new
question.
