### PR TITLE
[fix] demjson depends on Setuptools 58.0.0, which has removed support for 2to3, so import would fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ install_dep: &install_dep
       name: Install Dependencies
       command: |
         source activate mmf
-        pip install --upgrade setuptools
+        pip install --progress-bar off 'setuptools<58.0'
         pip install --upgrade torch torchvision
         pip install --progress-bar off flake8==3.7.9
         pip install --progress-bar off black==19.3b0

--- a/.github/workflows/cpu_test.yaml
+++ b/.github/workflows/cpu_test.yaml
@@ -48,7 +48,8 @@ jobs:
       run: |
         conda activate mmf
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools certifi
+        pip install --upgrade certifi
+        pip install --progress-bar off 'setuptools<58.0'
         pip install --progress-bar off torch torchvision torchaudio
         pip install --progress-bar off scipy==1.4.1 pybind11==2.5.0 pywin32==225
         python -c 'import torch; print("Torch version:", torch.__version__)'
@@ -59,7 +60,7 @@ jobs:
       run: |
         conda activate mmf
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools
+        pip install --progress-bar off 'setuptools<58.0'
         pip install --progress-bar off pytest
         pip install -r requirements.txt
         python -c 'import torch; print("Torch version:", torch.__version__)'

--- a/mmf/utils/configuration.py
+++ b/mmf/utils/configuration.py
@@ -7,7 +7,6 @@ import warnings
 from ast import literal_eval
 from typing import List
 
-import demjson
 import torch
 from mmf.common.registry import registry
 from mmf.utils.env import import_user_module
@@ -475,6 +474,14 @@ class Configuration:
 
     def _build_demjson_config(self, demjson_string):
         if demjson_string is None:
+            return OmegaConf.create()
+
+        try:
+            import demjson
+        except Exception:
+            logger.info(
+                "demjson failed. Likely https://github.com/dmeranda/demjson/issues/40"
+            )
             return OmegaConf.create()
 
         demjson_dict = demjson.decode(demjson_string)

--- a/mmf/utils/configuration.py
+++ b/mmf/utils/configuration.py
@@ -7,6 +7,7 @@ import warnings
 from ast import literal_eval
 from typing import List
 
+import demjson
 import torch
 from mmf.common.registry import registry
 from mmf.utils.env import import_user_module
@@ -474,14 +475,6 @@ class Configuration:
 
     def _build_demjson_config(self, demjson_string):
         if demjson_string is None:
-            return OmegaConf.create()
-
-        try:
-            import demjson
-        except Exception:
-            logger.info(
-                "demjson failed. Likely https://github.com/dmeranda/demjson/issues/40"
-            )
             return OmegaConf.create()
 
         demjson_dict = demjson.decode(demjson_string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ torch>=1.6.0, <=1.9.0
 torchvision>=0.7.0, <=0.10.0
 numpy>=1.16.6
 tqdm>=4.43.0,<4.50.0
+demjson==2.2.4
 torchtext==0.5.0
 GitPython==3.1.0
 requests==2.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@f0
 torchaudio>=0.6.0, <=0.9.0
 psutil
 pillow==8.3.1
+setuptools<58.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ torch>=1.6.0, <=1.9.0
 torchvision>=0.7.0, <=0.10.0
 numpy>=1.16.6
 tqdm>=4.43.0,<4.50.0
-demjson==2.2.4
 torchtext==0.5.0
 GitPython==3.1.0
 requests==2.23.0
@@ -23,4 +22,3 @@ pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning@f0
 torchaudio>=0.6.0, <=0.9.0
 psutil
 pillow==8.3.1
-setuptools<58.0.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1035 [feat][PL][11/N] Inference with test
* #1033 [feat][PL][10/N] lightning distributed
* #1030 [refactor][PL][9/N] change the name of the _load_checkpoint to be more descriptive to contain test
* #1024 [feat][PL][8/N] save config with checkpoint
* #1023 [feat][PL][7/N] trainer checkpoint from mmf to lightning update
* #1022 [feat][PL][6/N] pretrained state mapping for PL
* **#1076 [fix] demjson depends on Setuptools 58.0.0, which has removed support for 2to3, so import would fail**

Differential Revision: [D30798415](https://our.internmc.facebook.com/intern/diff/D30798415)