### PR TITLE
[fix] Memory leak in test reporter; detach report in inference

### DIFF
--- a/mmf/common/test_reporter.py
+++ b/mmf/common/test_reporter.py
@@ -113,6 +113,8 @@ class TestReporter(Dataset):
 
     def flush_report(self):
         if not is_master():
+            # Empty report in all processes to avoid any leaks
+            self.report = []
             return
 
         name = self.current_datamodule.dataset_name

--- a/mmf/trainers/core/evaluation_loop.py
+++ b/mmf/trainers/core/evaluation_loop.py
@@ -140,6 +140,7 @@ class TrainerEvaluationLoopMixin(ABC):
                             model_output = self.model(prepared_batch)
                         report = Report(prepared_batch, model_output)
                         reporter.add_to_report(report, self.model)
+                        report.detach()
 
                 reporter.postprocess_dataset_report()
 


### PR DESCRIPTION
Summary:
In recent PR, we started adding to report in all processors to better support TPUs. Unfortunately, the data collected in test reporter was not continuously flushed in cases other than master. This PR fixes.

Other than that, we now detach the report as well in prediction loop.

Reviewed By: rayhou0710

Differential Revision: D28338749

