### PR TITLE
[postray] assign attn_mask to empty images

### DIFF
--- a/mmf/configs/models/mmf_transformer/defaults.yaml
+++ b/mmf/configs/models/mmf_transformer/defaults.yaml
@@ -39,4 +39,5 @@ model_config:
     layer_norm_weight_fill: 1.0
     random_initialize: false
     freeze_image_encoder: false
+    tie_weight_to_text_encoder: false
     num_labels: 2

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import logging
 from dataclasses import dataclass, field
 from typing import Dict, List
 
@@ -16,6 +17,8 @@ from mmf.modules.encoders import ResNet152ImageEncoder
 from mmf.utils.build import build_encoder
 from omegaconf import MISSING, OmegaConf
 from torch import Tensor, nn
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -48,6 +51,7 @@ class MMFTransformer(BaseTransformer):
         random_initialize: bool = False
         freeze_transformer: bool = False
         freeze_image_encoder: bool = False
+        tie_weight_to_text_encoder: bool = False
         finetune_lr_multiplier: float = 1
         backend: BaseTransformerBackendConfig = MMFTransformerBackendConfig(
             type="huggingface"
@@ -123,8 +127,8 @@ class MMFTransformer(BaseTransformer):
             encoder = build_encoder(encoder_config)
             self.encoders[modality.key] = encoder
 
-            if modality.type == "image" and getattr(
-                self.config, "freeze_image_encoder", False
+            if modality.type == "image" and self.config.get(
+                "freeze_image_encoder", False
             ):
                 for param in encoder.parameters():
                     param.requires_grad = False
@@ -134,9 +138,19 @@ class MMFTransformer(BaseTransformer):
         text_embedding_idx = self.modality_type.index("text")
         if text_embedding_idx >= 0:
             for head in self.heads:
-                head.tie_weights(
-                    self.backend.embeddings.token_embeddings[text_embedding_idx]
-                )
+                if self.config.get("tie_weight_to_text_encoder", False):
+                    assert "text" in self.encoders, (
+                        "MMFT needs to have a text encoder to tie weights to "
+                        + "its token embeddings."
+                    )
+                    logger.info("Tie weights to text_encoder input embeddings")
+                    head.tie_weights(
+                        self.encoders["text"].transformer.transformer.token_embedding
+                    )
+                else:
+                    head.tie_weights(
+                        self.backend.embeddings.token_embeddings[text_embedding_idx]
+                    )
 
     def preprocess_sample(
         self, sample_list: Dict[str, Tensor]

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -368,6 +368,11 @@ class MMFTransformer(BaseTransformer):
             masks,
         )
 
+        # if self.print_idx < 10:
+        #     print("======== encoded_layers length")
+        #     print(len(encoded_layers))
+        #     print("======== encoded_layers[3] shape")
+        #     print(encoded_layers[3].shape)
         # Transformer Heads
 
         return self.postprocess_output(

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -282,8 +282,18 @@ class MMFTransformer(BaseTransformer):
                     masks[modality] = sample_list["input_mask"]
             else:
                 mask_attribute = f"{modality}_mask"
+                mask_attribute_guide = f"{modality}_mask_guide"
                 if mask_attribute in sample_list:
                     masks[modality] = sample_list[mask_attribute]
+                elif mask_attribute_guide in sample_list:
+                    assert (
+                        len(sample_list[mask_attribute_guide].shape) == 1
+                    ), "mask_attribute_guide can only have a single dim equals to bsz"
+                    masks[modality] = (
+                        sample_list[mask_attribute_guide]
+                        .unsqueeze(1)
+                        .repeat(1, input_ids[modality].shape[1])
+                    )
                 else:
                     masks[modality] = torch.ones(
                         input_ids[modality].size()[:2],

--- a/mmf/modules/encoders.py
+++ b/mmf/modules/encoders.py
@@ -301,7 +301,12 @@ class TorchvisionResNetImageEncoder(Encoder):
     def forward(self, x):
         # B x 3 x 224 x 224 -> B x 2048 x 7 x 7
         out = self.model(x)
-        return out
+        # print("-------------")
+        # print(out.shape)
+        # print("-------------")
+        # out = torch.flatten(out, start_dim=2)
+        # out = out.transpose(1, 2).contiguous()
+        return out  # BxNx2048
 
 
 @registry.register_encoder("detectron2_resnet")

--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -33,6 +33,22 @@ def clip_gradients(model, optimizer, i_iter, writer, config, scale=1.0):
     max_grad_l2_norm = config.training.max_grad_l2_norm
     clip_norm_mode = config.training.clip_norm_mode
 
+    # Monitoring grad_norm of certain layer
+    # ie_tt_gn = nn.utils.clip_grad_norm_(
+    #     model.encoders["image"].parameters(), 1e10, error_if_nonfinite=False
+    # )
+    # print(f"image_encoder_total_gn = {ie_tt_gn}")
+    # print(list(model.encoders["image"].named_parameters())[-3][0])
+    # ie_ll_gn = nn.utils.clip_grad_norm_(
+    #     list(model.encoders["image"].named_parameters())[-3][1],
+    #     1e10,
+    #     error_if_nonfinite=False,
+    # )
+    # print(f"image_encoder_last_layer_gn = {ie_ll_gn}")
+    # if writer is not None:
+    #     writer.add_scalars({"image_encoder_total_gn": ie_tt_gn}, i_iter)
+    #     writer.add_scalars({"image_encoder_last_layer_gn": ie_ll_gn}, i_iter)
+
     if max_grad_l2_norm is not None:
         if clip_norm_mode == "all":
             if hasattr(optimizer, "clip_grad_norm"):


### PR DESCRIPTION
Summary: Make it optional to assign 0 attention masks to empty images so it's not involved during self-attention. Would be interesting to compare its performance with the one where we also apply attention on empty images.

Differential Revision: D27875352

