### PR TITLE
[feat,fix] Random init bert encocder, other QoL fixes (#178)

### DIFF
--- a/mmf/datasets/base_dataset.py
+++ b/mmf/datasets/base_dataset.py
@@ -102,6 +102,10 @@ class BaseDataset(Dataset):
     def dataset_name(self, name):
         self._dataset_name = name
 
+    @dataset_type.setter
+    def dataset_type(self, dataset_type):
+        self._dataset_type = dataset_type
+
     def format_for_prediction(self, report):
         return []
 

--- a/mmf/datasets/processors/bert_processors.py
+++ b/mmf/datasets/processors/bert_processors.py
@@ -164,7 +164,9 @@ class MaskedTokenProcessor(BaseProcessor):
         output = self._convert_to_indices(
             tokens_a, tokens_b, probability=self._probability
         )
-        output["is_correct"] = torch.tensor(item["is_correct"], dtype=torch.long)
+        output["is_correct"] = torch.tensor(
+            item.get("is_correct", True), dtype=torch.long
+        )
 
         return output
 

--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -769,8 +769,8 @@ class ContrastiveLoss(nn.Module):
 
 @registry.register_loss("mse")
 class MSELoss(nn.Module):
-    """Mean Squared Error loss
-    """
+    """Mean Squared Error loss"""
+
     def __init__(self):
         super().__init__()
         self.loss_fn = nn.MSELoss()
@@ -784,8 +784,8 @@ class MSELoss(nn.Module):
 
 @registry.register_loss("cos_emb_loss")
 class CosineEmbeddingLoss(nn.Module):
-    """Cosine embedding loss
-    """
+    """Cosine embedding loss"""
+
     def __init__(self):
         super().__init__()
         self.loss_fn = nn.CosineEmbeddingLoss()

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -108,16 +108,16 @@ class MMFTrainer(
 
     def load_fp16_scaler(self):
         if self.training_config.fp16:
-            assert (
-                version.parse(torch.__version__) >= version.parse("1.6")
+            assert version.parse(torch.__version__) >= version.parse(
+                "1.6"
             ), f"Using fp16 requires torch version >- 1.6, found: {torch.__version__}"
             assert self.device != torch.device("cpu"), "fp16 cannot be used on cpu"
 
         set_torch_grad_scaler = True
         if self.training_config.fp16 and self.distributed:
             try:
-                from fairscale.optim.oss import OSS
                 from fairscale.optim.grad_scaler import ShardedGradScaler
+                from fairscale.optim.oss import OSS
 
                 if isinstance(self.optimizer, OSS):
                     self.scaler = ShardedGradScaler()

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -87,7 +87,7 @@ def build_model(
     model = model_class(config)
 
     if hasattr(model, "build"):
-        """ Model build involves checkpoint loading
+        """Model build involves checkpoint loading
         If the checkpoint is not available the underlying
         methods try to download it.
         Let master build the model (download the checkpoints) while
@@ -383,7 +383,11 @@ def build_optimizer(model, config):
         assert (
             is_dist_initialized()
         ), "Optimizer state sharding can only be used in distributed mode."
-        optimizer = OSS(params=parameters, optim=optimizer_class, **params)
+
+        is_fp16 = config.get("training", {}).get("fp16", False)
+        optimizer = OSS(
+            params=parameters, optim=optimizer_class, broadcast_fp16=is_fp16, **params
+        )
     else:
         optimizer = optimizer_class(parameters, **params)
     return optimizer

--- a/tools/sweeps/lib/slurm.py
+++ b/tools/sweeps/lib/slurm.py
@@ -185,6 +185,8 @@ def launch_train(args, config):
         if args.num_nodes > 1:
             env["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
             env["NCCL_DEBUG"] = "INFO"
+        else:
+            env["NCCL_SOCKET_IFNAME"] = ""
 
         srun_cmd = [
             "srun",


### PR DESCRIPTION
Summary:
- Add dataset_type property to base_dataset class to avoid some failures
in dataset builders
- broadcast fp16 in OSS
- Fix NCCL error happening in sweep script
- is_correct if not present in processor output defaults to True

This changes are required for running fairseq_mlm.

Pull Request resolved: https://github.com/fairinternal/mmf-internal/pull/178

Differential Revision: D28393021

Pulled By: apsdehal

