### PR TITLE
[feat] Device of tensor being added to SampleList is checked #567

### DIFF
--- a/mmf/common/sample.py
+++ b/mmf/common/sample.py
@@ -312,6 +312,12 @@ class SampleList(OrderedDict):
                 )
             )
 
+        if tensor_field is not None:
+            device = self[tensor_field].device
+            if isinstance(data, torch.Tensor) and data.device != device:
+                if hasattr(data, "to"):
+                        data = data.to(device) # ensures the data being added is on the same device as existing tensors
+
         if isinstance(data, collections.abc.Mapping):
             self[field] = SampleList(data)
         else:


### PR DESCRIPTION
The requirement was that when adding a tensor to an existing sample_list, the add_field method should check:

1. If a tensor field exists. 
2. The device of the tensor field.

The device of the tensor being added should be same as the device of the tensor field. If it isn't, migrate the data item to be added to the device of the tensor field. 

I have tested this in the case where:
I have a sample_list with device='cuda:0', I try to add data item with 'device=cpu' and the code successfully detects the device discrepancy and migrates the device of new data item to 'cuda:0'. 

Kindly let me know if my interpretation of the feature requirement is correct. 