### PR TITLE
[feat][PL][10/N] lightning distributed

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -189,6 +189,8 @@ trainer:
         # (in that order). If `resume_from_checkpoint` is not specified, and if
         # `config.checkpoint` is not specified, then no checkpoint file will be loaded.
         resume_from_checkpoint: null
+        accelerator: null
+        move_metrics_to_cpu: True
 
 # Configuration for evaluation
 evaluation:

--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -36,6 +36,7 @@ class LightningLoopCallback(Callback):
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):
         registry.register("current_epoch", trainer.current_epoch)
         self.train_combined_report = None
+        pl_module.train_meter.reset()
 
     def on_train_batch_end(
         self,

--- a/mmf_cli/run.py
+++ b/mmf_cli/run.py
@@ -93,6 +93,12 @@ def run(opts: typing.Optional[typing.List[str]] = None, predict: bool = False):
     configuration.args = args
     config = configuration.get_config()
     config.start_rank = 0
+
+    if config.training.trainer == "lightning":
+        config.device_id = 0
+        main(configuration, predict=predict)
+        return
+
     if config.distributed.init_method is None:
         infer_init_method(config)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#1032 [feat] lightning distributed**
* #1030 [refactor][PL][9/N] change the name of the _load_checkpoint to be more descriptive to contain test
* #1024 [feat][PL][8/N] save config with checkpoint
* #1023 [feat][PL][7/N] trainer checkpoint from mmf to lightning update
* #1022 [feat][PL][6/N] pretrained state mapping for PL
* #1021 [feat][PL][5/N]  load model checkpoint directly + model zoo
* #1020 [feat][PL][4/N] best ckpt
* #1019 [fix][PL][3/N] minor change in base model
* #1018 [feat][PL][2/N] PL train checkpoint

