### PR TITLE
[fix] regression in tests for lightning with recent change

### DIFF
--- a/tests/trainers/lightning/test_loss.py
+++ b/tests/trainers/lightning/test_loss.py
@@ -31,7 +31,12 @@ class TestLightningTrainerLoss(unittest.TestCase, Callback):
     def on_train_batch_end(
         self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx
     ):
-        report = Report(outputs["input_batch"], outputs)
+        # TODO(asg): Ask Sasha to investigate what is happening here in depth
+        if "losses" in outputs:
+            output = outputs
+        else:
+            output = outputs[0][0]["extra"]
+        report = Report(output["input_batch"], output)
         self.lightning_losses.append(report["losses"]["loss"].item())
 
     def on_train_end(self, trainer, pl_module):


### PR DESCRIPTION
Regression caused by https://github.com/facebookresearch/mmf/commit/868c5892cf7607cdeca3df386fa7810ca1ba9b67
Fixes #876

Test Plan:
pytest

