### PR TITLE
[fix] XLA issues, test reporter barrier, oc and torch warnings

### DIFF
--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -3,6 +3,7 @@ import csv
 import json
 import logging
 import os
+import warnings
 from dataclasses import dataclass, field
 from typing import List
 
@@ -189,13 +190,16 @@ class TestReporter(Dataset):
             + "'current_dataloader' based function"
         )
 
-    def add_to_report(self, report, model, execute_on_master_only=True):
+    def add_to_report(self, report, model, *args, **kwargs):
+        if "execute_on_master_only" in kwargs:
+            warnings.warn(
+                "'execute_on_master_only keyword is deprecated and isn't used anymore",
+                DeprecationWarning,
+            )
         self._check_current_dataloader()
         for key in self.candidate_fields:
             report = self.reshape_and_gather(report, key)
 
-        if execute_on_master_only and not is_master():
-            return
         results = []
 
         if hasattr(self.current_dataset, "format_for_prediction"):

--- a/mmf/trainers/core/device.py
+++ b/mmf/trainers/core/device.py
@@ -84,6 +84,5 @@ class TrainerDeviceMixin(ABC):
                     self.model,
                     device_ids=[self.local_rank],
                     output_device=self.local_rank,
-                    check_reduction=True,
                     find_unused_parameters=self.config.training.find_unused_parameters,
                 )

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -79,9 +79,7 @@ class TrainerEvaluationLoopMixin(ABC):
                         if "__prediction_report__" in self.metrics.required_params:
                             # Still need to use original report here on GPU/TPU since
                             # it will be gathered
-                            reporter.add_to_report(
-                                report, self.model, execute_on_master_only=False
-                            )
+                            reporter.add_to_report(report, self.model)
 
                         if single_batch is True:
                             break

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -177,7 +177,7 @@ class Checkpoint:
     def save_config(self):
         cfg_file = os.path.join(self.ckpt_foldername, "config.yaml")
         with PathManager.open(cfg_file, "w") as f:
-            f.write(self.config.pretty(resolve=True))
+            f.write(OmegaConf.to_yaml(self.config, resolve=True))
 
     def load_state_dict(self):
         ckpt_config = self.config.checkpoint

--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -42,7 +42,8 @@ def synchronize(message="sync-workers"):
 
 
 def is_xla():
-    return registry.get("is_xla", no_warning=True)
+    # Cover none case as well
+    return not (not registry.get("is_xla", no_warning=True))
 
 
 def get_rank():

--- a/tests/datasets/test_bert_processors.py
+++ b/tests/datasets/test_bert_processors.py
@@ -13,9 +13,7 @@ class TestBERTProcessors(unittest.TestCase):
             {
                 "tokenizer_config": {
                     "type": "bert-base-uncased",
-                    "params": {
-                        "do_lower_case": True,
-                    },
+                    "params": {"do_lower_case": True},
                 },
                 "mask_probability": 0,
                 "max_seq_length": 128,


### PR DESCRIPTION
- Return false for is_xla in case it is not registered for correct
drop_last setting in dataloader
- Always call format_for_prediction for all workers to avoid hangs in
TPU and NCCLs
- Move .pretty use in OC to OmegaConf.to_yaml
- Remove `check_reduction` parameter from DDP init

Test Plan:
Tested locally with changes on charades branch


