### PR TITLE
[feat] add config option to skip update when NaN loss happens

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -153,11 +153,11 @@ training:
     # Set to true to look for NaNs in the losses and exit the training when NaN happens
     exit_on_nan_losses: true
 
-    # When setting to True, if the current batch results in NaNs in the losses, try
-    # forwarding on the previous batch in this iteration. This could be useful in avoiding
+    # When setting to True, if the current batch results in NaNs in the losses, skip the
+    # optimizer (and grad scaler) update on this batch. This could be useful in avoiding
     # occastional underflow or overflow when training.fp16 is activated.
     # Mutually exclusive with training.exit_on_nan_losses
-    try_previous_batch_on_nan_losses: false
+    skip_batch_on_nan_losses: false
 
 trainer:
     # Name of the trainer class used to define the training/evalution loop

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -153,6 +153,12 @@ training:
     # Set to true to look for NaNs in the losses and exit the training when NaN happens
     exit_on_nan_losses: true
 
+    # When setting to True, if the current batch results in NaNs in the losses, try
+    # forwarding on the previous batch in this iteration. This could be useful in avoiding
+    # occastional underflow or overflow when training.fp16 is activated.
+    # Mutually exclusive with training.exit_on_nan_losses
+    try_previous_batch_on_nan_losses: false
+
 trainer:
     # Name of the trainer class used to define the training/evalution loop
     # `mmf` or `lightning` to specify the trainer to be used

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -32,6 +32,7 @@ def get_trainer_config():
                 "num_workers": 0,
                 "max_grad_l2_norm": 1,
                 "exit_on_nan_losses": True,
+                "skip_batch_on_nan_losses": False,
             },
             "optimizer": {"type": "adam_w", "params": {"lr": 5e-5, "eps": 1e-8}},
             "scheduler": {


### PR DESCRIPTION
Add config option `training.skip_batch_on_nan_losses`.

When setting to True, if the current batch results in NaNs in the losses, skip the optimizer (and grad scaler) update on this batch. This could be useful in avoiding occastional underflow or overflow when `training.fp16` is activated. Mutually exclusive with `training.exit_on_nan_losses`.

Also changing the previous nan checks from `isnan` to `isfinite` to also check for Inf.

Test plan: added new test case `test_skipping_batch_on_nan_losses`. Also tested locally in MMF training