### PR TITLE
[feat] allow attribute prediction in UniT; fix UniT zoo ckpt yaml config

### DIFF
--- a/mmf/configs/models/unit/defaults.yaml
+++ b/mmf/configs/models/unit/defaults.yaml
@@ -93,3 +93,4 @@ model_config:
           num_labels: 2
           loss_type: cross_entropy
     max_task_num: 256
+    predict_attributes: false

--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -506,7 +506,7 @@ unit:
       resources:
       - url: mmf://models/unit_models/unit.coco.single_task.tar.gz
         file_name: unit.coco.single_task.tar.gz
-        hashcode: e425909ce0ff10921a88175e98e2616d556a268753183beeeba1f63d5f56128c
+        hashcode: d235fe2d27b47d8f19ce82bea2b1bc6d33151b7c6c1a5558c2a501911b9f4880
     single_task_without_task_embedding:
       # Model from project : projects/unit
       # - val/detection_coco/detection_mean_ap: 0.4015
@@ -514,7 +514,7 @@ unit:
       resources:
       - url: mmf://models/unit_models/unit.coco.single_task_without_task_embedding.tar.gz
         file_name: unit.coco.single_task_without_task_embedding.tar.gz
-        hashcode: 05c693d92ffbf17c36964a69f560c77a8b7fea6c30f1bd67d2dcc28c89ea59e9
+        hashcode: ded272f84b6fb27e3aaca3de4d494f8bbfdb1b6a870a43069b43aed6d94bd7d3
   all_8_datasets:
     shared_dec_with_coco_init:
       # Model from project : projects/unit
@@ -530,7 +530,7 @@ unit:
       resources:
       - url: mmf://models/unit_models/unit.all_8_datasets.shared_dec_with_coco_init.tar.gz
         file_name: unit.all_8_datasets.shared_dec_with_coco_init.tar.gz
-        hashcode: b85796246601c477d354d6ad315b55a200b4c7ba6bf7e263ef82bca74bdcab1c
+        hashcode: 63cd3a5cfd6728b6e529714d5dcdc5cb3d9b7d1038dbbb2351264d145e5852d4
     shared_dec_with_coco_init_without_task_embedding:
       # Model from project : projects/unit
       # - val/detection_coco/detection_mean_ap: 0.3847,
@@ -545,4 +545,4 @@ unit:
       resources:
       - url: mmf://models/unit_models/unit.all_8_datasets.shared_dec_with_coco_init_without_task_embedding.tar.gz
         file_name: unit.all_8_datasets.shared_dec_with_coco_init_without_task_embedding.tar.gz
-        hashcode: 4a9e0dbd4b73152c7b514cd1695f28068157e1c31e4c49ad0e9edec27a987c59
+        hashcode: c4a3c1072f07e605de76402ff7c0e2bc8d4514561c52dc94b3d28b3d4d7f698e

--- a/mmf/datasets/builders/coco/detection_dataset.py
+++ b/mmf/datasets/builders/coco/detection_dataset.py
@@ -66,6 +66,10 @@ class DetectionCOCODataset(BaseDataset):
         orig_size = gather_tensor_along_batch(report.orig_size)
 
         outputs = {"pred_logits": pred_logits, "pred_boxes": pred_boxes}
+        if hasattr(report, "attr_logits"):
+            attr_logits = gather_tensor_along_batch(report.attr_logits)
+            outputs["attr_logits"] = attr_logits
+
         image_ids = report.image_id.tolist()
         results = self.postprocessors["bbox"](outputs, orig_size)
 
@@ -94,6 +98,12 @@ class DetectionCOCODataset(BaseDataset):
                     ],
                 )
             )
+            if "attr_scores" in r:
+                attr_scores = r["attr_scores"].tolist()
+                attr_labels = r["attr_labels"].tolist()
+                for k in range(len(boxes_xywh)):
+                    predictions[-1][1][k]["attr_score"] = attr_scores[k]
+                    predictions[-1][1][k]["attr_label"] = attr_labels[k]
 
         return predictions
 
@@ -184,5 +194,12 @@ class PostProcess(nn.Module):
             {"scores": s, "labels": l, "boxes": b}
             for s, l, b in zip(scores, labels, boxes)
         ]
+
+        if "attr_logits" in outputs:
+            assert len(outputs["attr_logits"]) == len(results)
+            attr_scores, attr_labels = outputs["attr_logits"].max(-1)
+            for idx, r in enumerate(results):
+                r["attr_scores"] = attr_scores[idx]
+                r["attr_labels"] = attr_labels[idx]
 
         return results

--- a/mmf/models/unit/unit.py
+++ b/mmf/models/unit/unit.py
@@ -262,6 +262,15 @@ class UniT(BaseModel):
             }
             detr_outputs["losses"] = losses
 
+        if (
+            self.config.heads["detection"][sample_list.dataset_name]["use_attr"]
+            and self.config.predict_attributes
+        ):
+            hs_for_attr = detr_outputs["hs_for_attr"]
+            top_obj_class = detr_outputs["pred_logits"][..., :-1].argmax(dim=-1)
+            attr_head = self.det_losses[sample_list.dataset_name].attribute_head
+            detr_outputs["attr_logits"] = attr_head(hs_for_attr, top_obj_class)
+
         return detr_outputs
 
     def classifier_loss_calculation(self, detr_outputs: Dict[str, Tensor], sample_list):


### PR DESCRIPTION
- allow predicting attributes in Visual Genome detection -- run with `model_config.unit.predict_attributes=True` to write attributes into json prediction files
- also fix the config.yaml files for the UniT checkpoints
- visualizing predicted boxes and attributes: https://gist.github.com/ronghanghu/47053b7e58460d48986345fb9027b460#file-visualize_detection_vg_outputs_with_attr-ipynb

Test plan: tested locally and verified attribute outputs