### PR TITLE
[fixup] add update_registry_for_model to datamodules

### DIFF
--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -208,6 +208,8 @@ def build_multiple_datamodules(
             dataset_config = OmegaConf.create()
         datamodule_instance.prepare_data(dataset_config)
         datamodule_instance.setup()
+        if hasattr(datamodule_instance, "update_registry_for_model"):
+            datamodule_instance.update_registry_for_model(dataset_config)
         datamodules[dataset] = datamodule_instance
     return datamodules
 


### PR DESCRIPTION
Call `update_registry_for_model` to datamodules to register e.g. answer
num. Fix #847.

Test plan: tested locally with M4C and M4C-Captioner
