### PR TITLE
[feat] Charades dataset along with video and audio processors

### DIFF
--- a/mmf/configs/datasets/charades/defaults.yaml
+++ b/mmf/configs/datasets/charades/defaults.yaml
@@ -1,0 +1,75 @@
+dataset_config:
+  charades:
+    data_dir: ${env.data_dir}/datasets
+    zoo_requirements:
+    - charades.defaults
+    prediction_threshold: 0.5
+    annotations:
+      train:
+      - charades/defaults/Charades/Charades_v1_train.csv
+      val:
+      - charades/defaults/Charades/Charades_v1_test.csv
+      test:
+      - charades/defaults/Charades/Charades_v1_test.csv
+    videos:
+      train:
+      - charades/defaults/Charades_v1_480
+      val:
+      - charades/defaults/Charades_v1_480
+      test:
+      - charades/defaults/Charades_v1_480
+    classes_file: charades/defaults/Charades/Charades_v1_classes.txt
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 128
+      audio_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: truncate_or_pad
+              params:
+                output_size: 1000
+            - MelSpectrogram
+            - ToPILImage
+            - type: Resize
+              params:
+                size: [224, 224]
+            - ToTensor
+      video_train_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - video_to_tensor
+            - type: video_resize
+              params:
+                size: [128, 171]
+            - video_random_horizontal_flip
+            - type: video_normalize
+              params:
+                mean: [0.43216, 0.394666, 0.37645]
+                std: [0.22803, 0.22145, 0.216989]
+            - type: video_random_crop
+              params:
+                size: [112, 112]
+      video_test_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - video_to_tensor
+            - type: video_resize
+              params:
+                size: [128, 171]
+            - type: video_normalize
+              params:
+                mean: [0.43216, 0.394666, 0.37645]
+                std: [0.22803, 0.22145, 0.216989]
+            - type: video_random_crop
+              params:
+                size: [112, 112]

--- a/mmf/configs/zoo/datasets.yaml
+++ b/mmf/configs/zoo/datasets.yaml
@@ -599,3 +599,12 @@ visual_genome:
       - url: mmf://datasets/visual_genome/detection_split_by_coco_2017/annotations/annotations_split_by_coco_2017.tar.gz
         file_name: annotations_split_by_coco_2017.tar.gz
         hashcode: 19129558ef8ba766c1009106ec6f46d62221ec3bb87af505c4157b7e9bcc8e66
+
+charades:
+  defaults:
+    version: 1.0_2020_09_02
+    resources:
+    - url: https://ai2-public-datasets.s3-us-west-2.amazonaws.com/charades/Charades.zip
+      file_name: Charades.zip
+    - url: https://ai2-public-datasets.s3-us-west-2.amazonaws.com/charades/Charades_v1_480.zip
+      file_name: Charades_v1_480.zip

--- a/mmf/datasets/__init__.py
+++ b/mmf/datasets/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from . import processors
 from .base_dataset import BaseDataset
 from .base_dataset_builder import BaseDatasetBuilder
 from .concat_dataset import ConcatDataset
@@ -8,6 +9,7 @@ from .multi_dataset_loader import MultiDatasetLoader
 
 
 __all__ = [
+    "processors",
     "BaseDataset",
     "BaseDatasetBuilder",
     "ConcatDataset",

--- a/mmf/datasets/builders/charades/_utils.py
+++ b/mmf/datasets/builders/charades/_utils.py
@@ -1,0 +1,170 @@
+import logging
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import torch
+from torchvision.datasets.video_utils import VideoClips
+from torchvision.io import read_video
+
+
+logger = logging.getLogger(__name__)
+
+
+def make_charades_df(csv_path, video_dir, classes_file):
+    # load the csv
+    logger.info(f"Reading from {csv_path}")
+    df = pd.read_csv(csv_path)
+
+    # transform the id to a pathname
+    df["path"] = df["id"].map(lambda x: "{}/{}.mp4".format(video_dir, x))
+
+    # parse action labels
+    df["action_labels"] = df["actions"].map(
+        lambda x: [label.split(" ")[0] for label in x.split(";")]
+        if pd.notnull(x)
+        else []
+    )
+
+    # load id to class map
+    with open(classes_file, "r") as f:
+        class_names = f.readlines()
+
+    id2classname = {}
+    for c in class_names:
+        c_split = c.split(" ")
+        assert len(c_split) > 1
+        class_id = c_split[0]
+        class_name = " ".join(c_split[1:]).strip("\n")
+        id2classname[class_id] = class_name
+
+    # transform label ids to names
+    df["action_labels"] = df["action_labels"].map(
+        lambda x: [id2classname[class_id] for class_id in x]
+    )
+
+    # filter only these videos that actually exist
+    df_exists = df[df["path"].map(lambda x: Path(x).exists())]
+
+    return df_exists
+
+
+def img2gif(image_list, temporal_path="./tmp/"):
+    tmp_file = Path(tempfile.NamedTemporaryFile(suffix=".gif").name).name
+    tmp_file = Path(temporal_path) / tmp_file
+    Path(tmp_file.parent).mkdir(exist_ok=True)
+    print("Write to {}".format(tmp_file))
+    with open(tmp_file, "wb") as tmp:
+        image_list[0].save(
+            tmp,
+            format="GIF",
+            append_images=image_list[1:],
+            save_all=True,
+            duration=3,
+            loop=0,
+        )
+    return tmp_file
+
+
+class CharadesVideoClips(VideoClips):
+    @staticmethod
+    def select_clips_from_video(video_pts, num_frames, fps, frame_rate):
+        # this function replaces compute_clips_for_video from original Kinetics400
+        # it yields one clip with evenly separated num_frames
+        if fps is None:
+            # if for some reason the video doesn't have fps
+            # (because doesn't have a video stream) set the fps to 1.
+            # The value doesn't matter, because video_pts is empty anyway
+            fps = 1
+        if frame_rate is None:
+            frame_rate = fps
+
+        idxs = torch.round(torch.linspace(0, len(video_pts) - 1, num_frames)).type(
+            torch.LongTensor
+        )
+
+        video_pts = video_pts[idxs]
+
+        return video_pts, idxs
+
+    def compute_clips(self, num_frames, step, frame_rate=None):
+        self.num_frames = num_frames
+        self.step = step
+        self.frame_rate = frame_rate
+        self.clips = []
+        self.resampling_idxs = []
+        for video_pts, fps in zip(self.video_pts, self.video_fps):
+            clips, idxs = self.select_clips_from_video(
+                video_pts, num_frames, fps, frame_rate
+            )
+            self.clips.append(clips)
+            self.resampling_idxs.append(idxs)
+
+    def __len__(self):
+        return self.num_clips()
+
+    def num_videos(self):
+        return len(self.video_paths)
+
+    def num_clips(self):
+        return len(self.clips)
+
+    def get_clip(self, idx):
+        """
+        Gets a subclip from a list of videos.
+
+        Arguments:
+            idx (int): index of the subclip. Must be between 0 and num_clips().
+
+        Returns:
+            video (Tensor)
+            audio (Tensor)
+            info (Dict)
+            video_idx (int): index of the video in `video_paths`
+        """
+        if idx >= self.num_clips():
+            raise IndexError(
+                "Index {} out of range "
+                "({} number of clips)".format(idx, self.num_clips())
+            )
+        video_path = self.video_paths[idx]
+        clip_pts = self.clips[idx]
+
+        from torchvision import get_video_backend
+
+        backend = get_video_backend()
+
+        if backend == "pyav":
+            # check for invalid options
+            if self._video_width != 0:
+                raise ValueError("pyav backend doesn't support _video_width != 0")
+            if self._video_height != 0:
+                raise ValueError("pyav backend doesn't support _video_height != 0")
+            if self._video_min_dimension != 0:
+                raise ValueError(
+                    "pyav backend doesn't support _video_min_dimension != 0"
+                )
+            if self._video_max_dimension != 0:
+                raise ValueError(
+                    "pyav backend doesn't support _video_max_dimension != 0"
+                )
+            if self._audio_samples != 0:
+                raise ValueError("pyav backend doesn't support _audio_samples != 0")
+
+        if backend == "pyav":
+            assert len(clip_pts) > 0
+            start_pts = clip_pts[0].item()
+            end_pts = clip_pts[-1].item()
+            video, audio, info = read_video(video_path, start_pts, end_pts)
+        else:
+            raise NotImplementedError(f"backend {backend} is not implemented.")
+
+        resampling_idx = self.resampling_idxs[idx]
+        if isinstance(resampling_idx, torch.Tensor):
+            resampling_idx = resampling_idx - resampling_idx[0]
+        video = video[resampling_idx]
+        info["video_fps"] = self.frame_rate
+        assert len(video) == self.num_frames, "{} x {}".format(
+            video.shape, self.num_frames
+        )
+        return video, audio, info

--- a/mmf/datasets/builders/charades/builder.py
+++ b/mmf/datasets/builders/charades/builder.py
@@ -1,0 +1,16 @@
+from mmf.common.registry import registry
+from mmf.datasets.builders.charades.dataset import CharadesDataset
+from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
+
+
+@registry.register_builder("charades")
+class CharadesBuilder(MMFDatasetBuilder):
+    def __init__(
+        self, dataset_name="charades", dataset_class=CharadesDataset, *args, **kwargs
+    ):
+        super().__init__(dataset_name)
+        self.dataset_class = CharadesDataset
+
+    @classmethod
+    def config_path(cls):
+        return "configs/datasets/charades/defaults.yaml"

--- a/mmf/datasets/builders/charades/dataset.py
+++ b/mmf/datasets/builders/charades/dataset.py
@@ -1,0 +1,179 @@
+import os
+
+import PIL
+import torch
+from mmf.common.sample import Sample
+from mmf.datasets.base_dataset import BaseDataset
+from mmf.datasets.builders.charades._utils import (
+    CharadesVideoClips,
+    img2gif,
+    make_charades_df,
+)
+from mmf.utils.distributed import byte_tensor_to_object, object_to_byte_tensor
+from mmf.utils.file_io import PathManager
+
+
+class CharadesDataset(BaseDataset):
+    def __init__(self, config, dataset_type, imdb_file_index, *args, **kwargs):
+        super().__init__("charades", config, dataset_type)
+        self.imdb_file_index = imdb_file_index
+        self.load_df()
+        self.length = len(self.video_clips)
+        self.audio_processor = None
+        self.video_processor = None
+        self.video_train_processor = None
+        self.video_test_processor = None
+        self.prediction_threshold = self.config.get("prediction_threshold", 0.5)
+        # Some pickling related issues can be resolved by loading it at runtime
+        # optionally, uncomment next line if you face those issues.
+        # self.video_clips = []
+
+    def init_processors(self):
+        super().init_processors()
+        self.set_processors()
+
+    def load_df(self):
+        dataset_type = self.dataset_type
+        imdb_file_index = self.imdb_file_index
+        config = self.config
+        csv_path = self.get_resource_path(
+            config, config.annotations.get(dataset_type)[imdb_file_index]
+        )
+        video_dir = self.get_resource_path(
+            config, config.videos.get(dataset_type)[imdb_file_index]
+        )
+        classes_file = self.get_resource_path(config, config.classes_file)
+        df = make_charades_df(
+            csv_path=csv_path, video_dir=video_dir, classes_file=classes_file
+        )
+
+        precomputed_metadata = None
+        pkl_path = os.path.join("charades", "defaults", f"metadata_{dataset_type}.pt")
+        pkl_path = self.get_resource_path(config, pkl_path)
+
+        if PathManager.exists(pkl_path):
+            local_path = PathManager.get_local_path(pkl_path)
+            with PathManager.open(local_path, "rb") as f:
+                precomputed_metadata = torch.load(f)
+
+        self.process_df(
+            df,
+            frames_per_clip=16,
+            column_map={
+                "labels": "action_labels",
+                "video": "path",
+                "text": "script",
+                "id": "id",
+            },
+            num_workers=10,
+            _precomputed_metadata=precomputed_metadata,
+        )
+
+        if not PathManager.exists(pkl_path):
+            with PathManager.open(pkl_path, "wb") as f:
+                torch.save(self.metadata, f)
+
+    def get_resource_path(self, config, path):
+        return os.path.join(config.data_dir, path)
+
+    def process_df(
+        self,
+        df,
+        frames_per_clip=16,
+        column_map={},
+        num_workers=1,
+        _precomputed_metadata=None,
+        **kwargs,
+    ):
+        self.labels = df[column_map.get("labels", "labels")].tolist()
+        self.idx_to_class = sorted(
+            list(set([item for sublist in self.labels for item in sublist]))
+        )
+        self.classes = self.idx_to_class
+        self.class_to_idx = {self.classes[i]: i for i in range(len(self.classes))}
+        self.text_list = df[column_map.get("text", "text")].tolist()
+        self.ids_list = df[column_map.get("id", "id")].tolist()
+
+        video_list = df[column_map.get("video", "video")].tolist()
+        self.video_clips = CharadesVideoClips(
+            video_list,
+            clip_length_in_frames=frames_per_clip,
+            _precomputed_metadata=_precomputed_metadata,
+            num_workers=num_workers,
+        )
+
+    @property
+    def metadata(self):
+        return self.video_clips.metadata
+
+    def set_processors(self):
+        if self.dataset_type == "train":
+            self.video_processor = self.video_train_processor
+        else:
+            self.video_processor = self.video_test_processor
+
+    def format_for_prediction(self, report):
+        scores = torch.sigmoid(report.scores)
+        binary_scores = scores > self.prediction_threshold
+        predictions = []
+
+        for idx, item_id in enumerate(report.id):
+            item_id = byte_tensor_to_object(item_id)
+            score = binary_scores[idx]
+            labels = []
+            score = score.nonzero(as_tuple=False)
+            for item in score:
+                labels.append(self.idx_to_class[item.item()])
+            predictions.append({"id": item_id, "labels": labels})
+
+        return predictions
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, idx):
+        if len(self.video_clips) == 0:
+            self.load_df()
+        video, audio, info = self.video_clips.get_clip(idx)
+        text = self.text_list[idx]
+        actual_idx = self.ids_list[idx]
+        label = [self.class_to_idx[class_name] for class_name in self.labels[idx]]
+        one_hot_label = torch.zeros(len(self.class_to_idx))
+        one_hot_label[label] = 1
+
+        if self.video_processor is not None:
+            video = self.video_processor(video)
+
+        if self.audio_processor is not None:
+            audio = self.audio_processor(audio)
+
+        sample = Sample()
+        sample.id = object_to_byte_tensor(actual_idx)
+        sample.video = video
+        sample.audio = audio
+        sample.update(self.text_processor({"text": text}))
+        sample.targets = one_hot_label
+        return sample
+
+    def show_clip(self, idx):
+        from IPython.display import Image, Audio
+        from IPython.display import display
+
+        video, audio, text, one_hot = self[idx]
+        # one hot to label index
+        label = (
+            torch.arange(one_hot.shape[0])[one_hot == 1].numpy().astype(int).tolist()
+        )
+
+        image_list = [PIL.Image.fromarray(frame.numpy()) for frame in video]
+
+        audio_list = audio.numpy()
+
+        path_to_gif = img2gif(image_list)
+
+        display(
+            "Labels: {}".format(str([self.classes[label_id] for label_id in label]))
+        )
+        display(Image(str(path_to_gif), format="png"))
+        display(Audio(audio_list, rate=48000))
+        display(text)

--- a/mmf/datasets/builders/retrieval/datasets.py
+++ b/mmf/datasets/builders/retrieval/datasets.py
@@ -1,9 +1,8 @@
 import json
 
+import pandas as pd
 import torch
 from mmf.utils.file_io import PathManager
-
-import pandas as pd
 
 
 class CaptionsDatabase(torch.utils.data.Dataset):

--- a/mmf/datasets/processors/functional.py
+++ b/mmf/datasets/processors/functional.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Tuple, Union
+
+import torch
+
+
+# Functional file similar to torch.nn.functional
+def video_crop(vid: torch.tensor, i: int, j: int, h: int, w: int) -> torch.Tensor:
+    return vid[..., i : (i + h), j : (j + w)]
+
+
+def video_center_crop(vid: torch.Tensor, output_size: Tuple[int, int]) -> torch.Tensor:
+    h, w = vid.shape[-2:]
+    th, tw = output_size
+
+    i = int(round((h - th) / 2.0))
+    j = int(round((w - tw) / 2.0))
+    return video_crop(vid, i, j, th, tw)
+
+
+def video_hflip(vid: torch.Tensor) -> torch.Tensor:
+    return vid.flip(dims=(-1,))
+
+
+# NOTE: for those functions, which generally expect mini-batches, we keep them
+# as non-minibatch so that they are applied as if they were 4d (thus image).
+# this way, we only apply the transformation in the spatial domain
+def video_resize(
+    vid: torch.Tensor,
+    size: Union[int, Tuple[int, int]],
+    interpolation: str = "bilinear",
+) -> torch.Tensor:
+    # NOTE: using bilinear interpolation because we don't work on minibatches
+    # at this level
+    scale = None
+    if isinstance(size, int):
+        scale = float(size) / min(vid.shape[-2:])
+        size = None
+    return torch.nn.functional.interpolate(
+        vid, size=size, scale_factor=scale, mode=interpolation, align_corners=False
+    )
+
+
+def video_pad(
+    vid: torch.Tensor, padding: float, fill: float = 0, padding_mode: str = "constant"
+) -> torch.Tensor:
+    # NOTE: don't want to pad on temporal dimension, so let as non-batch
+    # (4d) before padding. This works as expected
+    return torch.nn.functional.pad(vid, padding, value=fill, mode=padding_mode)
+
+
+def video_to_normalized_float_tensor(vid: torch.Tensor) -> torch.Tensor:
+    return vid.permute(3, 0, 1, 2).to(torch.float32) / 255
+
+
+def video_normalize(vid: torch.Tensor, mean: float, std: float) -> torch.Tensor:
+    shape = (-1,) + (1,) * (vid.dim() - 1)
+    mean = torch.as_tensor(mean).reshape(shape)
+    std = torch.as_tensor(std).reshape(shape)
+    return (vid - mean) / std

--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -75,7 +75,7 @@ import re
 import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 import torch
@@ -86,6 +86,7 @@ from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
 from mmf.utils.text import VocabDict
 from mmf.utils.vocab import Vocab, WordToVectorDict
+from omegaconf import DictConfig
 
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ class BaseProcessor:
 
     """
 
-    def __init__(self, config: Dict[str, Any], *args, **kwargs):
+    def __init__(self, *args, config: Optional[DictConfig] = None, **kwargs):
         return
 
     def __call__(self, item: Any, *args, **kwargs) -> Any:

--- a/mmf/datasets/processors/video_processors.py
+++ b/mmf/datasets/processors/video_processors.py
@@ -1,0 +1,126 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# TODO: Once internal torchvision transforms become stable either in torchvision
+# or in pytorchvideo, move to use those transforms.
+import random
+
+import mmf.datasets.processors.functional as F
+import torch
+from mmf.common.registry import registry
+from mmf.datasets.processors import BaseProcessor
+
+
+@registry.register_processor("video_random_crop")
+class VideoRandomCrop(BaseProcessor):
+    def __init__(self, *args, size=None, **kwargs):
+        super().__init__()
+        if size is None:
+            raise TypeError("Parameter 'size' is required")
+        self.size = size
+
+    @staticmethod
+    def get_params(vid, output_size):
+        """Get parameters for ``crop`` for a random crop.
+        """
+        h, w = vid.shape[-2:]
+        th, tw = output_size
+        if w == tw and h == th:
+            return 0, 0, h, w
+        i = random.randint(0, h - th)
+        j = random.randint(0, w - tw)
+        return i, j, th, tw
+
+    def __call__(self, vid):
+        i, j, h, w = self.get_params(vid, self.size)
+        return F.video_crop(vid, i, j, h, w)
+
+
+@registry.register_processor("video_center_crop")
+class VideoCenterCrop(BaseProcessor):
+    def __init__(self, *args, size=None, **kwargs):
+        super().__init__()
+        if size is None:
+            raise TypeError("Parameter 'size' is required")
+        self.size = size
+
+    def __call__(self, vid):
+        return F.video_center_crop(vid, self.size)
+
+
+@registry.register_processor("video_resize")
+class VideoResize(BaseProcessor):
+    def __init__(self, *args, size=None, **kwargs):
+        if size is None:
+            raise TypeError("Parameter 'size' is required")
+        self.size = size
+
+    def __call__(self, vid):
+        return F.video_resize(vid, self.size)
+
+
+@registry.register_processor("video_to_tensor")
+class VideoToTensor(BaseProcessor):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        pass
+
+    def __call__(self, vid):
+        return F.video_to_normalized_float_tensor(vid)
+
+
+@registry.register_processor("video_normalize")
+class VideoNormalize(BaseProcessor):
+    def __init__(self, mean=None, std=None, **kwargs):
+        super().__init__()
+        if mean is None and std is None:
+            raise TypeError("'mean' and 'std' params are required")
+        self.mean = mean
+        self.std = std
+
+    def __call__(self, vid):
+        return F.video_normalize(vid, self.mean, self.std)
+
+
+@registry.register_processor("video_random_horizontal_flip")
+class VideoRandomHorizontalFlip(BaseProcessor):
+    def __init__(self, p=0.5, **kwargs):
+        super().__init__()
+        self.p = p
+
+    def __call__(self, vid):
+        if random.random() < self.p:
+            return F.video_hflip(vid)
+        return vid
+
+
+@registry.register_processor("video_pad")
+class Pad(BaseProcessor):
+    def __init__(self, padding=None, fill=0, **kwargs):
+        super().__init__()
+        if padding is None:
+            raise TypeError("Parameter 'padding' is required")
+        self.padding = padding
+        self.fill = fill
+
+    def __call__(self, vid):
+        return F.video_pad(vid, self.padding, self.fill)
+
+
+@registry.register_processor("truncate_or_pad")
+class TruncateOrPad(BaseProcessor):
+    # truncate or add 0 until the desired output size
+    def __init__(self, output_size=None, **kwargs):
+        super().__init__()
+        if output_size is None:
+            raise TypeError("Parameter 'output_size' is required")
+        assert isinstance(output_size, (int, tuple))
+        self.output_size = output_size
+
+    def __call__(self, sample):
+        if sample.shape[1] >= self.output_size:
+            return sample[0, : self.output_size]
+        else:
+            return torch.cat(
+                (sample[0, :], torch.zeros(1, self.output_size - sample.shape[1])),
+                axis=1,
+            )

--- a/mmf/models/unit/matcher.py
+++ b/mmf/models/unit/matcher.py
@@ -9,9 +9,8 @@ from typing import Dict, List
 
 import torch
 from mmf.utils.box_ops import box_cxcywh_to_xyxy, generalized_box_iou
-from torch import Tensor, nn
-
 from scipy.optimize import linear_sum_assignment
+from torch import Tensor, nn
 
 
 class HungarianMatcher(nn.Module):

--- a/projects/mmf_transformer/configs/charades/direct.yaml
+++ b/projects/mmf_transformer/configs/charades/direct.yaml
@@ -1,0 +1,34 @@
+includes:
+- configs/models/mmf_transformer/with_audio_video.yaml
+
+model_config:
+  mmf_transformer:
+    heads:
+    - type: mlp
+      num_labels: 157
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+scheduler:
+  type: warmup_cosine
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: 60000
+
+evaluation:
+  metrics:
+  - multilabel_micro_f1
+
+training:
+  batch_size: 8
+  lr_scheduler: true
+  # Don't forget to update schedule_attributes if you update this
+  max_updates: 60000
+  find_unused_parameters: true
+  early_stop:
+    criteria: charades/multilabel_micro_f1
+    minimize: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@
 # are considered third party there
 known_third_party = [
     "PIL", "caffe2", "cv2", "demjson", "fairscale", "filelock", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "matplotlib",
-    "mmf", "mmf_cli", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
-    "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
-    "torchtext", "torchvision", "tqdm", "transformers", "pytorch_lightning"
+    "mmf", "mmf_cli", "numpy", "omegaconf", "packaging", "pandas", "pycocoevalcap", "pytorch_sphinx_theme",
+    "recommonmark", "requests", "scipy", "setuptools", "sklearn", "termcolor", "tests", "torch",
+    "torchaudio", "torchtext", "torchvision", "tqdm", "transformers", "pytorch_lightning"
 ]
 skip_glob = "**/build/**,website/**,**/fb/**"
 combine_as_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ matplotlib==3.3.4
 pycocotools==2.0.2
 ftfy==5.8
 pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@7a48db5
+torchaudio>=0.6.0, <=0.8.1


### PR DESCRIPTION
This PR adds support for Charades dataset along with general purpose video and audio processors

Test Plan:

```
python mmf_cli/run.py config=projects/mmf_transformer/configs/charades/direct.yaml  run_type=train_val dataset=charades model=mmf_transformer training.batch_size=4 training.num_workers=1 training.find_unused_parameters=True training.log_interval=100
```