### PR TITLE
fix fp16 overflow issue

### DIFF
--- a/mmf/modules/layers.py
+++ b/mmf/modules/layers.py
@@ -752,7 +752,7 @@ class AttnPool1d(nn.Module):
         b = query.size(0)
         score = self.linear(query).transpose(-2, -1)
         if mask is not None:
-            score.data.masked_fill_(mask.unsqueeze(1), -1e9)
+            score.data.masked_fill_(mask.unsqueeze(1), -10000.0)
         self.p_attn = nn.functional.softmax(score, dim=-1)
 
         return torch.matmul(self.p_attn, value).view(b, self.num_attn, -1)


### PR DESCRIPTION
"-1e9" induces "RuntimeError: value cannot be converted to type at::Half without overflow:" when fp16=true, replace it with "-10000.0"

Tested locally

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines), please open an issue first about
the feature/bug, and indicate how you want to contribute.

Use [contributing guidelines](https://github.com/facebookresearch/mmf/tree/master/.github/CONTRIBUTING.md) before opening up the PR to follow MMF style guidelines.
