### PR TITLE
[feat] make it optional to tie mlm head weights to text_encoder embedding weights

### DIFF
--- a/mmf/configs/models/mmf_transformer/defaults.yaml
+++ b/mmf/configs/models/mmf_transformer/defaults.yaml
@@ -39,4 +39,5 @@ model_config:
     layer_norm_weight_fill: 1.0
     random_initialize: false
     freeze_image_encoder: false
+    tie_weight_to_text_encoder: false
     num_labels: 2

--- a/mmf/datasets/multi_datamodule.py
+++ b/mmf/datasets/multi_datamodule.py
@@ -29,6 +29,8 @@ class MultiDataModule(pl.LightningDataModule):
         self.batch_size = get_batch_size()
 
         self.dataset_list: List[str] = dataset_list_from_config(self.config)
+        # logger.info("++++++++++ dataset_list")
+        # logger.info(self.dataset_list)
         self.datamodules: List[pl.LightningDataModule] = build_multiple_datamodules(
             self.dataset_list, self.config.dataset_config
         )

--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -37,6 +37,7 @@ class HuggingfaceEmbeddings(nn.Module):
         self.layer_norms = nn.ModuleList()
         self.dropouts = nn.ModuleList()
         self.modality_keys: List = []
+        self.print_idx = 0
 
         # Build layers for each modality and initialize
         self.build_layers()
@@ -141,17 +142,27 @@ class HuggingfaceEmbeddings(nn.Module):
             )
         ):
             modality_name = self.modality_keys[idx]
+            if self.print_idx < 10:
+                # print(f"================ tokens_ids_{modality_name} ")
+                # print(tokens_ids[modality_name])
+                # print(tokens_ids[modality_name].shape)
+                self.print_idx += 1
+
             total_embedding = token_emb(tokens_ids[modality_name])
 
             if modality_name in position_ids:
                 total_embedding += pos_emb(position_ids[modality_name])
 
             if modality_name in segment_ids:
+                # print("************* token_type_embeddings")
+                # print(segment_ids[modality_name])
                 total_embedding += self.token_type_embeddings(
                     segment_ids[modality_name]
                 )
 
             list_embeddings.append(dropout(layer_norm(total_embedding)))
+            if self.print_idx < 10:
+                print(f"finish {modality_name}")
 
         return torch.cat(list_embeddings, dim=1)
 

--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -336,6 +336,8 @@ class BaseTransformerBackend(nn.Module, ABC):
         embedding = self.generate_embeddings(
             tokens_ids, position_ids, segment_ids, attention_mask
         )
+        # print("--- concated inputs")
+        # print(embedding.shape)
 
         # Encoder
         encoded_layers = self.generate_encoded_layers(embedding, attention_mask)

--- a/mmf/modules/encoders.py
+++ b/mmf/modules/encoders.py
@@ -301,7 +301,12 @@ class TorchvisionResNetImageEncoder(Encoder):
     def forward(self, x):
         # B x 3 x 224 x 224 -> B x 2048 x 7 x 7
         out = self.model(x)
-        return out
+        # print("-------------")
+        # print(out.shape)
+        # print("-------------")
+        # out = torch.flatten(out, start_dim=2)
+        # out = out.transpose(1, 2).contiguous()
+        return out  # BxNx2048
 
 
 @registry.register_encoder("detectron2_resnet")

--- a/mmf/trainers/core/training_loop.py
+++ b/mmf/trainers/core/training_loop.py
@@ -13,7 +13,7 @@ from mmf.common.sample import to_device
 from mmf.utils.distributed import is_xla
 from mmf.utils.general import clip_gradients, get_max_updates
 from torch import Tensor
-
+from mmf.utils.distributed import get_rank
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +75,10 @@ class TrainerTrainingLoopMixin(ABC):
 
             should_start_update = True
             for idx, batch in enumerate(self.train_loader):
+
+                # print(f"Duplicate batch check - rank {get_rank()}")
+                # print(batch)
+
                 if should_start_update:
                     combined_report = None
                     self._start_update()

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -21,6 +21,7 @@ from mmf.utils.distributed import is_dist_initialized, is_master, is_xla, synchr
 from mmf.utils.general import get_optimizer_parameters
 from omegaconf import DictConfig, OmegaConf
 
+logger = logging.getLogger(__name__)
 
 try:
     import torch_xla.core.xla_model as xm  # noqa
@@ -197,15 +198,21 @@ def build_multiple_datamodules(
 ) -> Dict[str, pl.LightningDataModule]:
     datamodules: Dict[str, pl.LightningDataModule] = {}
     for dataset in dataset_list:
+        logger.info("++++++++++ for dataset in dataset_list")
+        logger.info(dataset)
         datamodule_instance = build_datamodule(dataset)
         if dataset in all_dataset_config:
             dataset_config = all_dataset_config[dataset]
+            logger.info("++++++++++ if dataset in all_dataset_config:")
+            logger.info(dataset_config)
         else:
             warnings.warn(
                 f"Dataset {dataset} is missing from dataset_config"
                 + " in config. Proceeding with empty config."
             )
             dataset_config = OmegaConf.create()
+            logger.info("else")
+            logger.info(dataset_config)
         datamodule_instance.prepare_data(dataset_config)
         datamodule_instance.setup()
         if hasattr(datamodule_instance, "update_registry_for_model"):
@@ -243,6 +250,9 @@ def build_dataloader_and_sampler(
         "shuffle": datamodule_config.get("shuffle", None),
         "batch_size": datamodule_config.get("batch_size", None),
     }
+    logger.info("=--=-=-== datamodule_config")
+    logger.info(datamodule_config)
+    logger.info(other_args)
 
     # IterableDataset returns batches directly, so no need to add Sampler
     # or batch size as user is expected to control those. This is a fine

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -33,13 +33,31 @@ def clip_gradients(model, optimizer, i_iter, writer, config, scale=1.0):
     max_grad_l2_norm = config.training.max_grad_l2_norm
     clip_norm_mode = config.training.clip_norm_mode
 
+    # Monitoring grad_norm of certain layer
+    ie_tt_gn = nn.utils.clip_grad_norm_(
+        model.encoders["image"].parameters(), 1e10, error_if_nonfinite=False
+    )
+    # print(f"image_encoder_total_gn = {ie_tt_gn}")
+    # print(list(model.encoders["image"].named_parameters())[-3][0])
+    ie_ll_gn = nn.utils.clip_grad_norm_(
+        list(model.encoders["image"].named_parameters())[-3][1],
+        1e10,
+        error_if_nonfinite=False,
+    )
+    # print(f"image_encoder_last_layer_gn = {ie_ll_gn}")
+    if writer is not None:
+        writer.add_scalars({"image_encoder_total_gn": ie_tt_gn}, i_iter)
+        writer.add_scalars({"image_encoder_last_layer_gn": ie_ll_gn}, i_iter)
+
     if max_grad_l2_norm is not None:
         if clip_norm_mode == "all":
             if hasattr(optimizer, "clip_grad_norm"):
                 norm = optimizer.clip_grad_norm(max_grad_l2_norm * scale)
             else:
                 norm = nn.utils.clip_grad_norm_(
-                    model.parameters(), max_grad_l2_norm * scale
+                    model.parameters(),
+                    max_grad_l2_norm * scale,
+                    error_if_nonfinite=False,
                 )
             if writer is not None:
                 writer.add_scalars({"grad_norm": norm}, i_iter)


### PR DESCRIPTION
Summary: Make it possible to have the mlm head weights tied to text_encoder embedding weights in case we have a separate text encoder for encoding text modalities.

Differential Revision: D27728450

