### PR TITLE
[refactor][PL][9/N] change the name of the _load_checkpoint to be more descriptive to contain test

### DIFF
--- a/tests/trainers/lightning/test_checkpoint.py
+++ b/tests/trainers/lightning/test_checkpoint.py
@@ -190,19 +190,19 @@ class TestLightningCheckpoint(unittest.TestCase):
 class TestLightningCheckpoint(TestLightningCheckpoint):
     def test_load_resume_parity_with_mmf(self):
         # with checkpoint.resume = True, by default it loads "current.ckpt"
-        self._load_checkpoint("current.ckpt", ckpt_config={"resume": True})
+        self._load_checkpoint_and_test("current.ckpt", ckpt_config={"resume": True})
 
     def test_load_resume_best_parity_with_mmf(self):
         # with checkpoint.resume = True and checkpoint.resume_best = True
         # by default it loads best.ckpt. It should load the "best.ckpt"
-        self._load_checkpoint(
+        self._load_checkpoint_and_test(
             "best.ckpt", ckpt_config={"resume": True, "resume_best": True}
         )
 
     def test_load_resume_ignore_resume_zoo(self):
         # specifying both checkpoint.resume = True and resume_zoo
         # resume zoo should be ignored. It should load the "current.ckpt"
-        self._load_checkpoint(
+        self._load_checkpoint_and_test(
             "current.ckpt",
             ckpt_config={"resume": True, "resume_zoo": "visual_bert.pretrained.coco"},
         )
@@ -463,7 +463,7 @@ class TestLightningCheckpoint(TestLightningCheckpoint):
             )
         return mmf_ckpt_current
 
-    def _load_checkpoint(self, filename, ckpt_config=None):
+    def _load_checkpoint_and_test(self, filename, ckpt_config=None):
         # Make sure it loads x.ckpt when mmf
         mmf_ckpt = self._get_mmf_ckpt(filename, ckpt_config=ckpt_config)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1035 [feat][PL][11/N] Inference with test
* #1033 [feat][PL][10/N] lightning distributed
* **#1030 [refactor][PL][9/N] change the name of the _load_checkpoint to be more descriptive to contain test**
* #1024 [feat][PL][8/N] save config with checkpoint
* #1023 [feat][PL][7/N] trainer checkpoint from mmf to lightning update
* #1022 [feat][PL][6/N] pretrained state mapping for PL

Differential Revision: [D29888294](https://our.internmc.facebook.com/intern/diff/D29888294)