### PR TITLE
[feat] allow modules to have mismatch dimensions when loading pretrained checkpoints

### DIFF
--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -382,7 +382,6 @@ class MMFTransformer(BaseTransformer):
         )
 
         # Transformer Heads
-
         return self.postprocess_output(
             sequence_output, encoded_layers, processed_sample_list
         )
@@ -403,7 +402,6 @@ class MMFTransformer(BaseTransformer):
             )
         return output_dict
 
-    # encoder_key = self.config.tie_weight_to_encoder
     def _find_unique_encoder_key(self, key):
         assert key in self.encoders, f"MMFT doesn't have {key} encoder."
         for modality in self.config.modalities:

--- a/mmf/utils/checkpoint.py
+++ b/mmf/utils/checkpoint.py
@@ -382,8 +382,26 @@ class Checkpoint:
                         and own_attr.replace(key, "")
                         == formatted_attr.replace(value, "")
                     ):
-                        logger.info("Copying " + own_attr + " from " + attr)
-                        own_state[own_attr].copy_(ckpt[attr])
+                        if own_state[own_attr].shape != ckpt[
+                            attr
+                        ].shape and self.config.checkpoint.get(
+                            "bypass_shape_mismatch", False
+                        ):
+                            logger.warning(
+                                "bypass_shape_mismatch in config.checkpoint"
+                                + " is set to be True"
+                            )
+                            logger.warning(
+                                f"""
+                                Modules {own_attr} and {attr} don't have the same shape:
+                                own_attr has shape {own_state[own_attr].shape} while
+                                attr has shape {ckpt[attr].shape} - so skipping copy.
+                                """
+                            )
+                            pass
+                        else:
+                            logger.info("Copying " + own_attr + " from " + attr)
+                            own_state[own_attr].copy_(ckpt[attr])
         logger.info("Pretrained model loaded")
 
     def upgrade_state_dict(self, state_dict):


### PR DESCRIPTION
Summary: Make it possible to skip dimension mismatch weight copying during pretrained checkpoint loading if users specify so. One use case is to add new modalities (xray video embedding) into the pretrained checkpoint so that things like token_type embedding can be changed.

Reviewed By: apsdehal

Differential Revision: D28703466

