### PR TITLE
[feat] use persistent workers in data loader by default

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -61,6 +61,9 @@ training:
     dataset_size_proportional_sampling: true
     # Whether to pin memory in dataloader
     pin_memory: false
+    # Whether to use persistent workers in dataloader
+    # (only effective for PyTorch 1.8 or higher which supports persistent_workers)
+    persistent_workers: true
 
     # After `checkpoint_interval` number of updates, MMF will make a snapshot
     # which will involve creating a checkpoint for current training scenarios

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -21,6 +21,7 @@ from mmf.utils.configuration import Configuration, get_global_config
 from mmf.utils.distributed import is_dist_initialized, is_master, is_xla, synchronize
 from mmf.utils.general import get_optimizer_parameters
 from omegaconf import DictConfig, OmegaConf
+from packaging import version
 
 
 try:
@@ -248,6 +249,15 @@ def build_dataloader_and_sampler(
         "shuffle": datamodule_config.get("shuffle", None),
         "batch_size": datamodule_config.get("batch_size", None),
     }
+    if version.parse(torch.__version__) >= version.parse("1.8"):
+        # only use persistent workers in PyTorch 1.8 or higher
+        # (PyTorch 1.7 also has this option but doesn't support it correctly due to
+        # https://github.com/pytorch/pytorch/issues/48370)
+        other_args["persistent_workers"] = (
+            datamodule_config.get(
+                "persistent_workers", training_config.get("persistent_workers", True)
+            ),
+        )
 
     # IterableDataset returns batches directly, so no need to add Sampler
     # or batch size as user is expected to control those. This is a fine

--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -258,6 +258,12 @@ def build_dataloader_and_sampler(
                 "persistent_workers", training_config.get("persistent_workers", True)
             ),
         )
+        if other_args["persistent_workers"] and other_args["num_workers"] == 0:
+            logger.warning(
+                "persistent_workers cannot be used together with num_workers == 0; "
+                "setting persistent_workers to False"
+            )
+            other_args["persistent_workers"] = False
 
     # IterableDataset returns batches directly, so no need to add Sampler
     # or batch size as user is expected to control those. This is a fine


### PR DESCRIPTION
Switch to use persistent workers in MMF data loaders, so that one doesn't need to keep forking and joining worker processes upon each iteration. This update reduces the overhead and potential OOM error in worker forking.

Test plan: tested locally
