### PR TITLE
[PostRay] Create a Recurring WPIE Eval that skips the sweep launcher 1/N

### DIFF
--- a/tools/sweeps/lib/__init__.py
+++ b/tools/sweeps/lib/__init__.py
@@ -7,7 +7,8 @@ import os
 import socket
 
 
-def get_args():
+# if argv is None, we will read from sys.argv (invoke params)
+def get_args(argv=None):
     parser = argparse.ArgumentParser("Script for launching hyperparameter sweeps")
     parser.add_argument(
         "-p",
@@ -168,7 +169,8 @@ def get_args():
         help="enable tensorboard logging by passing --tensorboard 1",
     )
 
-    args = parser.parse_args()
+    # Will read sys.argv if argv is None
+    args = parser.parse_args(argv)
     return args
 
 


### PR DESCRIPTION
Summary:
Created a new flow workflow that performs the same operations as the current launcher, but does it as part of flow execution so it can be launched with flow-cli (or indeed, as a recurring run)

The prefix field defaults to having a date/time macro in it which should allow us to avoid collisions in the recurring run

Reviewed By: madian9

Differential Revision: D28608702

