### PR TITLE
[feat] ITM Loss

### DIFF
--- a/mmf/datasets/builders/coco/masked_dataset.py
+++ b/mmf/datasets/builders/coco/masked_dataset.py
@@ -53,20 +53,19 @@ class MaskedCOCODataset(COCODataset):
         other_caption = None
         is_correct = -1
 
-        if self._dataset_type == "train":
-            if self._two_sentence:
-                if random.random() > self._two_sentence_probability:
-                    other_caption = self._get_mismatching_caption(image_id)
-                    is_correct = False
-                else:
-                    other_caption = captions[random.choice(other_caption_indices)]
-                    is_correct = True
-            elif self._false_caption:
-                if random.random() < self._false_caption_probability:
-                    selected_caption = self._get_mismatching_caption(image_id)
-                    is_correct = False
-                else:
-                    is_correct = True
+        if self._two_sentence:
+            if random.random() > self._two_sentence_probability:
+                other_caption = self._get_mismatching_caption(image_id)
+                is_correct = False
+            else:
+                other_caption = captions[random.choice(other_caption_indices)]
+                is_correct = True
+        elif self._false_caption:
+            if random.random() < self._false_caption_probability:
+                selected_caption = self._get_mismatching_caption(image_id)
+                is_correct = False
+            else:
+                is_correct = True
 
         processed = self.masked_token_processor(
             {

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -197,6 +197,7 @@ class MMFTransformer(BaseTransformer):
             "segment_ids": segment_ids,
             "masks": masks,
             "mlm_labels": mlm_labels,
+            "is_correct": sample_list.is_correct,
         }
 
     def _infer_input_ids(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:

--- a/mmf/models/transformers/heads/itm.py
+++ b/mmf/models/transformers/heads/itm.py
@@ -1,0 +1,52 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.transformers.base import BaseTransformerHead
+from transformers.modeling_bert import BertPooler, BertOnlyNSPHead
+
+@registry.register_transformer_head("itm")
+class ITM(BaseTransformerHead):
+    @dataclass
+    class Config(BaseTransformerHead.Config):
+        type: str = "itm"
+        hidden_size: int = 768
+        loss_name: str = "itm_loss"
+        ignore_index: int = -1
+        label_key: str = "is_correct"
+
+    def __init__(self, config: Config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+
+        # Head modules
+        self.pooler = BertPooler(self.config)
+        self.cls = BertOnlyNSPHead(self.config)
+
+        # Loss
+        self.ce_loss = torch.nn.CrossEntropyLoss(ignore_index=self.config.ignore_index)
+
+    def forward(
+        self,
+        sequence_output: torch.Tensor,
+        encoded_layers: Optional[List[torch.Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, torch.Tensor]]] = None,
+    ):
+        assert (
+            processed_sample_list is not None
+        ), "ITM head requires 'processed_sample_list' argument"
+
+        output_dict = {}
+
+        next_sentence_labels = processed_sample_list[self.config.label_key]
+        pooled_output = self.pooler(sequence_output)
+        seq_relationship_score = self.cls(pooled_output)
+        itm_loss = self.ce_loss(
+            seq_relationship_score.contiguous().view(-1, 2),
+            next_sentence_labels.contiguous().view(-1),
+        )
+        output_dict["losses"] = {}
+        output_dict["losses"][self.config.loss_name] = itm_loss
+        return output_dict

--- a/projects/mmf_transformer/configs/masked_coco/defaults.yaml
+++ b/projects/mmf_transformer/configs/masked_coco/defaults.yaml
@@ -1,0 +1,51 @@
+model_config:
+  mmf_transformer:
+    modalities:
+      - type: text
+        key: text
+        position_dim: 512
+        segment_id: 0
+        embedding_dim: 768
+        layer_norm_eps: 1e-12
+        hidden_dropout_prob: 0.1
+      - type: image
+        key: image
+        embedding_dim: 2048
+        position_dim: 1
+        segment_id: 1
+        layer_norm_eps: 1e-12
+        hidden_dropout_prob: 0.1
+        encoder:
+            type: identity
+            params:
+                in_dim : 2048
+    heads:
+      - type: mlm
+        freeze: false
+        lr_multiplier: 1.0
+        # default for bert base
+        hidden_size: 768
+        # default vocab size for bert base
+        vocab_size: 30522
+
+dataset_config:
+  masked_coco:
+    return_features_info: true
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 1000
+    num_training_steps: 11000
+
+training:
+  batch_size: 480
+  lr_scheduler: true
+  # Don't forget to update schedule_attributes if you update this
+  max_updates: 11000

--- a/projects/mmf_transformer/configs/masked_coco/pretrain_itm.yaml
+++ b/projects/mmf_transformer/configs/masked_coco/pretrain_itm.yaml
@@ -1,0 +1,17 @@
+includes:
+- ./defaults.yaml
+
+model_config:
+  mmf_transformer:
+    heads:
+      - type: itm
+        freeze: false
+        lr_multiplier: 1.0
+        # default for bert base
+        hidden_size: 768
+
+dataset_config:
+  masked_coco:
+    return_features_info: true
+    false_caption: true
+    false_caption_probability: 0.1


### PR DESCRIPTION
PR adds Image-text matching loss to MMF. The loss can be used standalone or with the MMFTransformer as a head. 

Addresses #947 #466

- Adds ITM loss
- Fixes ITM loss for validation dataset
- Adds config for COCO ITM loss
