### PR TITLE
[refactor] Move test_reporter_config to top level config

### DIFF
--- a/mmf/common/dataset_loader.py
+++ b/mmf/common/dataset_loader.py
@@ -60,12 +60,9 @@ class DatasetLoader:
         return build_test_reporter(datamodules, test_reporter_config, dataset_type)
 
     def _get_test_reporter_config(self):
-        dataset_name = list(self.config.dataset_config.keys())[0]
-        dataset_config = self.config.dataset_config.get(dataset_name)
-        if hasattr(dataset_config, "get"):
-            return dataset_config.get("test_reporter_config", None)
-        else:
-            return None
+        from mmf.utils.configuration import get_global_config
+
+        return get_global_config("evaluation.reporter")
 
     def prepare_batch(self, batch, *args, **kwargs):
         batch = SampleList(batch)

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -171,6 +171,10 @@ evaluation:
     predict: false
     # Prediction file format (csv|json), default is json
     predict_file_format: json
+    # Test reporter params. Defaults to type: file
+    reporter:
+        type: file
+        params: {}
 
 # Configuration for models, default configuration files for various models
 # included in MMF can be found under configs directory in root folder

--- a/mmf/datasets/multi_datamodule.py
+++ b/mmf/datasets/multi_datamodule.py
@@ -92,12 +92,9 @@ class MultiDataModule(pl.LightningDataModule):
         return build_test_reporter(self.datamodules, test_reporter_config, dataset_type)
 
     def _get_test_reporter_config(self):
-        dataset_name = list(self.config.dataset_config.keys())[0]
-        dataset_config = self.config.dataset_config.get(dataset_name)
-        if hasattr(dataset_config, "get"):
-            return dataset_config.get("test_reporter_config", None)
-        else:
-            return None
+        from mmf.utils.configuration import get_global_config
+
+        return get_global_config("evaluation.reporter")
 
     def prepare_batch(self, batch, *args, **kwargs):
         batch = SampleList(batch)


### PR DESCRIPTION
Summary: Test reporter config as opposed to original design should be a top level config node as it is not specific to one dataset but encompasses all datasets in one go. This diff refactors that to be a top level config node so that it is not per dataset config which conflicts with overall definition of test reporter.

Reviewed By: madian9

Differential Revision: D27301920

