### PR TITLE
[fix] get_optimizer_parameters in BaseTransformer

### DIFF
--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -126,7 +126,7 @@ class BaseTransformer(BaseModel):
                 # For other modules in trunk, add to same param group
                 param_list += list(module.named_parameters())
 
-        parameters += get_bert_configured_parameters(self)
+        parameters += get_bert_configured_parameters(param_list)
 
         return parameters
 


### PR DESCRIPTION
Summary: Fix the functionality of assigning a different lr to task heads.

Reviewed By: vedanuj

Differential Revision: D28112762

