### PR TITLE
[feat] merge no_token_embedding_backend to main mmf

### DIFF
--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -63,7 +63,7 @@ class HuggingfaceEmbeddings(nn.Module):
             hidden_dropout_prob = modality.get(
                 "hidden_dropout_prob", self.transformer_config.hidden_dropout_prob
             )
-            if modality.type == "text":
+            if modality.type == "text" and modality.get("consume_raw", True):
                 self.token_embeddings.append(
                     nn.Embedding(
                         self.transformer_config.vocab_size,

--- a/mmf/models/transformers/base.py
+++ b/mmf/models/transformers/base.py
@@ -39,6 +39,7 @@ class BaseTransformerModalityConfig:
     # This is actually: Union[EncoderFactory.Config, Encoder.Config]
     # NOTE: Waiting on https://github.com/omry/omegaconf/issues/144
     encoder: Any = IdentityEncoder.Config()
+    consume_raw: bool = True
 
 
 @dataclass


### PR DESCRIPTION
Summary: We can upstream the pytext_backend_without_token_embeddings to main mmf to avoid duplicate code.

Differential Revision: D30673593

