### PR TITLE
[feat] Implement knowledge distillation in MMF

### DIFF
--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -764,3 +764,34 @@ class ContrastiveLoss(nn.Module):
         loss1 = F.cross_entropy(mma, labels)
         loss2 = F.cross_entropy(mma.T, labels)
         return (loss1 + loss2) / 2
+
+
+@registry.register_loss("mse")
+class MSELoss(nn.Module):
+    """Mean Squared Error loss
+    """
+    def __init__(self):
+        super().__init__()
+        self.loss_fn = nn.MSELoss()
+
+    def forward(self, sample_list, model_output):
+        targets = sample_list["targets"]
+        scores = model_output["scores"]
+        loss = self.loss_fn(scores, targets)
+        return loss
+
+
+@registry.register_loss("cos_emb_loss")
+class CosineEmbeddingLoss(nn.Module):
+    """Cosine embedding loss
+    """
+    def __init__(self):
+        super().__init__()
+        self.loss_fn = nn.CosineEmbeddingLoss()
+
+    def forward(self, sample_list, model_output):
+        targets = sample_list["targets"]
+        scores = model_output["scores"]
+        y = torch.ones(targets.size(0)).to(targets.device)
+        loss = self.loss_fn(scores, targets, y)
+        return loss

--- a/tests/modules/test_losses.py
+++ b/tests/modules/test_losses.py
@@ -108,3 +108,23 @@ class TestModuleLosses(unittest.TestCase):
         self.assertAlmostEqual(
             in_batch_hinge_loss(sample_list_input, predicted).item(), 6.5529985, 4
         )
+
+    def test_mse_loss(self):
+        mse_loss = losses.MSELoss()
+
+        # Test random tensor but the same targets and scores
+        torch.manual_seed(1234)
+        random_tensor = torch.rand((1, 768))
+        sample_list = {"targets": random_tensor}
+        model_output = {"scores": random_tensor}
+        self.assertEqual(mse_loss(sample_list, model_output).item(), 0.0)
+
+    def test_cosine_embedding_loss(self):
+        cos_emb_loss = losses.CosineEmbeddingLoss()
+
+        # Test random tensor but the same targets and scores
+        torch.manual_seed(1234)
+        random_tensor = torch.rand((1, 768))
+        sample_list = {"targets": random_tensor}
+        model_output = {"scores": random_tensor}
+        self.assertEqual(cos_emb_loss(sample_list, model_output).item(), 0.0)


### PR DESCRIPTION
Summary:
Add a general knowledge distillation in MMF

# High-level Design

* Knowledge distillation model contains teacher and student models. Teacher model is used to generate soft targets and let student model mimic.
* Add a processor which can process text and feature of teacher and student models. The text/feature processors can be different.
* In yaml config, student model still uses the name like `text_processor` in dataset_config. `teacher_text_processor` or `teacher_feature_key` can be added to specify teacher's processor or feature_key. Teacher model is built and loaded from `modal_config.kd.teacher.pretrained_checkpoint` and its parameters can be frozen or tunable. Student config has the same format as teacher's and supports loading pretrained model.
* Support three distillation losses: MSELoss, CosineEmbeddingLoss, and KLDivergence. The final loss is a weighted sum of distillation and metric losses.

# Summary of experiment results
1. LR set as 1e-4 to 1e-3
2. KL divergence as distillation loss is the best
3. Classification loss weight should be small
4. Different teacher architecture doesn't really matter
5. It doesn't matter whether student parameters are pretrained or not
6. If image features are the same in teacher and student, extra data is not needed to get similar performance
7. Otherwise, unlabeled data will help student model performance

Reviewed By: vedanuj

Differential Revision: D27726297

