### PR TITLE
[feat,fix] CPU evaluation and report memory leak

### DIFF
--- a/mmf/common/report.py
+++ b/mmf/common/report.py
@@ -1,14 +1,21 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import collections
+import copy
 import warnings
 from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
+from mmf.common.sample import SampleList, detach_tensor
 
 
 class Report(OrderedDict):
-    def __init__(self, batch, model_output=None, *args):
+    def __init__(
+        self, batch: SampleList = None, model_output: Dict[str, Any] = None, *args
+    ):
         super().__init__(self)
+        if batch is None:
+            return
         if model_output is None:
             model_output = {}
         if self._check_and_load_tuple(batch):
@@ -40,15 +47,15 @@ class Report(OrderedDict):
                     warnings.warn(log)
                 self[key] = item
 
-    def get_batch_size(self):
+    def get_batch_size(self) -> int:
         return self.batch_size
 
     @property
-    def batch_size(self):
+    def batch_size(self) -> int:
         return self._batch_size
 
     @batch_size.setter
-    def batch_size(self, batch_size):
+    def batch_size(self, batch_size: int):
         self._batch_size = batch_size
 
     def _check_and_load_tuple(self, batch):
@@ -62,19 +69,92 @@ class Report(OrderedDict):
         else:
             return False
 
-    def __setattr__(self, key, value):
+    def __setattr__(self, key: str, value: Any):
         self[key] = value
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str):
         try:
             return self[key]
         except KeyError:
             raise AttributeError(key)
 
-    def fields(self):
+    def fields(self) -> List[str]:
         return list(self.keys())
 
-    def accumulate_tensor_fields_and_loss(self, report, field_list):
+    def apply_fn(self, fn: Callable, fields: Optional[List[str]] = None):
+        """Applies a function `fn` on all items in a report. Can apply to specific
+        fields if `fields` parameter is passed
+
+        Args:
+            fn (Callable): A callable to called on each item in report
+            fields (List[str], optional): Use to apply on specific fields.
+                Defaults to None.
+
+        Returns:
+            Report: Update report after apply fn
+        """
+        for key in self.keys():
+            if fields is not None and isinstance(fields, (list, tuple)):
+                if key not in fields:
+                    continue
+            self[key] = fn(self[key])
+            if isinstance(self[key], collections.MutableSequence):
+                for idx, item in enumerate(self[key]):
+                    self[key][idx] = fn(item)
+            elif isinstance(self[key], dict):
+                for subkey in self[key].keys():
+                    self[key][subkey] = fn(self[key][subkey])
+        return self
+
+    def detach(self) -> "Report":
+        """Similar to tensor.detach, detach all items in a report from their graphs.
+        This is useful in clearing up memory sometimes.
+
+        Returns:
+            Report: Detached report is returned back.
+        """
+        return self.apply_fn(detach_tensor)
+
+    def to(
+        self,
+        device: Union[torch.device, str],
+        non_blocking: bool = True,
+        fields: Optional[List[str]] = None,
+    ):
+        """Move report to a specific device defined 'device' parameter.
+        This is similar to how one moves a tensor or sample_list to a device
+
+        Args:
+            device (torch.device): Device can be str defining device or torch.device
+            non_blocking (bool, optional): Whether transfer should be non_blocking.
+                Defaults to True.
+            fields (List[str], optional): Use this is you only want to move some
+                specific fields to the device instead of full report. Defaults to None.
+
+        Raises:
+            TypeError: If device type is not correct
+
+        Returns:
+            Report: Updated report is returned back
+        """
+        if not isinstance(device, torch.device):
+            if not isinstance(device, str):
+                raise TypeError(
+                    "device must be either 'str' or "
+                    "'torch.device' type, {} found".format(type(device))
+                )
+            device = torch.device(device)
+
+        def fn(x):
+            if hasattr(x, "to"):
+                x = x.to(device, non_blocking=non_blocking)
+            return x
+
+        return self.apply_fn(fn, fields)
+
+    def accumulate_tensor_fields_and_loss(
+        self, report: "Report", field_list: List[str]
+    ):
         for key in field_list:
             if key == "__prediction_report__":
                 continue
@@ -89,7 +169,7 @@ class Report(OrderedDict):
 
         self._accumulate_loss(report)
 
-    def _accumulate_loss(self, report):
+    def _accumulate_loss(self, report: "Report"):
         for key, value in report.losses.items():
             if key not in self.losses.keys():
                 warnings.warn(
@@ -99,3 +179,19 @@ class Report(OrderedDict):
                 continue
             if isinstance(self.losses[key], torch.Tensor):
                 self.losses[key] += value
+
+    def copy(self) -> "Report":
+        """Get a copy of the current Report
+
+        Returns:
+            Report: Copy of current Report.
+
+        """
+        report = Report()
+
+        fields = self.fields()
+
+        for field in fields:
+            report[field] = copy.deepcopy(self[field])
+
+        return report

--- a/mmf/common/sample.py
+++ b/mmf/common/sample.py
@@ -366,6 +366,14 @@ class SampleList(OrderedDict):
 
         return self
 
+    def detach(self):
+        fields = self.keys()
+
+        for field in fields:
+            self[field] = detach_tensor(self[field])
+
+        return self
+
     def to_dict(self) -> Dict[str, Any]:
         """Converts a sample list to dict, this is useful for TorchScript and for
         other internal API unification efforts.
@@ -443,3 +451,18 @@ def to_device(
     if sample_list.get_device() != device:
         sample_list = sample_list.to(device)
     return sample_list
+
+
+def detach_tensor(tensor: Any) -> Any:
+    """Detaches any element passed which has a `.detach` function defined.
+    Currently, in MMF can be SampleList, Report or a tensor.
+
+    Args:
+        tensor (Any): Item to be detached
+
+    Returns:
+        Any: Detached element
+    """
+    if hasattr(tensor, "detach"):
+        tensor = tensor.detach()
+    return tensor

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -167,6 +167,9 @@ trainer:
 evaluation:
     # Metrics for evaluation
     metrics: []
+    # Use CPU for metrics and other calculations, you can use this option if
+    # you see OOM in validation as in metrics are calculated globally
+    use_cpu: false
     # Generate predictions in a file
     predict: false
     # Prediction file format (csv|json), default is json

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -89,6 +89,7 @@ class TrainerTrainingLoopMixin(ABC):
                 self.profile("Batch load time")
 
                 report = self.run_training_batch(batch, num_batches_for_this_update)
+                report = report.detach()
 
                 # accumulate necessary params (including loss) for metric calculation
                 if combined_report is None:

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -56,6 +56,9 @@ class MMFTrainer(
         self.logistics_callback = LogisticsCallback(self.config, self)
         self.lr_scheduler_callback = LRSchedulerCallback(self.config, self)
 
+        # Reset callbacks as they are class variables and would be shared between
+        # multiple interactive shell calls to `run`
+        self.callbacks = []
         # Add callbacks for execution during events
         self.callbacks.append(self.lr_scheduler_callback)
         # checkpoint_callback needs to be called after lr_scheduler_callback so that

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -16,7 +16,6 @@ from mmf.utils.timer import Timer
 from termcolor import colored
 
 
-@functools.lru_cache()
 def setup_output_folder(folder_only: bool = False):
     """Sets up and returns the output file where the logs will be placed
     based on the configuration passed. Usually "save_dir/logs/log_<timestamp>.txt".
@@ -52,8 +51,6 @@ def setup_output_folder(folder_only: bool = False):
     return log_filename
 
 
-# so that calling setup_logger multiple times won't add many handlers
-@functools.lru_cache()
 def setup_logger(
     output: str = None,
     color: bool = True,

--- a/projects/mmf_transformer/configs/vqa2/defaults.yaml
+++ b/projects/mmf_transformer/configs/vqa2/defaults.yaml
@@ -1,3 +1,6 @@
+includes:
+- ../../../../mmf/configs/datasets/vqa2/with_raw_images.yaml
+
 model_config:
   mmf_transformer:
     training_head_type: classification
@@ -7,6 +10,7 @@ model_config:
 
 dataset_config:
   vqa2:
+    use_images: true
     return_features_info: true
     processors:
       text_processor:
@@ -33,14 +37,14 @@ scheduler:
 
 evaluation:
   metrics:
-  - vqa_accuracy
+  - accuracy
 
 training:
   batch_size: 480
   lr_scheduler: true
   max_updates: 11000
   early_stop:
-    criteria: vqa2/vqa_accuracy
+    criteria: vqa2/accuracy
     minimize: false
 
 checkpoint:

--- a/tests/common/test_report.py
+++ b/tests/common/test_report.py
@@ -1,0 +1,65 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+
+import tests.test_utils as test_utils
+import torch
+from mmf.common.report import Report
+from mmf.common.sample import SampleList
+
+
+class TestReport(unittest.TestCase):
+    def _build_report(self):
+        tensor_a = torch.tensor([[1, 2, 3, 4], [2, 3, 4, 5]])
+        sample_list = SampleList()
+        sample_list.add_field("a", tensor_a)
+        model_output = {"scores": torch.rand(2, 2)}
+
+        report = Report(sample_list, model_output)
+        return report
+
+    def test_report_copy(self):
+        original_report = self._build_report()
+        report_copy = original_report.copy()
+
+        report_copy["scores"].zero_()
+
+        self.assertFalse(
+            test_utils.compare_tensors(report_copy["scores"], original_report["scores"])
+        )
+
+    def test_report_detach(self):
+        report = self._build_report()
+        report.a = report.a.float()
+        report.a.requires_grad = True
+        report.scores = report.a * 2
+        self.assertTrue(report.scores.requires_grad)
+        self.assertTrue(report.a.requires_grad)
+        self.assertFalse(report.scores.is_leaf)
+        self.assertTrue(report.a.is_leaf)
+        report = report.detach()
+        self.assertFalse(report.scores.requires_grad)
+        self.assertFalse(report.a.requires_grad)
+        self.assertTrue(report.scores.is_leaf)
+        self.assertTrue(report.a.is_leaf)
+
+    @test_utils.skip_if_no_cuda
+    def test_to_device(self):
+        report = self._build_report()
+        self.assertFalse(report.a.is_cuda)
+        self.assertFalse(report.scores.is_cuda)
+
+        report = report.to("cuda")
+
+        self.assertTrue(report.a.is_cuda)
+        self.assertTrue(report.scores.is_cuda)
+
+        report = report.to("cpu", non_blocking=False)
+
+        self.assertFalse(report.a.is_cuda)
+        self.assertFalse(report.scores.is_cuda)
+
+        report = report.to("cuda", fields=["scores"])
+
+        self.assertFalse(report.a.is_cuda)
+        self.assertTrue(report.scores.is_cuda)

--- a/tests/trainers/callbacks/test_logistics.py
+++ b/tests/trainers/callbacks/test_logistics.py
@@ -69,7 +69,6 @@ class TestLogisticsCallback(unittest.TestCase):
         # Keep original copy for testing purposes
         self.trainer.config = deepcopy(self.config)
         registry.register("config", self.trainer.config)
-        setup_logger.cache_clear()
         setup_logger()
         self.report = Mock(spec=Report)
         self.report.dataset_name = "abcd"

--- a/tests/trainers/test_eval_loop.py
+++ b/tests/trainers/test_eval_loop.py
@@ -8,13 +8,15 @@ from tests.trainers.test_training_loop import TrainerTrainingLoopMock
 
 
 class TestEvalLoop(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(2)
+
     @patch(
         "mmf.common.test_reporter.PathManager",
         return_value=MagicMock(return_value=None),
     )
     @patch("mmf.common.test_reporter.get_mmf_env", return_value="")
     def test_eval_loop(self, a, b):
-        torch.random.manual_seed(2)
         trainer = TrainerTrainingLoopMock(100, max_updates=2, max_epochs=2)
         trainer.load_datasets()
         combined_report, meter = trainer.evaluation_loop("val")

--- a/tests/trainers/test_trainer_mocks.py
+++ b/tests/trainers/test_trainer_mocks.py
@@ -84,7 +84,8 @@ class TrainerTrainingLoopMock(MMFTrainer):
                         "batch_size_per_device": batch_size_per_device,
                         "tensorboard": tensorboard,
                         "run_type": "train",
-                    }
+                    },
+                    "evaluation": {"use_cpu": False},
                 }
             )
             self.training_config = self.config.training

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -23,6 +23,7 @@ def get_trainer_config():
                 "lr_scheduler": False,
                 "batch_size": 1,
             },
+            "evaluation": {"use_cpu": False},
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {
                 "type": "warmup_linear",

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -11,7 +11,7 @@ from typing import Optional
 from mmf.common.registry import registry
 from mmf.utils.configuration import Configuration
 from mmf.utils.file_io import PathManager
-from mmf.utils.logger import setup_logger, setup_output_folder
+from mmf.utils.logger import setup_logger
 
 
 class TestLogger(unittest.TestCase):
@@ -29,8 +29,6 @@ class TestLogger(unittest.TestCase):
         configuration.freeze()
         cls.config = configuration.get_config()
         registry.register("config", cls.config)
-        setup_output_folder.cache_clear()
-        setup_logger.cache_clear()
         cls.writer = setup_logger()
 
     @classmethod


### PR DESCRIPTION
This PR has three purposes:
- Allow CPU evaluation for the cases where evaluation set is big can OOM
on calculation for global metrics. Enable this via evaluation.use_cpu
- Fix a memory leak which is caused as first report in training loop is
not detached while generating a new one.
- It also fixes an issues with shallow report copy made prediction
report purposes. This would cause issues in multiple metrics calculation
where some metrics use prediction report and some don't. Since, it is
shallow copy, first report copy shares tensors with original report
which when gathered in reporter would lead to average number from all
GPUs and hence that report would like into original report. This is
fixed by creating a deep copy of report rather than shallow copy by
introducing a copy method

The PR also fixes
- the incorrect config settings for mmf transformer on
VQA2.0
- relaunching of a run using cmd api was adding multiple callbacks to
trainer as callbacks are a class variable. This PR also reset callbacks
in each setup so that multiple logs or checkpoints are seen.
- remove lru caching of logging functionality as they are only called
once and cause issue with caching when called in cmd api
- add evaluation configuration options to trainer configs in tests

Test Plan:

Tested with UniT, VisualBERT on Hateful Memes, MMFT on VQA2. Added
extensive tests as well.