### PR TITLE
[fix] Fixed drop_last setting and all_gather for xla device.

### DIFF
--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -259,7 +259,7 @@ def build_dataloader_and_sampler(
         collate_fn=BatchCollator(
             dataset_instance.dataset_name, dataset_instance.dataset_type
         ),
-        drop_last=False,  # see also MultiDatasetLoader.__len__
+        drop_last=is_xla(),  # see also MultiDatasetLoader.__len__
         **other_args,
     )
 

--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -135,7 +135,7 @@ def gather_tensor(tensor):
             tensor_list = tensor_list.view(world_size, *tensor.size())
         else:
             dist.all_gather(tensor_list, tensor)
-        tensor_list = torch.stack(tensor_list, dim=0)
+            tensor_list = torch.stack(tensor_list, dim=0)
     return tensor_list
 
 


### PR DESCRIPTION
fixed drop_last setting for xla aligned with length computation.  fixed all gather (torch.stack only needed for GPU path.)