### PR TITLE
[refactor][PL][1/N]: clean up trainers test code

### DIFF
--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -42,7 +42,7 @@ class LightningTrainer(BaseTrainer):
 
         lightning_params_dict = OmegaConf.to_container(lightning_params, resolve=True)
         self.trainer = Trainer(
-            callbacks=self._callbacks,
+            callbacks=self.callbacks,
             max_steps=self._max_updates,
             default_root_dir=get_mmf_env(key="log_dir"),
             **lightning_params_dict
@@ -98,7 +98,7 @@ class LightningTrainer(BaseTrainer):
         self.model.metrics = Metrics(metrics)
 
     def configure_callbacks(self) -> None:
-        self._callbacks = [LightningLoopCallback(self)]
+        self.callbacks = [LightningLoopCallback(self)]
 
     def train(self) -> None:
         logger.info("===== Model =====")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional
 
 import torch
+from mmf.common.registry import registry
 from mmf.common.sample import Sample, SampleList
 from mmf.models.base_model import BaseModel
 from mmf.utils.general import get_current_device
@@ -197,9 +198,8 @@ class SimpleModel(BaseModel):
 
 
 class SimpleLightningModel(SimpleModel):
-    def __init__(self, config: SimpleModel.Config, trainer_config=None):
+    def __init__(self, config: SimpleModel.Config):
         super().__init__(config)
-        self.trainer_config = trainer_config
 
     def build_meters(self, run_type):
         from mmf.utils.build import build_meters
@@ -218,12 +218,13 @@ class SimpleLightningModel(SimpleModel):
         return output
 
     def configure_optimizers(self):
-        if self.config is None:
+        config = registry.get("config")
+        if config is None:
             return torch.optim.Adam(self.parameters(), lr=0.01)
         else:
             from mmf.utils.build import build_lightning_optimizers
 
-            return build_lightning_optimizers(self, self.trainer_config)
+            return build_lightning_optimizers(self, config)
 
 
 def assertModulesEqual(mod1, mod2):

--- a/tests/trainers/lightning/lightning_trainer_mock.py
+++ b/tests/trainers/lightning/lightning_trainer_mock.py
@@ -6,52 +6,26 @@ from tests.trainers.test_trainer_mocks import MultiDataModuleNumbersTestObject
 
 
 class LightningTrainerMock(LightningTrainer):
-    def __init__(
-        self,
-        config,
-        max_steps,
-        max_epochs=None,
-        callback=None,
-        num_data_size=100,
-        batch_size=1,
-        accumulate_grad_batches=1,
-        lr_scheduler=False,
-        gradient_clip_val=0.0,
-        precision=32,
-        **kwargs
-    ):
+    def __init__(self, config, num_data_size=100, **kwargs):
         self.config = config
-        self._callbacks = None
-        if callback:
-            self._callbacks = [callback]
-
-        # data
-        self.data_module = MultiDataModuleNumbersTestObject(
-            num_data=num_data_size, batch_size=batch_size
-        )
+        self.callbacks = []
 
         # settings
         trainer_config = self.config.trainer.params
-        trainer_config.accumulate_grad_batches = accumulate_grad_batches
-        trainer_config.precision = precision
-        trainer_config.max_steps = max_steps
-        trainer_config.max_epochs = max_epochs
-        trainer_config.gradient_clip_val = gradient_clip_val
-        trainer_config.precision = precision
+        self.trainer_config = trainer_config
+        self.training_config = self.config.training
 
         for key, value in kwargs.items():
             trainer_config[key] = value
 
-        self.trainer_config = trainer_config
-        self.training_config = self.config.training
-        self.training_config.batch_size = batch_size
+        # data
+        self.data_module = MultiDataModuleNumbersTestObject(
+            config=config, num_data=num_data_size
+        )
+
         self.run_type = self.config.get("run_type", "train")
-        self.config.training.lr_scheduler = lr_scheduler
         registry.register("config", self.config)
 
-        self.data_module = MultiDataModuleNumbersTestObject(
-            num_data=num_data_size, batch_size=batch_size
-        )
         self.train_loader = self.data_module.train_dataloader()
         self.val_loader = self.data_module.val_dataloader()
         self.test_loader = self.data_module.test_dataloader()

--- a/tests/trainers/lightning/test_grad_accumulate.py
+++ b/tests/trainers/lightning/test_grad_accumulate.py
@@ -4,23 +4,37 @@ import unittest
 from unittest.mock import patch
 
 import torch
-from tests.trainers.test_utils import get_lightning_trainer
+from tests.trainers.test_utils import get_config_with_defaults, get_lightning_trainer
 
 
 class TestLightningTrainerGradAccumulate(unittest.TestCase):
     def test_grad_accumulate(self):
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer1 = get_lightning_trainer(
+            config = self._get_config(
                 accumulate_grad_batches=2, max_steps=2, batch_size=3
             )
+            trainer1 = get_lightning_trainer(config=config)
             trainer1.trainer.fit(trainer1.model, trainer1.data_module.train_loader)
 
-            trainer2 = get_lightning_trainer(
+            config = self._get_config(
                 accumulate_grad_batches=1, max_steps=2, batch_size=6
             )
+            trainer2 = get_lightning_trainer(config=config)
             trainer2.trainer.fit(trainer2.model, trainer2.data_module.train_loader)
 
             for param1, param2 in zip(
                 trainer1.model.parameters(), trainer2.model.parameters()
             ):
                 self.assertTrue(torch.allclose(param1, param2))
+
+    def _get_config(self, accumulate_grad_batches, max_steps, batch_size):
+        config = {
+            "trainer": {
+                "params": {
+                    "accumulate_grad_batches": accumulate_grad_batches,
+                    "max_steps": max_steps,
+                }
+            },
+            "training": {"batch_size": batch_size},
+        }
+        return get_config_with_defaults(config)

--- a/tests/trainers/lightning/test_grad_clipping.py
+++ b/tests/trainers/lightning/test_grad_clipping.py
@@ -6,26 +6,27 @@ from unittest.mock import MagicMock, patch
 import torch
 from mmf.utils.general import clip_gradients
 from pytorch_lightning.callbacks.base import Callback
-from tests.trainers.test_utils import get_lightning_trainer, get_mmf_trainer
+from tests.trainers.test_utils import (
+    get_config_with_defaults,
+    get_lightning_trainer,
+    get_mmf_trainer,
+)
 
 
 class TestLightningTrainerGradClipping(unittest.TestCase, Callback):
     def setUp(self):
         self.mmf_grads = []
         self.lightning_grads = []
-
         self.grad_clip_magnitude = 0.15
-        self.grad_clipping_config = {
-            "max_grad_l2_norm": self.grad_clip_magnitude,
-            "clip_norm_mode": "all",
-        }
 
     def test_grad_clipping_and_parity_to_mmf(self):
-        mmf_trainer = get_mmf_trainer(
+        config = self._get_mmf_config(
             max_updates=5,
             max_epochs=None,
-            grad_clipping_config=self.grad_clipping_config,
+            max_grad_l2_norm=self.grad_clip_magnitude,
+            clip_norm_mode="all",
         )
+        mmf_trainer = get_mmf_trainer(config=config)
         mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
 
         def _finish_update():
@@ -48,12 +49,11 @@ class TestLightningTrainerGradClipping(unittest.TestCase, Callback):
         mmf_trainer.training_loop()
 
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer = get_lightning_trainer(
-                max_steps=5,
-                max_epochs=None,
-                gradient_clip_val=self.grad_clip_magnitude,
-                callback=self,
+            config = self._get_config(
+                max_steps=5, max_epochs=None, gradient_clip_val=self.grad_clip_magnitude
             )
+            trainer = get_lightning_trainer(config=config)
+            trainer.callbacks.append(self)
             trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
 
     def on_after_backward(self, trainer, pl_module):
@@ -67,3 +67,29 @@ class TestLightningTrainerGradClipping(unittest.TestCase, Callback):
     def on_train_end(self, trainer, pl_module):
         for lightning_grad, mmf_grad in zip(self.lightning_grads, self.mmf_grads):
             self.assertAlmostEqual(lightning_grad, mmf_grad, places=6)
+
+    def _get_config(self, max_steps, max_epochs, gradient_clip_val):
+        config = {
+            "trainer": {
+                "params": {
+                    "max_steps": max_steps,
+                    "max_epochs": max_epochs,
+                    "gradient_clip_val": gradient_clip_val,
+                }
+            }
+        }
+        return get_config_with_defaults(config)
+
+    def _get_mmf_config(
+        self, max_updates, max_epochs, max_grad_l2_norm, clip_norm_mode
+    ):
+        config = {
+            "training": {
+                "max_updates": max_updates,
+                "max_epochs": max_epochs,
+                "clip_gradients": True,
+                "max_grad_l2_norm": max_grad_l2_norm,
+                "clip_norm_mode": clip_norm_mode,
+            }
+        }
+        return get_config_with_defaults(config)

--- a/tests/trainers/lightning/test_logging.py
+++ b/tests/trainers/lightning/test_logging.py
@@ -7,9 +7,10 @@ from mmf.trainers.callbacks.logistics import LogisticsCallback
 from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
 from mmf.utils.timer import Timer
 from tests.trainers.test_utils import (
+    get_config_with_defaults,
     get_lightning_trainer,
     get_mmf_trainer,
-    run_lightning_trainer_with_callback,
+    run_lightning_trainer,
 )
 
 
@@ -38,7 +39,7 @@ class TestLightningTrainerLogging(unittest.TestCase):
         mkdirs,
     ):
         # mmf trainer
-        mmf_trainer = get_mmf_trainer(
+        config = self._get_mmf_config(
             max_updates=8,
             batch_size=2,
             max_epochs=None,
@@ -46,6 +47,7 @@ class TestLightningTrainerLogging(unittest.TestCase):
             evaluation_interval=9,
             tensorboard=True,
         )
+        mmf_trainer = get_mmf_trainer(config=config)
 
         def _add_scalars_mmf(log_dict, iteration):
             self.mmf_tensorboard_logs.append({iteration: log_dict})
@@ -63,14 +65,14 @@ class TestLightningTrainerLogging(unittest.TestCase):
         mmf_trainer.training_loop()
 
         # lightning_trainer
-        trainer = get_lightning_trainer(
+        config = self._get_config(
             max_steps=8,
             batch_size=2,
-            prepare_trainer=False,
             log_every_n_steps=3,
             val_check_interval=9,
             tensorboard=True,
         )
+        trainer = get_lightning_trainer(config=config, prepare_trainer=False)
 
         def _add_scalars_lightning(log_dict, iteration):
             self.lightning_tensorboard_logs.append({iteration: log_dict})
@@ -79,9 +81,9 @@ class TestLightningTrainerLogging(unittest.TestCase):
             trainer.tb_writer.add_scalars = _add_scalars_lightning
 
         callback = LightningLoopCallback(trainer)
-        run_lightning_trainer_with_callback(
-            trainer, callback, on_fit_start_callback=_on_fit_start_callback
-        )
+        trainer.callbacks.append(callback)
+
+        run_lightning_trainer(trainer, on_fit_start_callback=_on_fit_start_callback)
         self.assertEqual(
             len(self.mmf_tensorboard_logs), len(self.lightning_tensorboard_logs)
         )
@@ -90,3 +92,39 @@ class TestLightningTrainerLogging(unittest.TestCase):
             self.mmf_tensorboard_logs, self.lightning_tensorboard_logs
         ):
             self.assertDictEqual(mmf, lightning)
+
+    def _get_config(
+        self, max_steps, batch_size, log_every_n_steps, val_check_interval, tensorboard
+    ):
+        config = {
+            "trainer": {
+                "params": {
+                    "max_steps": max_steps,
+                    "log_every_n_steps": log_every_n_steps,
+                    "val_check_interval": val_check_interval,
+                }
+            },
+            "training": {"batch_size": batch_size, "tensorboard": tensorboard},
+        }
+        return get_config_with_defaults(config)
+
+    def _get_mmf_config(
+        self,
+        max_updates,
+        max_epochs,
+        batch_size,
+        log_interval,
+        evaluation_interval,
+        tensorboard,
+    ):
+        config = {
+            "training": {
+                "batch_size": batch_size,
+                "tensorboard": tensorboard,
+                "max_updates": max_updates,
+                "max_epochs": max_epochs,
+                "log_interval": log_interval,
+                "evaluation_interval": evaluation_interval,
+            }
+        }
+        return get_config_with_defaults(config)

--- a/tests/trainers/lightning/test_loop_conditions.py
+++ b/tests/trainers/lightning/test_loop_conditions.py
@@ -3,13 +3,14 @@
 import unittest
 from unittest.mock import patch
 
-from tests.trainers.test_utils import get_lightning_trainer
+from tests.trainers.test_utils import get_config_with_defaults, get_lightning_trainer
 
 
 class TestLightningTrainer(unittest.TestCase):
     def test_epoch_over_updates(self):
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer = get_lightning_trainer(max_steps=2, max_epochs=0.04)
+            config = self._get_config(max_steps=2, max_epochs=0.04)
+            trainer = get_lightning_trainer(config=config)
             self.assertEqual(trainer._max_updates, 4)
 
             self._check_values(trainer, 0, 0)
@@ -18,7 +19,8 @@ class TestLightningTrainer(unittest.TestCase):
 
     def test_fractional_epoch(self):
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer = get_lightning_trainer(max_steps=None, max_epochs=0.04)
+            config = self._get_config(max_steps=None, max_epochs=0.04)
+            trainer = get_lightning_trainer(config=config)
             self.assertEqual(trainer._max_updates, 4)
 
             self._check_values(trainer, 0, 0)
@@ -27,7 +29,8 @@ class TestLightningTrainer(unittest.TestCase):
 
     def test_updates(self):
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer = get_lightning_trainer(max_steps=2, max_epochs=None)
+            config = self._get_config(max_steps=2, max_epochs=None)
+            trainer = get_lightning_trainer(config=config)
             self.assertEqual(trainer._max_updates, 2)
 
             self._check_values(trainer, 0, 0)
@@ -37,3 +40,9 @@ class TestLightningTrainer(unittest.TestCase):
     def _check_values(self, trainer, current_iteration, current_epoch):
         self.assertEqual(trainer.trainer.global_step, current_iteration)
         self.assertEqual(trainer.trainer.current_epoch, current_epoch)
+
+    def _get_config(self, max_steps, max_epochs):
+        config = {
+            "trainer": {"params": {"max_steps": max_steps, "max_epochs": max_epochs}}
+        }
+        return get_config_with_defaults(config)

--- a/tests/trainers/lightning/test_loss.py
+++ b/tests/trainers/lightning/test_loss.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 
 from mmf.common.report import Report
 from pytorch_lightning.callbacks.base import Callback
-from tests.trainers.test_utils import get_lightning_trainer, get_mmf_trainer
+from tests.trainers.test_utils import (
+    get_config_with_defaults,
+    get_lightning_trainer,
+    get_mmf_trainer,
+)
 
 
 class TestLightningTrainerLoss(unittest.TestCase, Callback):
@@ -18,15 +22,19 @@ class TestLightningTrainerLoss(unittest.TestCase, Callback):
         def _on_update_end(report, meter, should_log):
             self.mmf_losses.append(report["losses"]["loss"].item())
 
-        mmf_trainer = get_mmf_trainer(
-            max_updates=5, max_epochs=None, on_update_end_fn=_on_update_end
+        config = get_config_with_defaults(
+            {"training": {"max_updates": 5, "max_epochs": None}}
         )
+        mmf_trainer = get_mmf_trainer(config=config)
+        mmf_trainer.on_update_end = _on_update_end
         mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
         mmf_trainer.training_loop()
 
         # compute lightning_trainer training losses
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer = get_lightning_trainer(callback=self, max_steps=5)
+            config = get_config_with_defaults({"trainer": {"params": {"max_steps": 5}}})
+            trainer = get_lightning_trainer(config=config)
+            trainer.callbacks.append(self)
             trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
 
     def on_train_batch_end(

--- a/tests/trainers/lightning/test_lr_schedule.py
+++ b/tests/trainers/lightning/test_lr_schedule.py
@@ -4,10 +4,11 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
+from mmf.trainers.callbacks.lr_scheduler import LRSchedulerCallback
 from tests.trainers.test_utils import (
+    get_config_with_defaults,
     get_lightning_trainer,
     get_mmf_trainer,
-    get_trainer_config,
 )
 
 
@@ -15,10 +16,12 @@ class TestLightningTrainerLRSchedule(unittest.TestCase):
     def test_lr_schedule(self):
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
             # note, be aware some of the logic also is in the SimpleLightningModel
-            trainer1 = get_lightning_trainer(max_steps=8, lr_scheduler=True)
+            config = self._get_config(max_steps=8, lr_scheduler=True)
+            trainer1 = get_lightning_trainer(config=config)
             trainer1.trainer.fit(trainer1.model, trainer1.data_module.train_loader)
 
-            trainer2 = get_lightning_trainer(max_steps=8)
+            config = self._get_config(max_steps=8)
+            trainer2 = get_lightning_trainer(config=config)
             trainer2.trainer.fit(trainer2.model, trainer2.data_module.train_loader)
 
             last_model_param1 = list(trainer1.model.parameters())[-1]
@@ -26,18 +29,30 @@ class TestLightningTrainerLRSchedule(unittest.TestCase):
             self.assertFalse(torch.allclose(last_model_param1, last_model_param2))
 
     def test_lr_schedule_compared_to_mmf_is_same(self):
-        trainer_config = get_trainer_config()
-        mmf_trainer = get_mmf_trainer(
-            max_updates=8, max_epochs=None, scheduler_config=trainer_config.scheduler
+        config = get_config_with_defaults(
+            {"training": {"max_updates": 8, "max_epochs": None, "lr_scheduler": True}}
         )
+
+        mmf_trainer = get_mmf_trainer(config=config)
+        mmf_trainer.lr_scheduler_callback = LRSchedulerCallback(config, mmf_trainer)
+        mmf_trainer.callbacks.append(mmf_trainer.lr_scheduler_callback)
+        mmf_trainer.on_update_end = mmf_trainer.lr_scheduler_callback.on_update_end
         mmf_trainer.evaluation_loop = MagicMock(return_value=(None, None))
         mmf_trainer.training_loop()
 
         with patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value=None):
-            trainer = get_lightning_trainer(max_steps=8, lr_scheduler=True)
+            config = self._get_config(max_steps=8, lr_scheduler=True)
+            trainer = get_lightning_trainer(config=config)
             trainer.trainer.fit(trainer.model, trainer.data_module.train_loader)
 
             mmf_trainer.model.to(trainer.model.device)
             last_model_param1 = list(mmf_trainer.model.parameters())[-1]
             last_model_param2 = list(trainer.model.parameters())[-1]
             self.assertTrue(torch.allclose(last_model_param1, last_model_param2))
+
+    def _get_config(self, max_steps, lr_scheduler=False):
+        config = {
+            "trainer": {"params": {"max_steps": max_steps}},
+            "training": {"lr_scheduler": lr_scheduler},
+        }
+        return get_config_with_defaults(config)

--- a/tests/trainers/lightning/test_validation.py
+++ b/tests/trainers/lightning/test_validation.py
@@ -11,9 +11,10 @@ from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
 from mmf.utils.logger import TensorboardLogger
 from mmf.utils.timer import Timer
 from tests.trainers.test_utils import (
+    get_config_with_defaults,
     get_lightning_trainer,
     get_mmf_trainer,
-    run_lightning_trainer_with_callback,
+    run_lightning_trainer,
 )
 
 
@@ -47,15 +48,16 @@ class TestLightningTrainerValidation(unittest.TestCase):
     @patch("mmf.common.test_reporter.PathManager.mkdirs")
     @patch("mmf.trainers.lightning_trainer.get_mmf_env", return_value="")
     def test_validation(self, log_dir, mkdirs):
-        trainer = get_lightning_trainer(
+        config = self._get_config(
             max_steps=8,
             batch_size=2,
-            prepare_trainer=False,
             val_check_interval=3,
             log_every_n_steps=9,  # turn it off
             limit_val_batches=1.0,
         )
+        trainer = get_lightning_trainer(config=config, prepare_trainer=False)
         callback = LightningLoopCallback(trainer)
+        trainer.callbacks.append(callback)
         lightning_values = []
 
         def log_values(
@@ -79,7 +81,7 @@ class TestLightningTrainerValidation(unittest.TestCase):
             "mmf.trainers.lightning_core.loop_callback.summarize_report",
             side_effect=log_values,
         ):
-            run_lightning_trainer_with_callback(trainer, callback)
+            run_lightning_trainer(trainer)
 
         self.assertEqual(len(self.ground_truths), len(lightning_values))
         for gt, lv in zip(self.ground_truths, lightning_values):
@@ -107,9 +109,10 @@ class TestLightningTrainerValidation(unittest.TestCase):
     @patch("mmf.common.test_reporter.get_mmf_env", return_value="")
     @patch("mmf.trainers.callbacks.logistics.summarize_report")
     def test_validation_parity(self, summarize_report_fn, test_reporter, sw, mkdirs):
-        mmf_trainer = get_mmf_trainer(
-            max_updates=8, batch_size=2, max_epochs=None, evaluation_interval=3
+        config = self._get_mmf_config(
+            max_updates=8, max_epochs=None, batch_size=2, evaluation_interval=3
         )
+        mmf_trainer = get_mmf_trainer(config=config)
         mmf_trainer.load_metrics()
         logistics_callback = LogisticsCallback(mmf_trainer.config, mmf_trainer)
         logistics_callback.snapshot_timer = Timer()
@@ -132,3 +135,35 @@ class TestLightningTrainerValidation(unittest.TestCase):
                     self.assertAlmostEqual(kwargs["meter"].loss.avg, value, 1)
                 else:
                     self.assertAlmostEqual(kwargs[key], value, 1)
+
+    def _get_config(
+        self,
+        max_steps,
+        batch_size,
+        val_check_interval,
+        log_every_n_steps,
+        limit_val_batches,
+    ):
+        config = {
+            "trainer": {
+                "params": {
+                    "max_steps": max_steps,
+                    "log_every_n_steps": log_every_n_steps,
+                    "val_check_interval": val_check_interval,
+                    "limit_val_batches": limit_val_batches,
+                }
+            },
+            "training": {"batch_size": batch_size},
+        }
+        return get_config_with_defaults(config)
+
+    def _get_mmf_config(self, max_updates, max_epochs, batch_size, evaluation_interval):
+        config = {
+            "training": {
+                "max_updates": max_updates,
+                "max_epochs": max_epochs,
+                "batch_size": batch_size,
+                "evaluation_interval": evaluation_interval,
+            }
+        }
+        return get_config_with_defaults(config)

--- a/tests/trainers/test_eval_loop.py
+++ b/tests/trainers/test_eval_loop.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
-from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+from tests.trainers.test_utils import get_config_with_defaults, get_mmf_trainer
 
 
 class TestEvalLoop(unittest.TestCase):
@@ -17,8 +17,10 @@ class TestEvalLoop(unittest.TestCase):
     )
     @patch("mmf.common.test_reporter.get_mmf_env", return_value="")
     def test_eval_loop(self, a, b):
-        trainer = TrainerTrainingLoopMock(100, max_updates=2, max_epochs=2)
-        trainer.load_datasets()
+        config = get_config_with_defaults(
+            {"training": {"max_updates": 2, "max_epochs": 2}}
+        )
+        trainer = get_mmf_trainer(config=config)
         combined_report, meter = trainer.evaluation_loop("val")
         self.assertAlmostEqual(combined_report["losses"]["loss"], 493377.5312)
         self.assertAlmostEqual(combined_report["logits"].item(), -0.2379742, 6)

--- a/tests/trainers/test_fp16.py
+++ b/tests/trainers/test_fp16.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 from tests.test_utils import SimpleModel, skip_if_no_cuda
 from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+from tests.trainers.test_utils import get_config_with_defaults
 
 
 class SimpleModelWithFp16Assert(SimpleModel):
@@ -29,15 +30,32 @@ class MMFTrainerMock(TrainerTrainingLoopMock):
     def __init__(
         self, num_train_data, max_updates, max_epochs, device="cuda", fp16_model=False
     ):
-        super().__init__(num_train_data, max_updates, max_epochs, fp16=True)
-        self.device = torch.device(device)
+        config = get_config_with_defaults(
+            {
+                "training": {
+                    "max_updates": max_updates,
+                    "max_epochs": max_epochs,
+                    "evaluation_interval": 10000,
+                    "fp16": True,
+                },
+                "run_type": "train",
+            }
+        )
+        super().__init__(num_train_data, config=config)
         if fp16_model:
             assert (
                 torch.cuda.is_available()
             ), "MMFTrainerMock fp16 requires cuda enabled"
-            self.model = SimpleModelWithFp16Assert({"in_dim": 1})
-            self.model.build()
-            self.model = self.model.cuda()
+            model = SimpleModelWithFp16Assert({"in_dim": 1})
+            model.build()
+            model = model.cuda()
+        else:
+            model = SimpleModel({"in_dim": 1})
+            model.build()
+            model.train()
+            model.to(self.device)
+
+        self.model = model
         self.optimizer = torch.optim.SGD(self.model.parameters(), lr=1e-3)
 
 

--- a/tests/trainers/test_sharded_ddp.py
+++ b/tests/trainers/test_sharded_ddp.py
@@ -10,6 +10,7 @@ from mmf.utils.build import build_optimizer
 from omegaconf import OmegaConf
 from tests.test_utils import SimpleModel, skip_if_no_cuda
 from tests.trainers.test_training_loop import TrainerTrainingLoopMock
+from tests.trainers.test_utils import get_config_with_defaults
 
 
 try:
@@ -23,16 +24,13 @@ except ImportError:
 
 
 class MMFTrainerMock(TrainerTrainingLoopMock, MMFTrainer):
-    def __init__(
-        self,
-        config,
-        num_train_data,
-        max_updates,
-        max_epochs,
-        device="cuda",
-        fp16_model=False,
-    ):
-        super().__init__(num_train_data, max_updates, max_epochs, fp16=True)
+    def __init__(self, config, num_train_data, max_updates, max_epochs, device="cuda"):
+        config.training.max_updates = max_updates
+        config.training.max_epochs = max_epochs
+        config.training.fp16 = True
+        config = get_config_with_defaults(config)
+
+        super().__init__(num_train_data, config=config)
         self.device = torch.device(device)
         self.config = config
         self.model = SimpleModel({"in_dim": 1})

--- a/tests/trainers/test_trainer_mocks.py
+++ b/tests/trainers/test_trainer_mocks.py
@@ -8,16 +8,15 @@ from mmf.common.registry import registry
 from mmf.common.sample import SampleList
 from mmf.datasets.mmf_dataset_builder import MMFDatasetBuilder
 from mmf.datasets.multi_datamodule import MultiDataModule
-from mmf.trainers.callbacks.lr_scheduler import LRSchedulerCallback
 from mmf.trainers.mmf_trainer import MMFTrainer
-from mmf.utils.configuration import load_yaml
 from omegaconf import OmegaConf
-from tests.test_utils import NumbersDataset, SimpleModel
+from tests.test_utils import NumbersDataset
 
 
 class MultiDataModuleNumbersTestObject(MultiDataModule):
-    def __init__(self, num_data, batch_size):
-        self.batch_size = batch_size
+    def __init__(self, config, num_data):
+        super().__init__(config)
+        batch_size = config.training.batch_size
         config = OmegaConf.create(
             {
                 "use_features": True,
@@ -29,126 +28,63 @@ class MultiDataModuleNumbersTestObject(MultiDataModule):
                     "train": "not_a_real_features_dataset",
                     "val": "not_a_real_features_dataset",
                 },
-                "dataset_config": {"simple": 0},
+                "dataset_config": {"numbers": 0},
             }
         )
         self._num_data = num_data
-        self._batch_size = batch_size
+        self.batch_size = batch_size
         self.config = config
         self.dataset_list = []
         dataset_builder = MMFDatasetBuilder(
-            "simple", functools.partial(NumbersDataset, num_examples=num_data)
+            "numbers",
+            functools.partial(NumbersDataset, num_examples=num_data, always_one=True),
         )
-        dataset_builder.train_dataloader = self._get_dataloader
-        dataset_builder.val_dataloader = self._get_dataloader
-        dataset_builder.test_dataloader = self._get_dataloader
-        self.datamodules = {"simple": dataset_builder}
+        dataset_builder.train_dataloader = self._get_dataloader_train
+        dataset_builder.val_dataloader = self._get_dataloader_val
+        dataset_builder.test_dataloader = self._get_dataloader_test
+        self.datamodules = {"numbers": dataset_builder}
 
-    def _get_dataloader(self):
-        dataset = NumbersDataset(self._num_data)
-        dataloader = torch.utils.data.DataLoader(
+    def _get_dataloader_train(self):
+        return self._get_dataloader()
+
+    def _get_dataloader_val(self):
+        return self._get_dataloader("val")
+
+    def _get_dataloader_test(self):
+        return self._get_dataloader("test")
+
+    def _get_dataloader(self, dataset_type="train"):
+        dataset = NumbersDataset(
+            self._num_data, always_one=True, dataset_type=dataset_type
+        )
+        return torch.utils.data.DataLoader(
             dataset=dataset,
-            batch_size=self._batch_size,
+            batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,
             drop_last=False,
         )
-        return dataloader
 
 
 class TrainerTrainingLoopMock(MMFTrainer):
-    def __init__(
-        self,
-        num_train_data,
-        max_updates,
-        max_epochs,
-        config=None,
-        optimizer=None,
-        update_frequency=1,
-        batch_size=1,
-        batch_size_per_device=None,
-        fp16=False,
-        on_update_end_fn=None,
-        scheduler_config=None,
-        grad_clipping_config=None,
-        tensorboard=False,
-    ):
-        if config is None:
-            self.config = load_yaml("configs/defaults.yaml")
-            self.config = OmegaConf.merge(
-                self.config,
-                {
-                    "training": {
-                        "detect_anomaly": False,
-                        "evaluation_interval": 10000,
-                        "update_frequency": update_frequency,
-                        "fp16": fp16,
-                        "batch_size": batch_size,
-                        "batch_size_per_device": batch_size_per_device,
-                        "tensorboard": tensorboard,
-                        "run_type": "train",
-                        "num_workers": 0,
-                    },
-                    "datasets": "",
-                    "model": "",
-                },
-            )
-            self.training_config = self.config.training
-        else:
-            config.training.batch_size = batch_size
-            config.training.fp16 = fp16
-            config.training.update_frequency = update_frequency
-            config.training.tensorboard = tensorboard
-            self.training_config = config.training
-            self.config = config
-
+    def __init__(self, num_train_data=100, config=None):
+        self.training_config = config.training
+        self.config = config
         registry.register("config", self.config)
 
-        if max_updates is not None:
-            self.training_config["max_updates"] = max_updates
-        if max_epochs is not None:
-            self.training_config["max_epochs"] = max_epochs
-        self.model = SimpleModel({"in_dim": 1})
-        self.model.build()
         if torch.cuda.is_available():
-            self.model = self.model.cuda()
             self.device = "cuda"
         else:
             self.device = "cpu"
+
         self.distributed = False
-
-        if optimizer is None:
-            self.optimizer = MagicMock()
-            self.optimizer.step = MagicMock(return_value=None)
-            self.optimizer.zero_grad = MagicMock(return_value=None)
-        else:
-            self.optimizer = optimizer
-
-        if scheduler_config:
-            config.training.lr_scheduler = True
-            config.scheduler = scheduler_config
-            self.lr_scheduler_callback = LRSchedulerCallback(config, self)
-            self.callbacks.append(self.lr_scheduler_callback)
-            on_update_end_fn = (
-                on_update_end_fn
-                if on_update_end_fn
-                else self.lr_scheduler_callback.on_update_end
-            )
-        if grad_clipping_config:
-            self.training_config.clip_gradients = True
-            self.training_config.max_grad_l2_norm = grad_clipping_config[
-                "max_grad_l2_norm"
-            ]
-            self.training_config.clip_norm_mode = grad_clipping_config["clip_norm_mode"]
 
         self.on_batch_start = MagicMock(return_value=None)
         self.on_update_start = MagicMock(return_value=None)
         self.logistics_callback = MagicMock(return_value=None)
         self.logistics_callback.log_interval = MagicMock(return_value=None)
         self.on_batch_end = MagicMock(return_value=None)
-        self.on_update_end = (
-            on_update_end_fn if on_update_end_fn else MagicMock(return_value=None)
-        )
+        self.on_update_end = MagicMock(return_value=None)
         self.on_validation_start = MagicMock(return_value=None)
         self.scaler = torch.cuda.amp.GradScaler(enabled=False)
         self.early_stop_callback = MagicMock(return_value=None)
@@ -160,7 +96,7 @@ class TrainerTrainingLoopMock(MMFTrainer):
 
     def load_datasets(self):
         self.dataset_loader = MultiDataModuleNumbersTestObject(
-            num_data=self.num_data, batch_size=self.config.training.batch_size
+            config=self.config, num_data=self.num_data
         )
         self.dataset_loader.seed_sampler = MagicMock(return_value=None)
         self.dataset_loader.prepare_batch = lambda x: SampleList(x)

--- a/tests/trainers/test_training_loop.py
+++ b/tests/trainers/test_training_loop.py
@@ -1,17 +1,26 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 from mmf.common.registry import registry
 from mmf.utils.general import get_batch_size
 from tests.test_utils import SimpleModel
 from tests.trainers.test_trainer_mocks import TrainerTrainingLoopMock
+from tests.trainers.test_utils import (
+    add_model,
+    add_optimizer,
+    get_config_with_defaults,
+    get_mmf_trainer,
+)
 
 
 class TestTrainingLoop(unittest.TestCase):
-    def test_update_frequency_num_remaining_updates_greater_than_update_frequency(self):
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_update_frequency_num_remaining_updates_greater_than_update_frequency(
+        self, a
+    ):
         trainer1 = self._train_with_condition(
             num_train_data=20,
             max_updates=None,
@@ -31,7 +40,8 @@ class TestTrainingLoop(unittest.TestCase):
         self.assertEqual(trainer2.num_updates, 4)
         self._compare_model_params(trainer1, trainer2)
 
-    def test_update_frequency_reporting(self):
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_update_frequency_reporting(self, a):
         def _on_update_end(report, meter, should_log):
             # the losses here should be the sum of two losses in
             # iteration 0 and iteration 1 (both constitute update 0).
@@ -48,14 +58,17 @@ class TestTrainingLoop(unittest.TestCase):
             on_update_end_fn=_on_update_end,
         )
 
-    def test_update_frequency_correct_final_iteration(self):
-        trainer = TrainerTrainingLoopMock(100, 2, None, update_frequency=2)
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_update_frequency_correct_final_iteration(self, a):
+        config = self._get_config(max_updates=2, max_epochs=None, update_frequency=2)
+        trainer = get_mmf_trainer(config=config)
         trainer.load_datasets()
         trainer.training_loop()
         self.assertEqual(trainer.max_updates, 2)
         self.assertEqual(trainer.current_iteration, 4)
 
-    def test_update_frequency_same_model_params(self):
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_update_frequency_same_model_params(self, a):
         trainer1 = self._train_with_condition(
             num_train_data=100,
             max_updates=2,
@@ -90,28 +103,41 @@ class TestTrainingLoop(unittest.TestCase):
         on_update_end_fn=None,
     ):
         torch.random.manual_seed(2)
-        model = SimpleModel({"in_dim": 1})
-        model.build()
-        opt = torch.optim.SGD(model.parameters(), lr=0.01)
-        trainer = TrainerTrainingLoopMock(
-            num_train_data,
-            max_updates,
-            max_epochs,
-            optimizer=opt,
+        config = self._get_config(
+            max_updates=max_updates,
+            max_epochs=max_epochs,
             update_frequency=update_frequency,
             batch_size=batch_size,
         )
-        trainer.load_datasets()
+        trainer = get_mmf_trainer(num_data_size=num_train_data, config=config)
         if on_update_end_fn:
             trainer.on_update_end = on_update_end_fn
-        model.to(trainer.device)
-        trainer.model = model
         trainer.training_loop()
         return trainer
 
-    def test_epoch_over_updates(self):
-        trainer = TrainerTrainingLoopMock(100, 2, 0.04)
-        trainer.load_datasets()
+    def _get_config(
+        self,
+        max_updates,
+        max_epochs,
+        batch_size=1,
+        update_frequency=1,
+        batch_size_per_device=None,
+    ):
+        config = {
+            "training": {
+                "max_updates": max_updates,
+                "max_epochs": max_epochs,
+                "update_frequency": update_frequency,
+                "batch_size": batch_size,
+                "batch_size_per_device": batch_size_per_device,
+            }
+        }
+        return get_config_with_defaults(config)
+
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_epoch_over_updates(self, a):
+        config = self._get_config(max_updates=2, max_epochs=0.04)
+        trainer = get_mmf_trainer(config=config)
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 4)
 
@@ -119,9 +145,10 @@ class TestTrainingLoop(unittest.TestCase):
         trainer.training_loop()
         self.check_values(trainer, 4, 1, 4)
 
-    def test_fractional_epoch(self):
-        trainer = TrainerTrainingLoopMock(100, None, 0.04)
-        trainer.load_datasets()
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_fractional_epoch(self, a):
+        config = self._get_config(max_updates=None, max_epochs=0.04)
+        trainer = get_mmf_trainer(config=config)
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 4)
 
@@ -129,9 +156,10 @@ class TestTrainingLoop(unittest.TestCase):
         trainer.training_loop()
         self.check_values(trainer, 4, 1, 4)
 
-    def test_updates(self):
-        trainer = TrainerTrainingLoopMock(100, 2, None)
-        trainer.load_datasets()
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_updates(self, a):
+        config = self._get_config(max_updates=2, max_epochs=None)
+        trainer = get_mmf_trainer(config=config)
         max_updates = trainer._calculate_max_updates()
         self.assertEqual(max_updates, 2)
 
@@ -139,11 +167,15 @@ class TestTrainingLoop(unittest.TestCase):
         trainer.training_loop()
         self.check_values(trainer, 2, 1, 2)
 
-    def test_batch_size_per_device(self):
+    @patch("mmf.common.test_reporter.PathManager", return_value=MagicMock())
+    def test_batch_size_per_device(self, a):
         # Need to patch the mmf.utils.general's world size not mmf.utils.distributed
         # as the first one is what will be used
         with patch("mmf.utils.general.get_world_size", return_value=2):
-            trainer = TrainerTrainingLoopMock(100, 2, None, batch_size=4)
+            config = self._get_config(max_updates=2, max_epochs=None, batch_size=4)
+            trainer = TrainerTrainingLoopMock(config=config)
+            add_model(trainer, SimpleModel({"in_dim": 1}))
+            add_optimizer(trainer, config)
             registry.register("config", trainer.config)
             batch_size = get_batch_size()
             trainer.config.training.batch_size = batch_size
@@ -152,7 +184,12 @@ class TestTrainingLoop(unittest.TestCase):
             # with world size 2, batch size per device should 4 // 2 = 2
             self.assertEqual(trainer.train_loader.current_loader.batch_size, 2)
             # This is per device, so should stay same
-            trainer = TrainerTrainingLoopMock(100, 2, None, batch_size_per_device=4)
+            config = self._get_config(
+                max_updates=2, max_epochs=None, batch_size_per_device=4
+            )
+            trainer = TrainerTrainingLoopMock(config=config)
+            add_model(trainer, SimpleModel({"in_dim": 1}))
+            add_optimizer(trainer, config)
             registry.register("config", trainer.config)
             batch_size = get_batch_size()
             trainer.config.training.batch_size = batch_size

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -26,10 +26,12 @@ def get_trainer_config():
                 "update_frequency": 1,
                 "fp16": False,
                 "batch_size": 1,
+                "batch_size_per_device": None,
                 "lr_scheduler": False,
                 "tensorboard": False,
+                "num_workers": 0,
+                "max_grad_l2_norm": 1,
             },
-            "evaluation": {"use_cpu": False, "metrics": []},
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {
                 "type": "warmup_linear",
@@ -58,85 +60,64 @@ def get_trainer_config():
     )
 
 
-def get_lightning_trainer(
-    max_steps,
-    max_epochs=None,
-    batch_size=1,
-    model_size=1,
-    accumulate_grad_batches=1,
-    callback=None,
-    lr_scheduler=False,
-    gradient_clip_val=0.0,
-    precision=32,
-    prepare_trainer=True,
-    tensorboard=False,
-    **kwargs,
-):
-    torch.random.manual_seed(2)
-    trainer_config = get_trainer_config()
-    trainer_config.training.tensorboard = tensorboard
-    trainer = LightningTrainerMock(
-        config=trainer_config,
-        max_steps=max_steps,
-        max_epochs=max_epochs,
-        callback=callback,
-        batch_size=batch_size,
-        accumulate_grad_batches=accumulate_grad_batches,
-        lr_scheduler=lr_scheduler,
-        gradient_clip_val=gradient_clip_val,
-        precision=precision,
-        **kwargs,
-    )
-    trainer.model = SimpleLightningModel(
-        {"in_dim": model_size}, trainer_config=trainer.config
-    )
-    trainer.model.build()
-    trainer.model.train()
-    trainer.model.build_meters(trainer.run_type)
-    trainer.model.is_pl_enabled = True
-    if prepare_trainer:
-        prepare_lightning_trainer(trainer)
-    return trainer
+def get_config_with_defaults(new_config):
+    config = get_trainer_config()
+    config = OmegaConf.merge(config, OmegaConf.create(new_config))
+    return config
+
+
+def add_model(trainer, model):
+    model.build()
+    model.train()
+    model.to(trainer.device)
+    trainer.model = model
+
+
+def add_optimizer(trainer, config):
+    optimizer = build_optimizer(trainer.model, config)
+    trainer.optimizer = optimizer
 
 
 def get_mmf_trainer(
-    model_size=1,
-    num_data_size=100,
-    max_updates=5,
-    max_epochs=None,
-    on_update_end_fn=None,
-    fp16=False,
-    scheduler_config=None,
-    grad_clipping_config=None,
-    evaluation_interval=4,
-    log_interval=1,
-    batch_size=1,
-    tensorboard=False,
+    config=None, model_size=1, num_data_size=100, load_model_from_config=False
 ):
     torch.random.manual_seed(2)
-    model = SimpleModel({"in_dim": model_size})
-    model.build()
-    model.train()
-    trainer_config = get_trainer_config()
-    trainer_config.training.evaluation_interval = evaluation_interval
-    trainer_config.training.log_interval = log_interval
-    optimizer = build_optimizer(model, trainer_config)
-    trainer = TrainerTrainingLoopMock(
-        num_data_size,
-        max_updates,
-        max_epochs,
-        config=trainer_config,
-        optimizer=optimizer,
-        fp16=fp16,
-        on_update_end_fn=on_update_end_fn,
-        scheduler_config=scheduler_config,
-        grad_clipping_config=grad_clipping_config,
-        batch_size=batch_size,
-        tensorboard=tensorboard,
-    )
+    trainer = TrainerTrainingLoopMock(num_data_size, config=config)
+
+    if not load_model_from_config:
+        add_model(trainer, SimpleModel({"in_dim": model_size}))
+    else:
+        trainer.load_model()
+
+    add_optimizer(trainer, config)
+
     trainer.load_datasets()
-    model.to(trainer.device)
-    trainer.model = model
+    return trainer
+
+
+def get_lightning_trainer(
+    config=None,
+    model_size=1,
+    prepare_trainer=True,
+    load_model_from_config=False,
+    **kwargs
+):
+    torch.random.manual_seed(2)
+    trainer = LightningTrainerMock(config=config, **kwargs)
+
+    if not load_model_from_config:
+        trainer.model = SimpleLightningModel({"in_dim": model_size})
+        trainer.model.build()
+        trainer.model.train()
+
+        trainer.model.build_meters(trainer.run_type)
+        trainer.model.is_pl_enabled = True
+    else:
+        trainer.load_model()
+
+    if prepare_trainer:
+        prepare_lightning_trainer(trainer)
+
     return trainer
 
 
@@ -148,12 +129,7 @@ def prepare_lightning_trainer(trainer):
     trainer._load_trainer()
 
 
-def run_lightning_trainer_with_callback(trainer, callback, on_fit_start_callback=None):
-    callback.lightning_trainer = trainer
-    callback.trainer_config = trainer.trainer_config
-    callback.training_config = trainer.training_config
-    trainer._callbacks = [callback]
-
+def run_lightning_trainer(trainer, on_fit_start_callback=None):
     prepare_lightning_trainer(trainer)
     if on_fit_start_callback:
         on_fit_start_callback()


### PR DESCRIPTION
Separate Trainer Test code into two stages:
1. create config
2. Use config in the trainer configuration

This cleans up the implementation tests for lightning trainer and mmf trainer to make adding more tests easier. 