### PR TITLE
[fix] multinode jobs after recent lightning update

### DIFF
--- a/mmf/datasets/mmf_dataset_builder.py
+++ b/mmf/datasets/mmf_dataset_builder.py
@@ -61,6 +61,7 @@ class MMFDatasetBuilder(BaseDatasetBuilder):
         self.dataset_class = dataset_cls
 
     def build(self, config, dataset_type="train", *args, **kwargs):
+        self.config = config
         requirements = config.get("zoo_requirements", [])
 
         if len(requirements) == 0:

--- a/mmf/utils/download.py
+++ b/mmf/utils/download.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import numpy as np
 import requests
 import tqdm
-from mmf.utils.distributed import is_master, synchronize
 from mmf.utils.file_io import PathManager
 from mmf.utils.general import get_absolute_path
 from PIL import Image
@@ -376,9 +375,7 @@ def download_pretrained_model(model_name, *args, **kwargs):
     version = model_config.version
     resources = model_config.resources
 
-    if is_master():
-        download_resources(resources, download_path, version)
-    synchronize()
+    download_resources(resources, download_path, version)
 
     return download_path
 


### PR DESCRIPTION
After Sasha's update of pytorch lightning on MMF master, it broke MMF codebase for multinode job. The root problem to PR https://github.com/PyTorchLightning/pytorch-lightning/pull/6802. The assumption that SLURM_PROCID points to worker rank is wrong as some frameworks launch their own processes later using multiprocessing spawn and have ntasks_per_node=1 set. This means that first node will have procid = 0, second node will have procid = 1 set and so on. Now, since this is used in prepare_data masking in LightningDataModule, this leads to it running on all workers on first node and thus causing inconsistencies. Now, this leads to prepare_data being called on all workers on first node instead of rank zero. Specifically, the barrier call in prepare_data, is called on first node workers but not on others leading to block later on.

This PR fixes this by ensuring on our side that we only call prepare_data on rank zero. Furthermore, this can cause further confusion, we remove sync barrier calls from download as well. Users are now supposed to handle is_master checks on their own.

Test Plan:
Tested in multinode settings.

