### PR TITLE
[feat] add tests for eval loop

### DIFF
--- a/tests/datasets/test_mmf_dataset_builder.py
+++ b/tests/datasets/test_mmf_dataset_builder.py
@@ -4,21 +4,29 @@ import os
 import unittest
 from unittest.mock import MagicMock
 
+import torch
 from mmf.datasets.base_dataset import BaseDataset
 from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+from mmf.utils.general import get_current_device
 from omegaconf import OmegaConf
 
 
 class SimpleMMFDataset(BaseDataset):
     def __init__(
-        self, dataset_name, config, dataset_type, *args, num_examples, **kwargs
+        self, dataset_name, config, dataset_type, num_examples, *args, **kwargs
     ):
         self.num_examples = num_examples
-        self.features = [x for x in range(self.num_examples)]
-        self.annotations = [x for x in range(self.num_examples)]
+        self.features = [float(x) for x in range(self.num_examples)]
+        self.annotations = [float(x) for x in range(self.num_examples)]
+        self._device = get_current_device()
+        self._dataset_name = dataset_name
 
     def __getitem__(self, idx):
-        return self.features[idx], self.annotations[idx]
+        return {
+            "feature": torch.tensor(self.features[idx]),
+            "annotation": torch.tensor(self.annotations[idx]),
+            "test": torch.tensor(self.features[idx]),
+        }
 
     def __len__(self):
         return self.num_examples
@@ -63,8 +71,8 @@ class TestMMFDatasetBuilder(unittest.TestCase):
         return dataset_builder.load(self.config, dataset_type)
 
     def _samples_set(self, dataset):
-        return set(x for x, _ in dataset)
+        return set(dataset.features)
 
     def _test_alignment_in_dataset(self, dataset):
-        for feature, annotation in dataset:
+        for feature, annotation in zip(dataset.features, dataset.annotations):
             self.assertEqual(feature, annotation)

--- a/tests/datasets/test_multi_datamodule.py
+++ b/tests/datasets/test_multi_datamodule.py
@@ -1,0 +1,52 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import functools
+
+import torch
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+from mmf.datasets.multi_datamodule import MultiDataModule
+from omegaconf import OmegaConf
+from tests.datasets.test_mmf_dataset_builder import SimpleMMFDataset
+
+
+class MultiDataModuleTestObject(MultiDataModule):
+    def __init__(self, batch_size):
+        self.batch_size = batch_size
+        config = OmegaConf.create(
+            {
+                "use_features": True,
+                "annotations": {
+                    "train": "not_a_real_annotations_dataset",
+                    "val": "not_a_real_annotations_dataset",
+                },
+                "features": {
+                    "train": "not_a_real_features_dataset",
+                    "val": "not_a_real_features_dataset",
+                },
+                "dataset_config": {"simple": 0},
+            }
+        )
+        self.config = config
+        self.dataset_list = []
+        dataset_builder = MMFDatasetBuilder(
+            "simple", functools.partial(SimpleMMFDataset, num_examples=100)
+        )
+        dataset_builder.train_dataloader = self._get_dataloader
+        dataset_builder.val_dataloader = self._get_dataloader
+        dataset_builder.test_dataloader = self._get_dataloader
+        self.datamodules = {"simple": dataset_builder}
+
+    def _get_dataloader(self):
+        dataset = SimpleMMFDataset(
+            num_examples=100,
+            dataset_name="simple",
+            dataset_type="val",
+            config=self.config,
+        )
+        dataloader = torch.utils.data.DataLoader(
+            dataset=dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=1,
+            drop_last=False,
+        )
+        return dataloader

--- a/tests/trainers/lightning/test_grad_clipping.py
+++ b/tests/trainers/lightning/test_grad_clipping.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
+from unittest.mock import MagicMock
 
 import torch
 from mmf.utils.general import clip_gradients
@@ -25,6 +26,7 @@ class TestLightningTrainerGradClipping(unittest.TestCase, Callback):
             max_epochs=None,
             grad_clipping_config=self.grad_clipping_config,
         )
+        mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
 
         def _finish_update():
             clip_gradients(

--- a/tests/trainers/lightning/test_loss.py
+++ b/tests/trainers/lightning/test_loss.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
+from unittest.mock import MagicMock
 
 from mmf.common.report import Report
 from pytorch_lightning.callbacks.base import Callback
@@ -20,6 +21,7 @@ class TestLightningTrainerLoss(unittest.TestCase, Callback):
         mmf_trainer = get_mmf_trainer(
             max_updates=5, max_epochs=None, on_update_end_fn=_on_update_end
         )
+        mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
         mmf_trainer.training_loop()
 
         # compute lightning_trainer training losses

--- a/tests/trainers/lightning/test_lr_schedule.py
+++ b/tests/trainers/lightning/test_lr_schedule.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
+from unittest.mock import MagicMock
 
 import torch
 from tests.trainers.lightning.test_utils import (
@@ -28,6 +29,7 @@ class TestLightningTrainerLRSchedule(unittest.TestCase):
         mmf_trainer = get_mmf_trainer(
             max_updates=8, max_epochs=None, scheduler_config=trainer_config.scheduler
         )
+        mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
         mmf_trainer.training_loop()
 
         trainer = get_lightning_trainer(max_steps=8, lr_scheduler=True)

--- a/tests/trainers/test_eval_loop.py
+++ b/tests/trainers/test_eval_loop.py
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+from tests.datasets.test_multi_datamodule import MultiDataModuleTestObject
+from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+
+
+class MMFTrainerMock(TrainerTrainingLoopMock):
+    def __init__(self, num_train_data, max_updates, max_epochs, device="cuda"):
+        super().__init__(num_train_data, max_updates, max_epochs)
+
+    def load_datasets(self):
+        self.dataset_loader = MultiDataModuleTestObject(batch_size=1)
+        self.train_loader = self.dataset_loader.train_dataloader()
+        self.val_loader = self.dataset_loader.val_dataloader()
+        self.test_loader = self.dataset_loader.test_dataloader()
+
+
+class TestEvalLoop(unittest.TestCase):
+    def test_eval_loop(self):
+        torch.random.manual_seed(2)
+        with patch(
+            "mmf.common.test_reporter.PathManager",
+            return_value=MagicMock(return_value=None),
+        ):
+            trainer = MMFTrainerMock(100, 2, 2)
+            trainer.load_datasets()
+            combined_report, meter = trainer.evaluation_loop("val")
+            self.assertAlmostEqual(combined_report["losses"]["loss"], 493377.5312)
+            self.assertAlmostEqual(combined_report["logits"].item(), -0.2379742, 6)

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -35,7 +35,7 @@ class TrainerTrainingLoopMock(MMFTrainer):
                 {
                     "training": {
                         "detect_anomaly": False,
-                        "evaluation_interval": 10000,
+                        "evaluation_interval": 1000,
                         "update_frequency": update_frequency,
                         "fp16": fp16,
                         "batch_size": batch_size,
@@ -116,12 +116,11 @@ class TrainerTrainingLoopMock(MMFTrainer):
         self.meter = Meter()
         self.after_training_loop = MagicMock(return_value=None)
         self.on_validation_start = MagicMock(return_value=None)
-        self.evaluation_loop = MagicMock(return_value=(None, None))
         self.scaler = torch.cuda.amp.GradScaler(enabled=False)
         self.val_loader = MagicMock(return_value=None)
         self.early_stop_callback = MagicMock(return_value=None)
         self.on_validation_end = MagicMock(return_value=None)
-        self.metrics = MagicMock(return_value=None)
+        self.metrics = MagicMock(return_value={})
 
 
 class TestTrainingLoop(unittest.TestCase):

--- a/tests/utils/test_quality_checks.py
+++ b/tests/utils/test_quality_checks.py
@@ -20,8 +20,8 @@ def walk_and_assert_init(folder):
 
 
 def walk_and_assert_not_empty(folder):
-    for _, subfolders, files in os.walk(folder):
-        assert len(files) > 0 or len(subfolders) > 0, f"Folder {folder} is empty"
+    for root, subfolders, files in os.walk(folder):
+        assert len(files) > 0 or len(subfolders) > 0, f"Folder {root} is empty"
 
 
 class TestQualityChecks(unittest.TestCase):


### PR DESCRIPTION
* Adds test for evaluation loop for mmf trainer
* Makes it so that test folder quality is more explicit in terms of errors.

I wrote this test to understand deeper on how the evaluation_loop.py works. This needs to land before the next pytorch lightning update. 

To test that it works run:

`pytest tests`