### PR TITLE
[fix] Add zoo requirements to coco masked config

### DIFF
--- a/mmf/configs/datasets/coco/masked.yaml
+++ b/mmf/configs/datasets/coco/masked.yaml
@@ -5,6 +5,8 @@ dataset_config:
     fast_read: false
     use_images: false
     use_features: true
+    zoo_requirements:
+    - coco.defaults
     features:
       train:
       - coco/defaults/features/trainval2014.lmdb


### PR DESCRIPTION
Summary:
Add same zoo_requirements as coco dataset to masked_coco.
Prevents file not found error while loading datasets.
