### PR TITLE
[feat] check NaNs in losses during training, and exit when it happens

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -146,6 +146,10 @@ training:
     #       foo: bar
     callbacks: []
 
+    # check for NaNs in losses during training
+    # Set to true to look for NaNs in the losses and exit the training when NaN happens
+    exit_on_nan_losses: true
+
 trainer:
     # Name of the trainer class used to define the training/evalution loop
     # `mmf` or `lightning` to specify the trainer to be used

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -197,6 +197,13 @@ class SimpleModel(BaseModel):
         }
 
 
+class SimpleNaNLossModel(SimpleModel):
+    def forward(self, prepared_batch: Dict[str, Tensor]):
+        report = super().forward(prepared_batch)
+        report["losses"]["loss"] /= 0.0  # create an NaN loss
+        return report
+
+
 class SimpleLightningModel(SimpleModel):
     def __init__(self, config: SimpleModel.Config):
         super().__init__(config)

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -31,6 +31,7 @@ def get_trainer_config():
                 "tensorboard": False,
                 "num_workers": 0,
                 "max_grad_l2_norm": 1,
+                "exit_on_nan_losses": True,
             },
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {


### PR DESCRIPTION
Add config option `training.exit_on_nan_losses` (Default to True).

When `training.exit_on_nan_losses` is True, check for NaNs in the loss dict and exit the training when NaN happens.

Test plan: tested locally; a new test case `test_exit_on_nan_losses` is added.
