### PR TITLE
[feat][PL][5/N] load model checkpoint directly + model zoo

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -167,8 +167,8 @@ trainer:
         # `config.trainer.params.resume_from_checkpoint` always takes precedence over
         # `config.checkpoint` such as `config.checkpoint.resume_file`,
         # `config.checkpoint.resume_zoo` and `config.checkpoint.resume`.
-        # `resume_from_checkpoint` can take both file path and zoo identifier.
-        # Additional checkpoint customization is specified under config.checkpoint.
+        # `resume_from_checkpoint` is used to specify trainer resume parameters,
+        # including resuming model state.
         # If `resume_from_checkpoint` is not specified, then we default to using
         # "current.ckpt" if `config.checkpoint.resume is True`, or "best.ckpt" if
         # `config.checkpoint.resume_best is True`. Else, we read it from

--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -52,7 +52,12 @@ from mmf.common.registry import registry
 from mmf.common.report import Report
 from mmf.common.sample import SampleList, to_device
 from mmf.modules.losses import LossConfig, Losses
-from mmf.utils.checkpoint import load_pretrained_model
+from mmf.utils.checkpoint import (
+    is_model_only_checkpoint,
+    is_pl_checkpoint,
+    load_pretrained_model,
+    pl_checkpoint_from_mmf_checkpoint,
+)
 from mmf.utils.file_io import PathManager
 from mmf.utils.general import get_current_device
 from mmf.utils.logger import log_class_usage
@@ -114,6 +119,21 @@ class BaseModel(pl.LightningModule):
 
     def on_load_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
         self.build()
+
+        if is_model_only_checkpoint(checkpoint):
+            self._run_format_state_key(checkpoint)
+            if not is_pl_checkpoint(checkpoint):
+                pl_checkpoint_from_mmf_checkpoint(checkpoint)
+
+    def _run_format_state_key(self, state_dict: Dict[str, Any]) -> None:
+        """Function to rewrtie the checkpoint in place
+        """
+        tmp_state_dict = dict(state_dict)
+        for attr in tmp_state_dict:
+            new_attr = self.format_state_key(attr)
+            if attr != new_attr:
+                value = state_dict.pop(attr)
+                state_dict[new_attr] = value
 
     def build(self):
         """Function to be implemented by the child class, in case they need to

--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -2,7 +2,7 @@
 import logging
 import math
 import os
-from typing import List, Optional
+from typing import Any, Dict, List
 
 import omegaconf
 from mmf.common.registry import registry
@@ -11,7 +11,12 @@ from mmf.modules.metrics import Metrics
 from mmf.trainers.base_trainer import BaseTrainer
 from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
 from mmf.utils.build import build_model
-from mmf.utils.checkpoint import get_ckpt_path_from_folder
+from mmf.utils.checkpoint import (
+    get_ckpt_from_path,
+    get_ckpt_path_from_folder,
+    get_config_from_folder_or_ckpt,
+    is_model_only_checkpoint,
+)
 from mmf.utils.configuration import get_mmf_env
 from mmf.utils.download import download_pretrained_model
 from mmf.utils.file_io import PathManager
@@ -32,6 +37,7 @@ class LightningTrainer(BaseTrainer):
         self.trainer = None
         self.trainer_config = self.config.trainer.params
         self.data_module = None
+        self.resume_from_checkpoint = None
 
     def load(self):
         super().load()
@@ -41,7 +47,6 @@ class LightningTrainer(BaseTrainer):
 
     def _load_trainer(self):
         lightning_params = self.trainer_config
-        checkpoint_path = self.get_checkpoint_path()
         with omegaconf.open_dict(lightning_params):
             lightning_params.pop("max_steps")
             lightning_params.pop("max_epochs")
@@ -51,7 +56,7 @@ class LightningTrainer(BaseTrainer):
         self.trainer = Trainer(
             callbacks=self.callbacks,
             max_steps=self._max_updates,
-            resume_from_checkpoint=checkpoint_path,
+            resume_from_checkpoint=self.resume_from_checkpoint,
             default_root_dir=get_mmf_env(key="log_dir"),
             **lightning_params_dict,
         )
@@ -86,17 +91,43 @@ class LightningTrainer(BaseTrainer):
     def load_model(self) -> None:
         logger.info("Loading models")
 
+        checkpoint_data = self.get_checkpoint_data()
+        checkpoint_path = checkpoint_data["checkpoint_path"]
+        ckpt = checkpoint_data["ckpt"]
+        is_zoo = checkpoint_data["is_zoo"]
+        config = checkpoint_data["config"]
+
+        model_checkpoint_path = None
+        if checkpoint_path is not None:
+            assert ckpt, "checkpoint should have been loaded when path is available"
+            if is_model_only_checkpoint(ckpt):
+                # it is model only checkpoint, then we load it here
+                model_checkpoint_path = checkpoint_path
+            else:
+                # it is a trainer checkpoint, we pass it as a trainer param
+                self.resume_from_checkpoint = checkpoint_path
+
+        attributes = self.get_model_config(is_zoo, config)
+        self.model = build_model(attributes, model_checkpoint_path, is_pl_enabled=True)
+        self.model.build_meters(self.run_type)
+
+    def get_model_config(
+        self, is_zoo: bool = False, config: Dict[str, Any] = None
+    ) -> Dict[str, Any]:
+        ckpt_config = self.config.checkpoint
+        if is_zoo and ckpt_config.zoo_config_override and config:
+            self.config.model_config = config.model_config
+
         attributes = self.config.model_config[self.config.model]
         if isinstance(attributes, str):
             attributes = self.config.model_config[attributes]
         with omegaconf.open_dict(attributes):
             attributes.model = self.config.model
 
-        self.model = build_model(attributes, is_pl_enabled=True)
-        self.model.build_meters(self.run_type)
+        return attributes
 
-    def get_checkpoint_path(self) -> Optional[str]:
-        """ This function gets checkpoint file path from
+    def get_checkpoint_data(self) -> Dict[str, Any]:
+        """ This function gets checkpoint file path on disk from
         config.trainer.params.resume_from_checkpoint. However if it not specified,
         it gets checkpoint path from config.checkpoint. If config.resume is specified
         it gets the latest checkpoint from the config's save directory (alternatively it
@@ -105,17 +136,38 @@ class LightningTrainer(BaseTrainer):
         config.resume_zoo (in that order).
 
         Returns:
-            Optional[str]: a local file path specifying the checkpoint
-            location. If None, no checkpoint will be passed into trainer.
+            Dict[str, Any]: a dict containing the following keys,
+            `checkpoint_path` (str) local file path for the checkpoint;
+            `ckpt` (Dict[str, Any])
+            `is_zoo` (Bool) whether or not the checkpoint is specified through a
+                zoo identifier
+            `config` (Dict[str, Any]]) the config that is stored together with this
+                checkpoint
         """
         # get ckpt file path from config.trainer.params.resume_from_checkpoint
         path = self.config.trainer.params.get("resume_from_checkpoint", None)
         if path is not None:
-            if self.is_zoo_path(path):
-                path = download_pretrained_model(path)
-                path = get_ckpt_path_from_folder(path)
-            return path
+            is_zoo = self.is_zoo_path(path)
+            ckpt_filepath = path
+            if is_zoo:
+                folder = download_pretrained_model(path)
+                ckpt_filepath = get_ckpt_path_from_folder(folder)
+                ckpt = get_ckpt_from_path(ckpt_filepath)
+                config = get_config_from_folder_or_ckpt(folder, ckpt)
+            else:
+                ckpt = get_ckpt_from_path(ckpt_filepath)
+                config = None
 
+            return {
+                "ckpt": ckpt,
+                "checkpoint_path": ckpt_filepath,
+                "is_zoo": is_zoo,
+                "config": config,
+            }
+
+        is_zoo = False
+        config = None
+        ckpt = None
         # get ckpt file path from config.checkpoint
         ckpt_config = self.config.checkpoint
         suffix = "best.ckpt" if ckpt_config.resume_best else "current.ckpt"
@@ -128,15 +180,26 @@ class LightningTrainer(BaseTrainer):
             if ckpt_config.resume_file and PathManager.exists(ckpt_config.resume_file):
                 ckpt_filepath = ckpt_config.resume_file
             elif ckpt_config.resume_zoo is not None:
-                ckpt_filepath = download_pretrained_model(ckpt_config.resume_zoo)
-                ckpt_filepath = get_ckpt_path_from_folder(ckpt_filepath)
+                is_zoo = True
+                folder = download_pretrained_model(ckpt_config.resume_zoo)
+                ckpt_filepath = get_ckpt_path_from_folder(folder)
+                ckpt = get_ckpt_from_path(ckpt_filepath)
+                config = get_config_from_folder_or_ckpt(folder, ckpt)
             else:
                 raise RuntimeError(f"{ckpt_config.resume_file} doesn't exist")
 
         if ckpt_config.resume and PathManager.exists(path):
             ckpt_filepath = path
 
-        return ckpt_filepath
+        if ckpt_filepath is not None:
+            ckpt = get_ckpt_from_path(ckpt_filepath)
+
+        return {
+            "ckpt": ckpt,
+            "checkpoint_path": ckpt_filepath,
+            "is_zoo": is_zoo,
+            "config": config,
+        }
 
     def is_zoo_path(self, path) -> bool:
         from mmf.utils.configuration import get_mmf_env, load_yaml
@@ -162,7 +225,9 @@ class LightningTrainer(BaseTrainer):
 
     def monitor_criteria(self):
         monitor_criteria = self.training_config.early_stop.get("criteria", None)
-        assert monitor_criteria, "criteria is required when early stop is specified."
+        assert (
+            monitor_criteria
+        ), "monitor criteria is required when early stop is specified."
         if "val" not in monitor_criteria:
             monitor_criteria = f"val/{monitor_criteria}"
         mode = (
@@ -180,7 +245,7 @@ class LightningTrainer(BaseTrainer):
             self.callbacks += self.configure_earlystop_callback()
 
     def configure_earlystop_callback(self) -> List[ModelCheckpoint]:
-        pass
+        return []
 
     def configure_checkpoint_callbacks(self) -> List[ModelCheckpoint]:
         train_callback = ModelCheckpoint(

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -118,11 +118,11 @@ def build_model(
         )
         if is_master():
             load_model_requirements(config)
-            model = model_class.load_from_checkpoint(checkpoint_path, config=config)
+            model = model_class.load_from_checkpoint(checkpoint_path, config=config, strict=False)
             synchronize()
         else:
             synchronize()
-            model = model_class.load_from_checkpoint(checkpoint_path, config=config)
+            model = model_class.load_from_checkpoint(checkpoint_path, config=config, strict=False)
 
     model.init_losses()
     model.is_pl_enabled = is_pl_enabled

--- a/tests/trainers/lightning/lightning_trainer_mock.py
+++ b/tests/trainers/lightning/lightning_trainer_mock.py
@@ -7,6 +7,8 @@ from tests.trainers.test_trainer_mocks import MultiDataModuleNumbersTestObject
 
 class LightningTrainerMock(LightningTrainer):
     def __init__(self, config, num_data_size=100, **kwargs):
+        super().__init__(config)
+
         self.config = config
         self.callbacks = []
 

--- a/tests/trainers/lightning/test_checkpoint.py
+++ b/tests/trainers/lightning/test_checkpoint.py
@@ -207,12 +207,21 @@ class TestLightningCheckpointLoadingSaving(TestLightningCheckpoint):
                 ckpt_config=ckpt_config, model_config=model_config, max_updates=0
             )
             mmf_trainer.on_init_start()
-            model_state_dict = mmf_trainer.model.state_dict()
-            model_state_dict.pop("base.encoder.embeddings.position_ids")
-            self._assert_same_dict(ckpt, model_state_dict)
+            mmf_ckpt = mmf_trainer.model.state_dict()
+            mmf_ckpt.pop("base.encoder.embeddings.position_ids")
+            self._assert_same_dict(ckpt, mmf_ckpt)
 
-        # TODO @sash: lightning side would require the mmf_checkpoint
-        # to lightning adaptation. Next PR.
+        with mock_env_with_temp("mmf.trainers.lightning_trainer.get_mmf_env") as _:
+            # lightning load from zoo, in this case, the zoo ckpt is in mmf format
+            lightning = self._get_lightning_trainer(
+                ckpt_config=ckpt_config, model_config=model_config, max_steps=0, seed=4
+            )
+            lightning.trainer.fit(
+                lightning.model, train_dataloader=lightning.train_loader
+            )
+            lightning_ckpt = lightning.model.state_dict()
+            lightning_ckpt.pop("base.encoder.embeddings.position_ids")
+            self._assert_same_dict(ckpt, lightning_ckpt)
 
     def test_load_trainer_resume_zoo_parity_with_mmf(self):
         # TODO @sash: lightning side would require the mmf_checkpoint
@@ -220,6 +229,7 @@ class TestLightningCheckpointLoadingSaving(TestLightningCheckpoint):
         pass
 
     def test_load_trainer_resume_file_parity_with_mmf(self):
+        # directly setting lightning's trainer param: resume_from_checkpoint
         filename = "current.ckpt"
         mmf_ckpt_current = self._get_mmf_ckpt(filename, ckpt_config={"resume": True})
 
@@ -275,7 +285,7 @@ class TestLightningCheckpointLoadingSaving(TestLightningCheckpoint):
                 call_args_list = [l[0][4] for l in mock_method.call_args_list]
                 self.assertListEqual(list(range(6)), call_args_list)
 
-    def test_save_current_parity_with_mmf(self):
+    def test_trainer_save_current_parity_with_mmf(self):
         with mock_env_with_temp(
             "mmf.utils.checkpoint.get_mmf_env"
         ) as tmp_d, mock_env_with_temp("mmf.common.test_reporter.get_mmf_env") as _:
@@ -332,7 +342,10 @@ class TestLightningCheckpointLoadingSaving(TestLightningCheckpoint):
             # checkpoint
             lightning_ckpt_current = torch.load(os.path.join(tmp_d, filename))
             lightning = self._get_lightning_trainer(
-                ckpt_config=ckpt_config, max_steps=6, seed=4
+                ckpt_config=ckpt_config,
+                model_config={"simple_lightning_model": {"in_dim": 1}},
+                max_steps=6,
+                seed=4,
             )
             lightning.trainer.fit(
                 lightning.model, train_dataloader=lightning.train_loader


### PR DESCRIPTION
This PR tackles model only checkpoint loading, while previous PRs take advantage of the `resume_from_checkpoint` trainer param to resume the trainer state, this instantiates the model from the specified model only checkpoint. 

This test case covers loading a model checkpoint from the model zoo. The test case shows that loading model checkpoint from model zoo for both mmf and lightning results in the same model state_dict.

This PR also includes minor clean up of checkpoint functionality.