### PR TITLE
[fix] Assign config to instance in setup as well

### DIFF
--- a/mmf/datasets/base_dataset_builder.py
+++ b/mmf/datasets/base_dataset_builder.py
@@ -90,6 +90,8 @@ class BaseDatasetBuilder(pl.LightningDataModule):
     def setup(self, stage: Optional[str] = None, config: Optional[DictConfig] = None):
         if config is None:
             config = self.config
+
+        self.config = config
         self.train_dataset = self.load_dataset(config, "train")
         self.val_dataset = self.load_dataset(config, "val")
         self.test_dataset = self.load_dataset(config, "test")


### PR DESCRIPTION
Summary: Followup to https://github.com/facebookresearch/mmf/pull/921 for datasets which don't inherit from MMFDatasetBuilder

Reviewed By: ytsheng

Differential Revision: D28238562

