### PR TITLE
[fix] fix TPU checkpoint saving, parameter broadcasting, and misc stuff

### DIFF
--- a/mmf/trainers/core/device.py
+++ b/mmf/trainers/core/device.py
@@ -6,6 +6,11 @@ from abc import ABC
 
 import torch
 from mmf.common.registry import registry
+from mmf.utils.distributed import (
+    broadcast_xla_master_model_param,
+    get_world_size,
+    is_xla,
+)
 from omegaconf import open_dict
 
 
@@ -103,3 +108,6 @@ class TrainerDeviceMixin(ABC):
                     output_device=self.local_rank,
                     find_unused_parameters=self.config.training.find_unused_parameters,
                 )
+
+        if is_xla() and get_world_size() > 1:
+            broadcast_xla_master_model_param(self.model)

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -316,6 +316,8 @@ def build_dataloader_and_sampler(
     else:
         other_args.pop("shuffle")
 
+    # Set drop_last=True when using XLA to have constant batch size.
+    # In this case we also need to set drop_last=True in DistributedSampler.
     loader = torch.utils.data.DataLoader(
         dataset=dataset_instance,
         collate_fn=BatchCollator(
@@ -390,6 +392,7 @@ def _add_extra_args_for_dataloader(
             num_replicas=xm.xrt_world_size(),
             rank=xm.get_ordinal(),
             shuffle=other_args["shuffle"],
+            drop_last=True,
         )
         other_args.pop("shuffle")
 

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -12,10 +12,11 @@ import torch
 from mmf.common.registry import registry
 from mmf.utils.checkpoint_updater import get_pretrained_state_mapping_checkpoint
 from mmf.utils.configuration import get_mmf_env, load_yaml
-from mmf.utils.distributed import is_master, is_xla, synchronize
+from mmf.utils.distributed import is_master, is_xla, open_if_master, synchronize
 from mmf.utils.download import download_pretrained_model
 from mmf.utils.file_io import PathManager
 from mmf.utils.general import get_current_device, updir
+from mmf.utils.xla import save_xla_ckpt
 from omegaconf import OmegaConf
 
 
@@ -489,7 +490,7 @@ class Checkpoint:
         }
 
     def save_func(self, *args):
-        return xm.save(*args) if is_xla() else torch.save(*args)
+        return save_xla_ckpt(*args) if is_xla() else torch.save(*args)
 
     def save(self, update, iteration=None, update_best=False):
         # Only save in main process
@@ -559,22 +560,23 @@ class Checkpoint:
             git_metadata_dict = self._get_vcs_fields()
             ckpt.update(git_metadata_dict)
 
-        with PathManager.open(ckpt_filepath, "wb") as f:
+        with open_if_master(ckpt_filepath, "wb") as f:
             self.save_func(ckpt, f)
 
         if update_best:
             logger.info("Saving best checkpoint")
-            with PathManager.open(best_ckpt_filepath, "wb") as f:
+            with open_if_master(best_ckpt_filepath, "wb") as f:
                 self.save_func(ckpt, f)
 
         # Save current always
 
         logger.info("Saving current checkpoint")
-        with PathManager.open(current_ckpt_filepath, "wb") as f:
+        with open_if_master(current_ckpt_filepath, "wb") as f:
             self.save_func(ckpt, f)
 
         # Remove old checkpoints if max_to_keep is set
-        if self.max_to_keep > 0:
+        # In XLA, only delete checkpoint files in main process
+        if self.max_to_keep > 0 and is_master():
             if len(self.saved_iterations) == self.max_to_keep:
                 self.remove(self.saved_iterations.pop(0))
             self.saved_iterations.append(update)
@@ -596,5 +598,5 @@ class Checkpoint:
 
     def finalize(self):
         if is_master() or is_xla():
-            with PathManager.open(self.pth_filepath, "wb") as f:
+            with open_if_master(self.pth_filepath, "wb") as f:
                 self.save_func(self.trainer.model.state_dict(), f)

--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -1,11 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 # Inspired from maskrcnn_benchmark, fairseq
+import contextlib
 import logging
 import os
 import pickle
 import socket
 import subprocess
 import warnings
+from itertools import chain
 
 import torch
 from mmf.common.registry import registry
@@ -124,11 +126,11 @@ def broadcast_tensor(tensor, src=0):
     with torch.no_grad():
         if is_xla():
             tensor = xm.all_to_all(
-                tensor.repeat([world_size, 1]),
+                tensor.repeat([world_size] + [1] * tensor.dim()),
                 split_dimension=0,
                 concat_dimension=0,
                 split_count=world_size,
-            )[0]
+            )[src]
         else:
             dist.broadcast(tensor, src=0)
 
@@ -166,13 +168,12 @@ def gather_tensor(tensor):
     with torch.no_grad():
         tensor_list = []
 
-        for _ in range(world_size):
-            tensor_list.append(torch.zeros_like(tensor))
-
         if is_xla():
             tensor_list = xm.all_gather(tensor)
             tensor_list = tensor_list.view(world_size, *tensor.size())
         else:
+            for _ in range(world_size):
+                tensor_list.append(torch.zeros_like(tensor))
             dist.all_gather(tensor_list, tensor)
             tensor_list = torch.stack(tensor_list, dim=0)
     return tensor_list
@@ -409,3 +410,30 @@ def suppress_output(is_master):
     # Log warnings only once
     warnings.warn = warn
     warnings.simplefilter("once", UserWarning)
+
+
+def open_if_master(path, mode):
+    from mmf.utils.file_io import PathManager
+
+    if is_master():
+        return PathManager.open(path, mode)
+    else:
+        return contextlib.nullcontext()
+
+
+def broadcast_xla_master_model_param(model):
+    logger.info("Broadcasting XLA model parameters and buffers from master process ...")
+
+    parameters_and_buffers = []
+    for p in chain(model.parameters(), model.buffers()):
+        # Set all params in non-master devices to zero so that all_reduce is equivalent
+        # to broadcasting parameters from master to other devices.
+        if not is_master():
+            zero = torch.tensor(0, dtype=p.data.dtype, device=p.data.device)
+            p.data.mul_(zero)
+        parameters_and_buffers.append(p.data)
+    xm.wait_device_ops()
+    xm.all_reduce(xm.REDUCE_SUM, parameters_and_buffers)
+    xm.mark_step()
+    xm.rendezvous("mmf.trainers.core.device.broadcast_xla_master_model_param")
+    logger.info("Done!")

--- a/mmf/utils/xla.py
+++ b/mmf/utils/xla.py
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import torch
+from mmf.utils.distributed import is_master
+
+
+try:
+    import torch_xla.core.xla_model as xm
+except ImportError:
+    xm = None
+
+
+def save_xla_ckpt(ckpt, file_or_path):
+    """
+    Similar to xm.save, but only try to convert "model" and "optimizer" in an MMF
+    checkpoint to CPU, since they hold PyTorch tensors. Other items like lr_scheduler
+    often cannot be saved with xm.save due to its errors in handling mappingproxy.
+
+    Only save on the global master process (which is different from the default behavior
+    of xm.save that saves a checkpoint on each node).
+    """
+    should_write_data = is_master()
+
+    is_full_ckpt = isinstance(ckpt, dict) and "model" in ckpt and "optimizer" in ckpt
+    if is_full_ckpt:
+        ckpt["model"] = xm._maybe_convert_to_cpu(
+            ckpt["model"], convert=should_write_data
+        )
+        ckpt["optimizer"] = xm._maybe_convert_to_cpu(
+            ckpt["optimizer"], convert=should_write_data
+        )
+    else:
+        ckpt = xm._maybe_convert_to_cpu(ckpt, convert=should_write_data)
+
+    if should_write_data:
+        torch.save(ckpt, file_or_path)
+    xm.rendezvous("mmf.utils.checkpoint.save_xla_ckpt")


### PR DESCRIPTION
Fix the following on TPU training:
- instead of using `xm.save`, add a custom `save_xla_ckpt` to avoid
crashing on lr_scheduler state dict; **note that if we later switch back
to xm.save, we need to set `global_master=True` in xm.save**
- only delete old checkpoint from master process when using XLA
- only open file in "wb" mode from the master process when using XLA. (Otherwise, concurrent writing to the same file in `with PathManager.open(ckpt_filepath, "wb")` from multiple processes causes permission denied error).
- only save `config.yaml` from the global master process.
- skip batch size validation in XLA mode in evaluation loop (since data loader already automatically drops the last batch in XLA mode)
- On TPUs, there isn't an equivalent to DistributedDaraParallel yet, so adding a manual parameter broadcasting at the beginning of training (`broadcast_xla_master_model_param`). Otherwise we will have different parameters on each process since we are explicitly setting different seeds in different processes in MMF.
- set `drop_last=True` in DistributedSampler for XLA to correctly drop the last batch in XLA mode (the current codebase only set `drop_last=True` in DataLoader, which is not enough).

Test plan: tested on GCP.