### PR TITLE
[fix,feat] fix lightning requirements + add leak hook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ datasets==1.2.1
 matplotlib==3.3.4
 pycocotools==2.0.2
 ftfy==5.8
-pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@7a48db5
+pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@7b283e3c
 torchaudio>=0.6.0, <=0.8.1
+psutil

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import os
+from collections import namedtuple
+from itertools import groupby
+
+from psutil import Process
+
+
+LEAK_LIMIT = 10 * 1024 * 1024
+
+
+_proc = Process(os.getpid())
+START = "START"
+END = "END"
+ConsumedRamLogEntry = namedtuple(
+    "ConsumedRamLogEntry", ("nodeid", "on", "consumed_ram")
+)
+consumed_ram_log = []
+
+
+def get_consumed_ram():
+    return _proc.memory_info().rss
+
+
+def pytest_runtest_setup(item):
+    log_entry = ConsumedRamLogEntry(item.nodeid, START, get_consumed_ram())
+    consumed_ram_log.append(log_entry)
+
+
+def pytest_runtest_teardown(item):
+    log_entry = ConsumedRamLogEntry(item.nodeid, END, get_consumed_ram())
+    consumed_ram_log.append(log_entry)
+
+
+def pytest_terminal_summary(terminalreporter):
+    grouped = groupby(consumed_ram_log, lambda entry: entry.nodeid)
+    for nodeid, (start_entry, end_entry) in grouped:
+        leaked = end_entry.consumed_ram - start_entry.consumed_ram
+        if leaked > LEAK_LIMIT:
+            terminalreporter.write(
+                "LEAKED {}MB in {}\n".format(leaked / 1024 / 1024, nodeid)
+            )


### PR DESCRIPTION
* Lightning keeps updating and they change the internal tests, but they did not update the OSS dependency. We should communicate it to them so that they can also the OSS side. Or if there is an automatic way of doing this, it would be even better.
* This diff adds a pytest hook to check for memory leaks being caused. This just adds printing statements.