### PR TITLE
[feat] Add teardown support for datamodules

### DIFF
--- a/mmf/datasets/base_dataset_builder.py
+++ b/mmf/datasets/base_dataset_builder.py
@@ -200,3 +200,6 @@ class BaseDatasetBuilder(pl.LightningDataModule):
 
     def test_dataloader(self, *args, **kwargs):
         return self.build_dataloader(self.test_dataset, "test")
+
+    def teardown(self, *args, **kwargs) -> None:
+        pass

--- a/mmf/datasets/multi_datamodule.py
+++ b/mmf/datasets/multi_datamodule.py
@@ -52,6 +52,11 @@ class MultiDataModule(pl.LightningDataModule):
         loader = MultiDataLoader(loader_args)
         return loader
 
+    def teardown(self, *args, **kwargs):
+        for datamodule in self.datamodules:
+            if hasattr(datamodule, "teardown"):
+                datamodule.teardown()
+
     ############################################################
     ######## Functions below are required for MMFTrainer #######
     ########      and not used by the PL Trainer         #######

--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -87,6 +87,8 @@ class LightningTrainer(BaseTrainer):
 
         logger.info("Starting training...")
         self.trainer.fit(self.model, self.data_module)
+        # TODO: Look for a better way to hook this
+        self.data_module.teardown()
 
     def inference(self) -> None:
         logger.info("Starting inference...")

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -141,6 +141,7 @@ class MMFTrainer(
         self.on_train_end()
 
         self.inference()
+        self.dataset_loader.teardown()
 
     def inference(self):
         dataset_type = []


### PR DESCRIPTION
Summary: Without proper teardown, the job might fail as errored and restart. This diff adds proper teardown support for datamodules which inherently will include onbox dataloader as well.

Reviewed By: ytsheng, vedanuj

Differential Revision: D26687357

