### PR TITLE
[fix] Only return cuda as current device if cuda is actually initialized

### DIFF
--- a/mmf/utils/general.py
+++ b/mmf/utils/general.py
@@ -418,7 +418,7 @@ def get_current_device():
         import torch_xla.core.xla_model as xm
 
         return xm.xla_device()
-    if torch.cuda.is_available():
+    if torch.cuda.is_available() and torch.cuda.is_initialized():
         return f"cuda:{torch.cuda.current_device()}"
     else:
         return torch.device("cpu")


### PR DESCRIPTION
This causes issues when GPU is available but person still want to run on
CPU.

Test Plan:

Tested locally

