### PR TITLE
[MMF][feat] Add callback in registry

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -13,6 +13,7 @@ Various decorators for registry different kind of classes with unique keys
 
 - Register a trainer: ``@registry.register_trainer``
 - Register a dataset builder: ``@registry.register_builder``
+- Register a callback function: ``@registry.register_callback``
 - Register a metric: ``@registry.register_metric``
 - Register a loss: ``@registry.register_loss``
 - Register a fusion technique: ``@registery.register_fusion``
@@ -58,6 +59,7 @@ class Registry:
         "test_reporter_mapping": {},
         "iteration_strategy_name_mapping": {},
         "state": {},
+        "callback_name_mapping": {},
     }
 
     @classmethod
@@ -112,6 +114,36 @@ class Registry:
             ), "All builders must inherit BaseDatasetBuilder class"
             cls.mapping["builder_name_mapping"][name] = builder_cls
             return builder_cls
+
+        return wrap
+
+    @classmethod
+    def register_callback(cls, name):
+        r"""Register a callback to registry with key 'name'
+
+        Args:
+            name: Key with which the callback will be registered.
+
+        Usage::
+
+            from mmf.common.registry import registry
+            from mmf.trainers.callbacks.base import Callback
+
+
+            @registry.register_callback("logistic")
+            class LogisticCallback(Callback):
+                ...
+
+        """
+
+        def wrap(func):
+            from mmf.trainers.callbacks.base import Callback
+
+            assert issubclass(
+                func, Callback
+            ), "All callbacks must inherit Callback class"
+            cls.mapping["callback_name_mapping"][name] = func
+            return func
 
         return wrap
 
@@ -455,6 +487,10 @@ class Registry:
     @classmethod
     def get_builder_class(cls, name):
         return cls.mapping["builder_name_mapping"].get(name, None)
+
+    @classmethod
+    def get_callback_class(cls, name):
+        return cls.mapping["callback_name_mapping"].get(name, None)
 
     @classmethod
     def get_model_class(cls, name):

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -137,6 +137,15 @@ training:
     # drop in results.
     fp16: false
 
+    # Users can define their own callback functions in the trainer, e.g. adjust
+    # learning rate, plot data in tensorboard, etc.
+    # The format should look like:
+    # callbacks:
+    #   - type: my_callback
+    #     params:
+    #       foo: bar
+    callbacks: []
+
 trainer:
     # Name of the trainer class used to define the training/evalution loop
     # `mmf` or `lightning` to specify the trainer to be used

--- a/mmf/trainers/mmf_trainer.py
+++ b/mmf/trainers/mmf_trainer.py
@@ -67,6 +67,12 @@ class MMFTrainer(
         # (otherwise the saved last_epoch in scheduler would be wrong)
         self.callbacks.append(self.checkpoint_callback)
         self.callbacks.append(self.logistics_callback)
+        # Add all customized callbacks defined by users
+        for callback in self.config.training.get("callbacks", []):
+            callback_type = callback.type
+            callback_param = callback.params
+            callback_cls = registry.get_callback_class(callback_type)
+            self.callbacks.append(callback_cls(self.config, self, **callback_param))
 
     def load_datasets(self):
         logger.info("Loading datasets")

--- a/tests/trainers/callbacks/test_user_callback.py
+++ b/tests/trainers/callbacks/test_user_callback.py
@@ -1,0 +1,70 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import argparse
+import os
+import unittest
+from copy import deepcopy
+
+import torch
+from mmf.common.registry import registry
+from mmf.trainers.callbacks.lr_scheduler import LRSchedulerCallback
+from mmf.utils.configuration import load_yaml
+from omegaconf import OmegaConf
+from tests.test_utils import NumbersDataset, SimpleModel
+
+
+registry.register_callback("test_callback")(LRSchedulerCallback)
+
+
+class TestUserCallback(unittest.TestCase):
+    def setUp(self):
+        self.trainer = argparse.Namespace()
+        self.config = load_yaml(os.path.join("configs", "defaults.yaml"))
+        self.config = OmegaConf.merge(
+            self.config,
+            {
+                "model": "simple",
+                "model_config": {},
+                "training": {
+                    "lr_scheduler": True,
+                    "lr_ratio": 0.1,
+                    "lr_steps": [1, 2],
+                    "use_warmup": False,
+                    "callbacks": [{"type": "test_callback", "params": {}}],
+                },
+            },
+        )
+        # Keep original copy for testing purposes
+        self.trainer.config = deepcopy(self.config)
+        registry.register("config", self.trainer.config)
+
+        model = SimpleModel(SimpleModel.Config())
+        model.build()
+        self.trainer.model = model
+        self.trainer.val_loader = torch.utils.data.DataLoader(
+            NumbersDataset(2), batch_size=self.config.training.batch_size
+        )
+
+        self.trainer.optimizer = torch.optim.Adam(
+            self.trainer.model.parameters(), lr=1e-01
+        )
+        self.trainer.lr_scheduler_callback = LRSchedulerCallback(
+            self.config, self.trainer
+        )
+
+        self.trainer.callbacks = []
+        for callback in self.config.training.get("callbacks", []):
+            callback_type = callback.type
+            callback_param = callback.params
+            callback_cls = registry.get_callback_class(callback_type)
+            self.trainer.callbacks.append(
+                callback_cls(self.trainer.config, self.trainer, **callback_param)
+            )
+
+    def tearDown(self):
+        registry.unregister("config")
+
+    def test_on_update_end(self):
+        self.assertEqual(len(self.trainer.callbacks), 1)
+        user_callback = self.trainer.callbacks[0]
+        self.assertTrue(isinstance(user_callback, LRSchedulerCallback))


### PR DESCRIPTION
Summary:
Add callback register so that user can add their customized callback function in MMF training.

# Usage
```
training:
  ...
  callbacks:
    - type: my_callback
      params:
        foo: bar
```

Differential Revision: D29810950

