### PR TITLE
[feat][PL][8/N] save config with checkpoint

### DIFF
--- a/mmf/models/base_model.py
+++ b/mmf/models/base_model.py
@@ -192,6 +192,17 @@ class BaseModel(pl.LightningModule):
 
         return super().load_state_dict(copied_state_dict, *args, **kwargs)
 
+    def on_save_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
+        super().on_save_checkpoint(checkpoint)
+
+        config = registry.get("config")
+        config_dict = OmegaConf.to_container(config, resolve=True)
+        checkpoint["config"] = config_dict
+
+        # TODO: add git features, for example:
+        # 'git/branch', 'git/commit_hash', 'git/commit_author',
+        # 'git/commit_message', 'git/diff'
+
     def forward(self, sample_list, *args, **kwargs):
         """To be implemented by child class. Takes in a ``SampleList`` and
         returns back a dict.

--- a/mmf/trainers/lightning_trainer.py
+++ b/mmf/trainers/lightning_trainer.py
@@ -253,6 +253,7 @@ class LightningTrainer(BaseTrainer):
             every_n_train_steps=self.config.training.checkpoint_interval,
             dirpath=get_mmf_env(key="save_dir"),
             filename="models/model_{step}",
+            save_top_k=-1,
             save_last=True,
             verbose=True,
         )

--- a/tests/trainers/lightning/test_validation.py
+++ b/tests/trainers/lightning/test_validation.py
@@ -99,7 +99,7 @@ class TestLightningTrainerValidation(unittest.TestCase):
                     # rather than 0, since 1 update/step has already been done.
                     #
                     # When lightning fixes its bug, we will update this test to remove
-                    # the hack
+                    # the hack. # issue: 6997 in pytorch lightning
                     self.assertAlmostEqual(gt[key], lv[key] - 1, 1)
                 else:
                     self.assertAlmostEqual(gt[key], lv[key], 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1035 [feat][PL][11/N] Inference with test
* #1033 [feat][PL][10/N] lightning distributed
* #1030 [refactor][PL][9/N] change the name of the _load_checkpoint to be more descriptive to contain test
* **#1024 [feat][PL][8/N] save config with checkpoint**
* #1023 [feat][PL][7/N] trainer checkpoint from mmf to lightning update
* #1022 [feat][PL][6/N] pretrained state mapping for PL

Differential Revision: [D29670421](https://our.internmc.facebook.com/intern/diff/D29670421)