### PR TITLE
[feat] Adds audio (resnet18) and video (r2plus1d18) encoders

### DIFF
--- a/mmf/configs/models/mmf_transformer/with_audio_video.yaml
+++ b/mmf/configs/models/mmf_transformer/with_audio_video.yaml
@@ -1,0 +1,49 @@
+model_config:
+  mmf_transformer:
+    transformer_base: bert-base-uncased
+    modalities:
+      - type: text
+        key: text
+        segment_id: 0
+      - type: video
+        key: video
+        embedding_dim: 512
+        segment_id: 1
+        encoder:
+          type: r2plus1d_18
+          params:
+            num_output_features: 1
+            pool_type: avg
+            out_dim: 2048
+            three_d: true
+      - type: audio
+        key: audio
+        embedding_dim: 512
+        segment_id: 2
+        encoder:
+          type: resnet18_audio
+          params:
+            num_output_features: 1
+            pool_type: avg
+            out_dim: 2048
+            three_d: false
+    initializer_range: 0.02
+    initializer_mean: 0.0
+    layer_norm_weight_fill: 1.0
+    random_initialize: false
+    freeze_base: false
+    token_noise_std: 0.01
+    token_noise_mean: 0.0
+    finetune_lr_multiplier: 1
+    image_encoder:
+      type: resnet152
+      params:
+        pretrained: true
+        pool_type: avg
+        num_output_features: 1
+    freeze_encoder: false
+    heads:
+      - type: mlp
+        num_labels: ???
+    losses:
+    - type: logit_bce

--- a/tests/modules/test_encoders.py
+++ b/tests/modules/test_encoders.py
@@ -5,6 +5,7 @@ import unittest
 
 import torch
 from mmf.modules import encoders
+from omegaconf import OmegaConf
 from tests.test_utils import setup_proxy
 from torch import nn
 
@@ -64,3 +65,19 @@ class TestEncoders(unittest.TestCase):
         text_embeddings = encoder(text_ids, return_sequence=True)
         self.assertEqual(text_embeddings.dim(), 3)
         self.assertEqual(list(text_embeddings.size()), [2, 16, 768])
+
+    def test_r2plus1d18_video_encoder(self):
+        config = OmegaConf.structured(
+            encoders.R2Plus1D18VideoEncoder.Config(pretrained=False)
+        )
+        encoder = encoders.R2Plus1D18VideoEncoder(config)
+        x = torch.rand((1, 3, 16, 112, 112))
+        output = encoder(x)
+        self.assertEqual(output.size(-1), config.out_dim)
+
+    def test_resnet18_audio_encoder(self):
+        config = OmegaConf.structured(encoders.ResNet18AudioEncoder.Config())
+        encoder = encoders.ResNet18AudioEncoder(config)
+        x = torch.rand((1, 1, 4778, 224))
+        output = encoder(x)
+        self.assertEqual(output.size(-1), config.out_dim)


### PR DESCRIPTION
This PR adds support for audio and video modality encoders to MMF. These
can be used in conjunction with MMFTransformer. An example config has
been added to showcase the usage.

Test Plan:
Unit tests have been added.
