### PR TITLE
[mmf_ads][feat] Multi-task Learning

### DIFF
--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -419,7 +419,7 @@ class MultiLoss(nn.Module):
         loss = 0
         for idx, loss_fn in enumerate(self.losses):
             value = loss_fn(sample_list, model_output, *args, **kwargs)
-            loss += self.losses_weights[idx] * value
+            loss += self.losses_weights[idx] * list(value.values())[0]
         return loss
 
 
@@ -571,10 +571,8 @@ class M4CDecodingBCEWithMaskLoss(nn.Module):
 
 @registry.register_loss("cross_entropy")
 class CrossEntropyLoss(nn.Module):
-    def __init__(self, params=None):
+    def __init__(self, **params):
         super().__init__()
-        if params is None:
-            params = {}
         self.loss_fn = nn.CrossEntropyLoss(**params)
 
     def forward(self, sample_list, model_output):


### PR DESCRIPTION
Summary:
We fixed a small bug in `mmf/modules/losses.py`. When there are multiple loss, the returned losses from MMFLoss is a dictionary. We need to unwrap its values for summing the total loss.

Internally, we add multi-task learning for mmf_ads. Specifically, now it support two tasks:
1) megataxon classification
2) img cluster classification

Differential Revision: D27730656

