### PR TITLE
[feat] make it optional to tie mlm head weights to text_encoder embedding weights

### DIFF
--- a/mmf/configs/models/mmf_transformer/defaults.yaml
+++ b/mmf/configs/models/mmf_transformer/defaults.yaml
@@ -39,4 +39,5 @@ model_config:
     layer_norm_weight_fill: 1.0
     random_initialize: false
     freeze_image_encoder: false
+    tie_weight_to_text_encoder: false
     num_labels: 2

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import logging
 from dataclasses import dataclass, field
 from typing import Dict, List
 
@@ -16,6 +17,8 @@ from mmf.modules.encoders import ResNet152ImageEncoder
 from mmf.utils.build import build_encoder
 from omegaconf import MISSING, OmegaConf
 from torch import Tensor, nn
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -48,6 +51,7 @@ class MMFTransformer(BaseTransformer):
         random_initialize: bool = False
         freeze_transformer: bool = False
         freeze_image_encoder: bool = False
+        tie_weight_to_text_encoder: bool = False
         finetune_lr_multiplier: float = 1
         backend: BaseTransformerBackendConfig = MMFTransformerBackendConfig(
             type="huggingface"
@@ -134,9 +138,19 @@ class MMFTransformer(BaseTransformer):
         text_embedding_idx = self.modality_type.index("text")
         if text_embedding_idx >= 0:
             for head in self.heads:
-                head.tie_weights(
-                    self.backend.embeddings.token_embeddings[text_embedding_idx]
-                )
+                if getattr(self.config, "tie_weight_to_text_encoder", False):
+                    assert "text" in self.encoders, (
+                        "MMFT needs to have a text encoder to tie weights to "
+                        + "its token embeddings."
+                    )
+                    logger.info("Tie weights to text_encoder input embeddings")
+                    head.tie_weights(
+                        self.encoders["text"].transformer.transformer.token_embedding
+                    )
+                else:
+                    head.tie_weights(
+                        self.backend.embeddings.token_embeddings[text_embedding_idx]
+                    )
 
     def preprocess_sample(
         self, sample_list: Dict[str, Tensor]


### PR DESCRIPTION
Summary: Make it possible to have the mlm head weights tied to text_encoder embedding weights in case we have a separate text encoder for encoding text modalities.

Differential Revision: D27756957

