### PR TITLE
[perf] tune NCCL params for acceleration

### DIFF
--- a/mmf/utils/distributed.py
+++ b/mmf/utils/distributed.py
@@ -339,6 +339,17 @@ def distributed_init(config):
             f"Distributed Init (Rank {config.distributed.rank}): "
             f"{config.distributed.init_method}"
         )
+
+        nccl_config = config.distributed.get("nccl", {})
+
+        if nccl_config.get("nccl_nsocks_perthread", None):
+            os.environ["NCCL_NSOCKS_PERTHREAD"] = str(nccl_config["nccl_nsocks_perthread"])
+            logger.info(f"NCCL_NSOCKS_PERTHREAD: {os.environ['NCCL_NSOCKS_PERTHREAD']}")
+
+        if nccl_config.get("nccl_socket_nthreads", None):
+            os.environ["NCCL_SOCKET_NTHREADS"] = str(nccl_config["nccl_socket_nthreads"])
+            logger.info(f"NCCL_SOCKET_NTHREADS: {os.environ['NCCL_SOCKET_NTHREADS']}")
+
         dist.init_process_group(
             backend=config.distributed.backend,
             init_method=config.distributed.init_method,


### PR DESCRIPTION
Summary:
Following suggestions from post https://fb.workplace.com/notes/yi-wang/faster-distributed-training-in-2-lines/271004654689757 and add 2 more NCCL parameters if it's distributed training on FB cluster.

Generally, we are seeing around 1.5 ~ 2X speedup in MMF.

Differential Revision: D28306852

