### PR TITLE
[feat] PL last validation after training

### DIFF
--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -198,7 +198,7 @@ class BaseModel(pl.LightningModule):
             Dict: Dict containing loss.
         """
         output = self._forward_lightning_step(batch, batch_idx)
-        report = Report(batch, output)
+        report = Report(batch, output).detach()
         self.train_meter.update_from_report(report)
         return output
 
@@ -215,7 +215,7 @@ class BaseModel(pl.LightningModule):
             Dict
         """
         output = self._forward_lightning_step(batch, batch_idx)
-        report = Report(batch, output)
+        report = Report(batch, output).detach()
         self.val_meter.update_from_report(report)
         report.metrics = self.metrics(report, report)
         return output

--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -55,23 +55,12 @@ class LightningLoopCallback(Callback):
         )
 
         # log
-        if (trainer.global_step + 1) % self.trainer_config.log_every_n_steps == 0:
-            self._train_log(trainer, pl_module)
-
-        # save checkpoints - TODO: @sash
-
-    def on_train_end(self, trainer: Trainer, pl_module: LightningModule):
-        # Only do when run_type has train as it shouldn't happen on validation and
-        # inference runs. Inference will take care of this anyways. Also, don't run
-        # if current iteration is divisble by snapshot interval as it will just
-        # be a repeat
         if (
-            "train" in self.run_type
-            and trainer.global_step % self.trainer_config.val_check_interval != 0
+            self._get_num_updates_for_logging(trainer)
+            % self.trainer_config.log_every_n_steps
+            == 0
         ):
-            logger.info("Stepping into final validation check")
-            # Pytorch Lightning upgrades PR4945 and PR4948 will be enabled in 1.2
-            # TODO: perform final validation check
+            self._train_log(trainer, pl_module)
 
     # Validation Callbacks
     def on_validation_start(self, trainer: Trainer, pl_module: LightningModule):
@@ -101,6 +90,7 @@ class LightningLoopCallback(Callback):
             self.val_combined_report,
             update_meter=pl_module.val_meter,
         )
+        self.val_combined_report = self.val_combined_report.detach()
         self.val_combined_report.metrics = pl_module.metrics(
             self.val_combined_report, self.val_combined_report
         )
@@ -181,6 +171,7 @@ class LightningLoopCallback(Callback):
         return trainer.global_step + 1
 
     def _train_log(self, trainer: Trainer, pl_module: LightningModule):
+        self.train_combined_report = self.train_combined_report.detach()
         if self.training_config.evaluate_metrics:
             self.train_combined_report.metrics = pl_module.metrics(
                 self.train_combined_report, self.train_combined_report

--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -112,8 +112,20 @@ class LightningTrainer(BaseTrainer):
             return
 
         self.trainer.fit(self.model, self.data_module)
+        self.run_last_validation_after_train()
+
         # TODO: Look for a better way to hook this
         self.data_module.teardown()
+
+    def run_last_validation_after_train(self) -> None:
+        # Don't run if current iteration is divisble by
+        # val check interval as it will just be a repeat
+        if (
+            "val" in self.run_type
+            and self.trainer.global_step % self.trainer_config.val_check_interval != 0
+        ):
+            logger.info("Stepping into final validation check")
+            self.trainer.validate(self.model, self.val_loader)
 
     def inference(self) -> None:
         logger.info("Starting inference...")

--- a/tests/trainers/lightning/test_logging.py
+++ b/tests/trainers/lightning/test_logging.py
@@ -43,6 +43,7 @@ class TestLightningTrainerLogging(unittest.TestCase):
             batch_size=2,
             max_epochs=None,
             log_interval=3,
+            evaluation_interval=9,
             tensorboard=True,
         )
 
@@ -55,6 +56,7 @@ class TestLightningTrainerLogging(unittest.TestCase):
         logistics_callback.train_timer = Timer()
         logistics_callback.tb_writer.add_scalars = _add_scalars_mmf
         mmf_trainer.logistics_callback = logistics_callback
+        mmf_trainer.on_validation_end = logistics_callback.on_validation_end
         mmf_trainer.callbacks = [logistics_callback]
         mmf_trainer.early_stop_callback = MagicMock(return_value=None)
         mmf_trainer.on_update_end = logistics_callback.on_update_end
@@ -83,6 +85,7 @@ class TestLightningTrainerLogging(unittest.TestCase):
         self.assertEqual(
             len(self.mmf_tensorboard_logs), len(self.lightning_tensorboard_logs)
         )
+
         for mmf, lightning in zip(
             self.mmf_tensorboard_logs, self.lightning_tensorboard_logs
         ):

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -24,13 +24,12 @@ def get_trainer_config():
                 "lr_scheduler": False,
                 "tensorboard": False,
             },
-            "evaluation": {"use_cpu": False},
+            "evaluation": {"use_cpu": False, "metrics": []},
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {
                 "type": "warmup_linear",
                 "params": {"num_warmup_steps": 8, "num_training_steps": 8},
             },
-            "evaluation": {"metrics": []},
             "trainer": {
                 "type": "lightning",
                 "params": {
@@ -46,7 +45,7 @@ def get_trainer_config():
                     "accumulate_grad_batches": 1,
                     "precision": 32,
                     "num_sanity_val_steps": 0,
-                    "limit_val_batches": 5,
+                    "limit_val_batches": 1.0,
                     "logger": False,
                 },
             },
@@ -159,3 +158,4 @@ def run_lightning_trainer_with_callback(trainer, callback, on_fit_start_callback
         train_dataloader=trainer.train_loader,
         val_dataloaders=trainer.val_loader,
     )
+    trainer.run_last_validation_after_train()


### PR DESCRIPTION
* this implements the last validation functionality after training since it was added in PL master recently. 
* updated the tests to check for the last validation result.
* still waiting on PL to fix its tariner.global_step inconsistency
* two reports are being kept for now until we figure out a better way to consolidate them. They are being kept in the lightning module for calculating the early stopping and saving the checkpoint (PR coming soon); they are being kept in the loop callback for logging purposes. Eventually, we may move all of them into the lightning module. But I am submitting the PRs one step at the time for now. 