### PR TITLE
[feat] allow extra commandline args in sweep scripts

### DIFF
--- a/tools/sweeps/lib/__init__.py
+++ b/tools/sweeps/lib/__init__.py
@@ -55,7 +55,7 @@ def get_args(argv=None):
     parser.add_argument(
         "--extra_args",
         type=str,
-        nargs="+",
+        nargs="*",
         help="extra arguments to be passed into MMF command (e.g. config arguments)",
     )
     parser.add_argument(

--- a/tools/sweeps/lib/slurm.py
+++ b/tools/sweeps/lib/slurm.py
@@ -159,7 +159,7 @@ def launch_train(args, config):
         train_cmd.extend(["env.tensorboard_logdir", tensorboard_logdir])
     for hp in config.values():
         train_cmd.extend(map(str, hp.get_cli_args()))
-    if len(args.extra_args) > 0:
+    if args.extra_args is not None and len(args.extra_args) > 0:
         # convert commands with equal sign to the other format without the equal sign
         # e.g. ["training.batch_size=128"] to ["training.batch_size", "128"]
         extra_args = [c for arg in args.extra_args for c in arg.split("=")]


### PR DESCRIPTION
This PR adds `--extra_args` in sweep lib to allow passing additional MMF
command-line arguments, like `mmf_run` and `mmf_predict`.

Usage: one can append to the sweep script extra command line arguments such as
```
python tools/sweeps/sweep_visual_bert.py \
  <gpu, node, or other arguments> \
  --extra_args training.checkpoint_interval 10000 training.batch_size 128
```
Note that it also support the other format with equal sign `=` in args such as `--extra_args training.batch_size=128`

Test plan: tested on FAIR cluster
