### PR TITLE
[fix] test error when using the new datamodule api

### DIFF
--- a/mmf/datasets/iteration_strategies.py
+++ b/mmf/datasets/iteration_strategies.py
@@ -108,6 +108,10 @@ class ConstantIterationStrategy(IterationStrategy):
         super().__init__(config, dataloaders, *args, **kwargs)
         self._idx = self.config.idx
 
+    @property
+    def should_exhaust_all_iterators(self) -> bool:
+        return True
+
     def __call__(self, *args, **kwargs):
         return self._idx
 

--- a/tests/trainers/lightning/test_utils.py
+++ b/tests/trainers/lightning/test_utils.py
@@ -106,6 +106,7 @@ def get_mmf_trainer(
         scheduler_config=scheduler_config,
         grad_clipping_config=grad_clipping_config,
     )
+    trainer.load_datasets()
     model.to(trainer.device)
     trainer.model = model
     return trainer

--- a/tests/trainers/test_eval_loop.py
+++ b/tests/trainers/test_eval_loop.py
@@ -4,30 +4,19 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
-from tests.datasets.test_multi_datamodule import MultiDataModuleTestObject
 from tests.trainers.test_training_loop import TrainerTrainingLoopMock
 
 
-class MMFTrainerMock(TrainerTrainingLoopMock):
-    def __init__(self, num_train_data, max_updates, max_epochs, device="cuda"):
-        super().__init__(num_train_data, max_updates, max_epochs)
-
-    def load_datasets(self):
-        self.dataset_loader = MultiDataModuleTestObject(batch_size=1)
-        self.train_loader = self.dataset_loader.train_dataloader()
-        self.val_loader = self.dataset_loader.val_dataloader()
-        self.test_loader = self.dataset_loader.test_dataloader()
-
-
 class TestEvalLoop(unittest.TestCase):
-    def test_eval_loop(self):
+    @patch(
+        "mmf.common.test_reporter.PathManager",
+        return_value=MagicMock(return_value=None),
+    )
+    @patch("mmf.common.test_reporter.get_mmf_env", return_value="")
+    def test_eval_loop(self, a, b):
         torch.random.manual_seed(2)
-        with patch(
-            "mmf.common.test_reporter.PathManager",
-            return_value=MagicMock(return_value=None),
-        ):
-            trainer = MMFTrainerMock(100, 2, 2)
-            trainer.load_datasets()
-            combined_report, meter = trainer.evaluation_loop("val")
-            self.assertAlmostEqual(combined_report["losses"]["loss"], 493377.5312)
-            self.assertAlmostEqual(combined_report["logits"].item(), -0.2379742, 6)
+        trainer = TrainerTrainingLoopMock(100, max_updates=2, max_epochs=2)
+        trainer.load_datasets()
+        combined_report, meter = trainer.evaluation_loop("val")
+        self.assertAlmostEqual(combined_report["losses"]["loss"], 493377.5312)
+        self.assertAlmostEqual(combined_report["logits"].item(), -0.2379742, 6)

--- a/tests/trainers/test_fp16.py
+++ b/tests/trainers/test_fp16.py
@@ -45,6 +45,7 @@ class TestFp16(unittest.TestCase):
     @skip_if_no_cuda
     def test_fp16_works(self):
         trainer = MMFTrainerMock(100, 2, 0.04)
+        trainer.load_datasets()
         trainer.load_fp16_scaler()
         self.assertTrue(isinstance(trainer.scaler, torch.cuda.amp.GradScaler))
         self.assertEqual(trainer.current_iteration, 0)
@@ -54,5 +55,6 @@ class TestFp16(unittest.TestCase):
     @skip_if_no_cuda
     def test_fp16_values(self):
         trainer = MMFTrainerMock(100, 2, 0.04, fp16_model=True)
+        trainer.load_datasets()
         trainer.load_fp16_scaler()
         trainer.training_loop()

--- a/tests/trainers/test_sharded_ddp.py
+++ b/tests/trainers/test_sharded_ddp.py
@@ -84,6 +84,7 @@ class TestShardedDDP(unittest.TestCase):
     @unittest.skipUnless(FAIRSCALE_AVAILABLE, "Tests for fairscale")
     def test_no_sharding(self):
         self.trainer = MMFTrainerMock(self.config_no_oss, 100, 2, 0.04)
+        self.trainer.load_datasets()
 
         self.assertFalse(isinstance(self.trainer.optimizer, OSS))
 

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -1,17 +1,60 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import functools
 import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
-from mmf.common.meter import Meter
 from mmf.common.registry import registry
 from mmf.common.sample import SampleList
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+from mmf.datasets.multi_datamodule import MultiDataModule
 from mmf.trainers.callbacks.lr_scheduler import LRSchedulerCallback
 from mmf.trainers.mmf_trainer import MMFTrainer
 from mmf.utils.general import get_batch_size
 from omegaconf import OmegaConf
 from tests.test_utils import NumbersDataset, SimpleModel
+
+
+class MultiDataModuleNumbersTestObject(MultiDataModule):
+    def __init__(self, num_data, batch_size):
+        self.batch_size = batch_size
+        config = OmegaConf.create(
+            {
+                "use_features": True,
+                "annotations": {
+                    "train": "not_a_real_annotations_dataset",
+                    "val": "not_a_real_annotations_dataset",
+                },
+                "features": {
+                    "train": "not_a_real_features_dataset",
+                    "val": "not_a_real_features_dataset",
+                },
+                "dataset_config": {"simple": 0},
+            }
+        )
+        self._num_data = num_data
+        self._batch_size = batch_size
+        self.config = config
+        self.dataset_list = []
+        dataset_builder = MMFDatasetBuilder(
+            "simple", functools.partial(NumbersDataset, num_examples=num_data)
+        )
+        dataset_builder.train_dataloader = self._get_dataloader
+        dataset_builder.val_dataloader = self._get_dataloader
+        dataset_builder.test_dataloader = self._get_dataloader
+        self.datamodules = {"simple": dataset_builder}
+
+    def _get_dataloader(self):
+        dataset = NumbersDataset(self._num_data)
+        dataloader = torch.utils.data.DataLoader(
+            dataset=dataset,
+            batch_size=self._batch_size,
+            shuffle=False,
+            num_workers=1,
+            drop_last=False,
+        )
+        return dataloader
 
 
 class TrainerTrainingLoopMock(MMFTrainer):
@@ -29,36 +72,37 @@ class TrainerTrainingLoopMock(MMFTrainer):
         on_update_end_fn=None,
         scheduler_config=None,
         grad_clipping_config=None,
+        tensorboard=False,
     ):
         if config is None:
             self.config = OmegaConf.create(
                 {
                     "training": {
                         "detect_anomaly": False,
-                        "evaluation_interval": 1000,
+                        "evaluation_interval": 10000,
                         "update_frequency": update_frequency,
                         "fp16": fp16,
                         "batch_size": batch_size,
                         "batch_size_per_device": batch_size_per_device,
+                        "tensorboard": tensorboard,
                     }
                 }
             )
             self.training_config = self.config.training
         else:
+            config.training.batch_size = batch_size
+            config.training.fp16 = fp16
+            config.training.update_frequency = update_frequency
+            config.training.tensorboard = tensorboard
             self.training_config = config.training
             self.config = config
 
-        # Load batch size with custom config and cleanup
-        original_config = registry.get("config")
         registry.register("config", self.config)
-        batch_size = get_batch_size()
-        registry.register("config", original_config)
 
         if max_updates is not None:
             self.training_config["max_updates"] = max_updates
         if max_epochs is not None:
             self.training_config["max_epochs"] = max_epochs
-
         self.model = SimpleModel({"in_dim": 1})
         self.model.build()
         if torch.cuda.is_available():
@@ -68,9 +112,6 @@ class TrainerTrainingLoopMock(MMFTrainer):
             self.device = "cpu"
         self.distributed = False
 
-        self.dataset_loader = MagicMock()
-        self.dataset_loader.seed_sampler = MagicMock(return_value=None)
-        self.dataset_loader.prepare_batch = lambda x: SampleList(x)
         if optimizer is None:
             self.optimizer = MagicMock()
             self.optimizer.step = MagicMock(return_value=None)
@@ -88,7 +129,6 @@ class TrainerTrainingLoopMock(MMFTrainer):
                 if on_update_end_fn
                 else self.lr_scheduler_callback.on_update_end
             )
-
         if grad_clipping_config:
             self.training_config.clip_gradients = True
             self.training_config.max_grad_l2_norm = grad_clipping_config[
@@ -96,15 +136,6 @@ class TrainerTrainingLoopMock(MMFTrainer):
             ]
             self.training_config.clip_norm_mode = grad_clipping_config["clip_norm_mode"]
 
-        dataset = NumbersDataset(num_train_data)
-        self.train_loader = torch.utils.data.DataLoader(
-            dataset=dataset,
-            batch_size=batch_size,
-            shuffle=False,
-            num_workers=1,
-            drop_last=False,
-        )
-        self.train_loader.current_dataset = dataset
         self.on_batch_start = MagicMock(return_value=None)
         self.on_update_start = MagicMock(return_value=None)
         self.logistics_callback = MagicMock(return_value=None)
@@ -113,14 +144,25 @@ class TrainerTrainingLoopMock(MMFTrainer):
         self.on_update_end = (
             on_update_end_fn if on_update_end_fn else MagicMock(return_value=None)
         )
-        self.meter = Meter()
         self.after_training_loop = MagicMock(return_value=None)
         self.on_validation_start = MagicMock(return_value=None)
         self.scaler = torch.cuda.amp.GradScaler(enabled=False)
-        self.val_loader = MagicMock(return_value=None)
         self.early_stop_callback = MagicMock(return_value=None)
         self.on_validation_end = MagicMock(return_value=None)
         self.metrics = MagicMock(return_value={})
+
+        self.num_data = num_train_data
+
+    def load_datasets(self):
+        self.dataset_loader = MultiDataModuleNumbersTestObject(
+            num_data=self.num_data, batch_size=self.config.training.batch_size
+        )
+        self.dataset_loader.seed_sampler = MagicMock(return_value=None)
+        self.dataset_loader.prepare_batch = lambda x: SampleList(x)
+
+        self.train_loader = self.dataset_loader.train_dataloader()
+        self.val_loader = self.dataset_loader.val_dataloader()
+        self.test_loader = self.dataset_loader.test_dataloader()
 
 
 class TestTrainingLoop(unittest.TestCase):
@@ -163,6 +205,7 @@ class TestTrainingLoop(unittest.TestCase):
 
     def test_update_frequency_correct_final_iteration(self):
         trainer = TrainerTrainingLoopMock(100, 2, None, update_frequency=2)
+        trainer.load_datasets()
         trainer.training_loop()
         self.assertEqual(trainer.max_updates, 2)
         self.assertEqual(trainer.current_iteration, 4)
@@ -175,6 +218,7 @@ class TestTrainingLoop(unittest.TestCase):
             update_frequency=2,
             batch_size=2,
         )
+        trainer1.load_datasets()
         trainer2 = self._train_with_condition(
             num_train_data=100,
             max_updates=2,
@@ -182,6 +226,7 @@ class TestTrainingLoop(unittest.TestCase):
             update_frequency=1,
             batch_size=4,
         )
+        trainer2.load_datasets()
         self._compare_model_params(trainer1, trainer2)
 
     def _compare_model_params(self, trainer1, trainer2):
@@ -210,8 +255,10 @@ class TestTrainingLoop(unittest.TestCase):
             optimizer=opt,
             update_frequency=update_frequency,
             batch_size=batch_size,
-            on_update_end_fn=on_update_end_fn,
         )
+        trainer.load_datasets()
+        if on_update_end_fn:
+            trainer.on_update_end = on_update_end_fn
         model.to(trainer.device)
         trainer.model = model
         trainer.training_loop()
@@ -219,6 +266,7 @@ class TestTrainingLoop(unittest.TestCase):
 
     def test_epoch_over_updates(self):
         trainer = TrainerTrainingLoopMock(100, 2, 0.04)
+        trainer.load_datasets()
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 4)
 
@@ -228,6 +276,7 @@ class TestTrainingLoop(unittest.TestCase):
 
     def test_fractional_epoch(self):
         trainer = TrainerTrainingLoopMock(100, None, 0.04)
+        trainer.load_datasets()
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 4)
 
@@ -237,6 +286,7 @@ class TestTrainingLoop(unittest.TestCase):
 
     def test_updates(self):
         trainer = TrainerTrainingLoopMock(100, 2, None)
+        trainer.load_datasets()
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 2)
 
@@ -249,12 +299,20 @@ class TestTrainingLoop(unittest.TestCase):
         # as the first one is what will be used
         with patch("mmf.utils.general.get_world_size", return_value=2):
             trainer = TrainerTrainingLoopMock(100, 2, None, batch_size=4)
+            registry.register("config", trainer.config)
+            batch_size = get_batch_size()
+            trainer.config.training.batch_size = batch_size
+            trainer.load_datasets()
             # Train loader has batch size per device, for global batch size 4
             # with world size 2, batch size per device should 4 // 2 = 2
-            self.assertEqual(trainer.train_loader.batch_size, 2)
+            self.assertEqual(trainer.train_loader.current_loader.batch_size, 2)
             # This is per device, so should stay same
             trainer = TrainerTrainingLoopMock(100, 2, None, batch_size_per_device=4)
-            self.assertEqual(trainer.train_loader.batch_size, 4)
+            registry.register("config", trainer.config)
+            batch_size = get_batch_size()
+            trainer.config.training.batch_size = batch_size
+            trainer.load_datasets()
+            self.assertEqual(trainer.train_loader.current_loader.batch_size, 4)
 
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 2)


### PR DESCRIPTION
* Updated the TrainerTrainingLoop object to use the new datamodules API + iteration_strategy API
* Fixed bug related to API change for the per_gpu_batch_size test
* Fixed the test_eval test to use the new API
* Fixed the default iteration strategy (constant) to use `should_exhaust_all_iterators`=True. This is when multi-task condition is false. This was the default behavior before the iteration strategy API update. 

Test Plan:
run `pytest tests`