### PR TITLE
[fix] Download functionality work for frcnn

### DIFF
--- a/tools/scripts/features/frcnn/extract_features_frcnn.py
+++ b/tools/scripts/features/frcnn/extract_features_frcnn.py
@@ -23,7 +23,15 @@ from tools.scripts.features.frcnn.processing_image import Preprocess
 
 class FeatureExtractor:
 
-    MODEL_URL = {"LXMERT": "unc-nlp/frcnn-vg-finetuned"}
+    MODEL_URL = {
+        "FRCNN": "https://s3.amazonaws.com/models.huggingface.co/bert/unc-nlp/"
+        + "frcnn-vg-finetuned/pytorch_model.bin"
+    }
+
+    CONFIG_URL = {
+        "FRCNN": "https://s3.amazonaws.com/models.huggingface.co/bert/unc-nlp/"
+        + "frcnn-vg-finetuned/config.yaml"
+    }
 
     def __init__(self):
         self.args = self.get_parser().parse_args()
@@ -32,16 +40,19 @@ class FeatureExtractor:
     def get_parser(self):
         parser = argparse.ArgumentParser()
         parser.add_argument(
-            "--model_name",
-            default="LXMERT",
-            type=str,
-            help="Model to use for detection",
+            "--model_name", default="FRCNN", type=str, help="Model to use for detection"
         )
         parser.add_argument(
             "--model_file",
             default=None,
             type=str,
             help="Huggingface model file. This overrides the model_name param.",
+        )
+        parser.add_argument(
+            "--config_name",
+            default="FRCNN",
+            type=str,
+            help="Config to use for detection",
         )
         parser.add_argument(
             "--config_file", default=None, type=str, help="Huggingface config file"
@@ -118,7 +129,7 @@ class FeatureExtractor:
             frcnn_cfg = Config.from_pretrained(self.args.config_file)
         else:
             frcnn_cfg = Config.from_pretrained(
-                self.MODEL_URL.get(self.args.model_name, self.args.model_name)
+                self.CONFIG_URL.get(self.args.config_name, self.args.config_name)
             )
         if self.args.model_file:
             frcnn = GeneralizedRCNN.from_pretrained(

--- a/tools/scripts/features/frcnn/modeling_frcnn.py
+++ b/tools/scripts/features/frcnn/modeling_frcnn.py
@@ -36,6 +36,7 @@ from tools.scripts.features.frcnn.frcnn_utils import (
     WEIGHTS_NAME,
     Config,
     cached_path,
+    is_remote_url,
     load_checkpoint,
 )
 
@@ -1825,7 +1826,9 @@ class GeneralizedRCNN(nn.Module):
                             WEIGHTS_NAME, pretrained_model_name_or_path
                         )
                     )
-            elif os.path.isfile(pretrained_model_name_or_path):
+            elif os.path.isfile(pretrained_model_name_or_path) or is_remote_url(
+                pretrained_model_name_or_path
+            ):
                 archive_file = pretrained_model_name_or_path
             elif os.path.isfile(pretrained_model_name_or_path + ".index"):
                 assert (


### PR DESCRIPTION
Fixed the downloading functionality
for the FRCNN feature extraction script.

This resolves the TODO of using the
mmf download functionality to download
the configs and models.

Also updated the script to directly use
the huggingface urls

Resolves: #836 
