### PR TITLE
[mmf] validate batch sizes are same + debugging improvements

### DIFF
--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -6,10 +6,11 @@ from typing import Any, Dict, Tuple, Type
 
 import torch
 import tqdm
+from caffe2.python.timeout_guard import CompleteInTimeOrDie
 from mmf.common.meter import Meter
 from mmf.common.report import Report
 from mmf.common.sample import to_device
-from mmf.utils.distributed import is_master
+from mmf.utils.distributed import gather_tensor, is_master
 
 
 logger = logging.getLogger(__name__)
@@ -35,46 +36,51 @@ class TrainerEvaluationLoopMixin(ABC):
                     dataloader = tqdm.tqdm(dataloader, disable=disable_tqdm)
 
                 for batch in dataloader:
-                    prepared_batch = reporter.prepare_batch(batch)
-                    prepared_batch = to_device(prepared_batch, self.device)
-                    model_output = self.model(prepared_batch)
-                    report = Report(prepared_batch, model_output)
-                    report = report.detach()
+                    with CompleteInTimeOrDie(600):
+                        prepared_batch = reporter.prepare_batch(batch)
+                        prepared_batch = to_device(prepared_batch, self.device)
+                        if not validate_batch_sizes(prepared_batch.get_batch_size()):
+                            logger.info("Skip batch due to uneven batch sizes.")
+                            continue
+                        model_output = self.model(prepared_batch)
+                        report = Report(prepared_batch, model_output)
+                        report = report.detach()
 
-                    meter.update_from_report(report)
+                        meter.update_from_report(report)
 
-                    moved_report = report
-                    # Move to CPU for metrics calculation later if needed
-                    # Explicitly use `non_blocking=False` as this can cause
-                    # race conditions in next accumulate
-                    if use_cpu:
-                        moved_report = report.copy().to("cpu", non_blocking=False)
+                        moved_report = report
+                        # Move to CPU for metrics calculation later if needed
+                        # Explicitly use `non_blocking=False` as this can cause
+                        # race conditions in next accumulate
+                        if use_cpu:
+                            moved_report = report.copy().to("cpu", non_blocking=False)
 
-                    # accumulate necessary params for metric calculation
-                    if combined_report is None:
-                        # make a copy of report since `reporter.add_to_report` will
-                        # change some of the report keys later
-                        combined_report = moved_report.copy()
-                    else:
-                        combined_report.accumulate_tensor_fields_and_loss(
-                            moved_report, self.metrics.required_params
-                        )
-                        combined_report.batch_size += moved_report.batch_size
+                        # accumulate necessary params for metric calculation
+                        if combined_report is None:
+                            # make a copy of report since `reporter.add_to_report` will
+                            # change some of the report keys later
+                            combined_report = moved_report.copy()
+                        else:
+                            combined_report.accumulate_tensor_fields_and_loss(
+                                moved_report, self.metrics.required_params
+                            )
+                            combined_report.batch_size += moved_report.batch_size
 
-                    # Each node generates a separate copy of predict JSON from the
-                    # report, which will be used to evaluate dataset-level metrics
-                    # (such as mAP in object detection or CIDEr in image captioning)
-                    # Since `reporter.add_to_report` changes report keys (e.g. scores),
-                    # do this after `combined_report.accumulate_tensor_fields_and_loss`
-                    if "__prediction_report__" in self.metrics.required_params:
-                        # Still need to use original report here on GPU/TPU since
-                        # it will be gathered
-                        reporter.add_to_report(
-                            report, self.model, execute_on_master_only=False
-                        )
+                        # Each node generates a separate copy of predict JSON from the
+                        # report, which will be used to evaluate dataset-level metrics
+                        # (such as mAP in object detection or CIDEr in image captioning)
+                        # Since `reporter.add_to_report` changes report keys,
+                        # (e.g scores) do this after
+                        # `combined_report.accumulate_tensor_fields_and_loss`
+                        if "__prediction_report__" in self.metrics.required_params:
+                            # Still need to use original report here on GPU/TPU since
+                            # it will be gathered
+                            reporter.add_to_report(
+                                report, self.model, execute_on_master_only=False
+                            )
 
-                    if single_batch is True:
-                        break
+                        if single_batch is True:
+                            break
 
                 reporter.postprocess_dataset_report()
                 assert (
@@ -104,6 +110,8 @@ class TrainerEvaluationLoopMixin(ABC):
 
     def prediction_loop(self, dataset_type: str) -> None:
         reporter = self.dataset_loader.get_test_reporter(dataset_type)
+        skipped_batches = 0
+        loaded_batches = 0
         with torch.no_grad():
             self.model.eval()
             logger.info(f"Starting {dataset_type} inference predictions")
@@ -112,18 +120,24 @@ class TrainerEvaluationLoopMixin(ABC):
                 dataloader = reporter.get_dataloader()
                 if self._can_use_tqdm(dataloader):
                     dataloader = tqdm.tqdm(dataloader)
-
                 for batch in dataloader:
-                    prepared_batch = reporter.prepare_batch(batch)
-                    prepared_batch = to_device(prepared_batch, self.device)
-                    with torch.cuda.amp.autocast(enabled=self.training_config.fp16):
-                        model_output = self.model(prepared_batch)
-                    report = Report(prepared_batch, model_output)
-                    reporter.add_to_report(report, self.model)
+                    with CompleteInTimeOrDie(600):
+                        prepared_batch = reporter.prepare_batch(batch)
+                        prepared_batch = to_device(prepared_batch, self.device)
+                        loaded_batches += 1
+                        if not validate_batch_sizes(prepared_batch.get_batch_size()):
+                            logger.info("Skip batch due to unequal batch sizes.")
+                            skipped_batches += 1
+                            continue
+                        with torch.cuda.amp.autocast(enabled=self.training_config.fp16):
+                            model_output = self.model(prepared_batch)
+                        report = Report(prepared_batch, model_output)
+                        reporter.add_to_report(report, self.model)
 
                 reporter.postprocess_dataset_report()
 
-            logger.info("Finished predicting")
+            logger.info(f"Finished predicting. Loaded {loaded_batches}")
+            logger.info(f" -- skipped {skipped_batches} batches.")
             self.model.train()
 
     def _can_use_tqdm(self, dataloader: torch.utils.data.DataLoader):
@@ -139,3 +153,18 @@ class TrainerEvaluationLoopMixin(ABC):
         except (AttributeError, TypeError, NotImplementedError):
             use_tqdm = False
         return use_tqdm
+
+
+def validate_batch_sizes(my_batch_size: int) -> bool:
+    """
+    Validates all workers got the same batch size.
+    """
+    batch_size_tensor = torch.IntTensor([my_batch_size])
+    if torch.cuda.is_available():
+        batch_size_tensor = batch_size_tensor.cuda()
+    all_batch_sizes = gather_tensor(batch_size_tensor)
+    for j, oth_batch_size in enumerate(all_batch_sizes.data):
+        if oth_batch_size != my_batch_size:
+            logger.error(f"Node {j} batch {oth_batch_size} != {my_batch_size}")
+            return False
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # This is required to make sorting same as fbcode as all absolute imports
 # are considered third party there
 known_third_party = [
-    "PIL", "cv2", "demjson", "fairscale", "filelock", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "matplotlib",
+    "PIL", "caffe2", "cv2", "demjson", "fairscale", "filelock", "h5py", "lib", "lmdb", "maskrcnn_benchmark", "matplotlib",
     "mmf", "mmf_cli", "numpy", "omegaconf", "packaging", "pycocoevalcap", "pytorch_sphinx_theme",
     "recommonmark", "requests", "setuptools", "sklearn", "termcolor", "tests", "torch",
     "torchtext", "torchvision", "tqdm", "transformers", "pytorch_lightning"


### PR DESCRIPTION
Summary:
Before adding batch to reporter, sync with all workers and validate all have same batch size. If not, skip the batch. Reports in the end how many were skipped.

This should add quite negligible overhead. And once the problem itself is fixed (probably by constructing the dataloader with 'drop_incomplete' -- but i am not sure where to add this), this could be removed -- but perhaps better to just keep it.

In addition:
- remove master's logging to a file and instead log to stderr
- add CompleteInTimeOrDie() so that we get better traces than NCCL deadlocks cause.
- some tiny changes.

Differential Revision: D27954629

