### PR TITLE
[fix] Fix typo in script feature extraction

### DIFF
--- a/tools/scripts/features/extraction_utils.py
+++ b/tools/scripts/features/extraction_utils.py
@@ -36,7 +36,7 @@ def get_image_files(
     for f in list(files):
         file_name = f.split(os.path.sep)[-1].split(".")[0]
         if file_name in exclude or file_name in output_ignore:
-            files.pop(f)
+            files.remove(f)
 
     files = list(files)
     files = sorted(files)


### PR DESCRIPTION
`files` datatype should be set, so the function to remove
an obj is `remove`, not `pop`.