### PR TITLE
[fix] Fix bug in wandb logging config logic

### DIFF
--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -58,8 +58,8 @@ class LogisticsCallback(Callback):
             if env_wandb_logdir:
                 log_dir = env_wandb_logdir
 
-            wandb_projectname = config.trainer.wandb.wandb_projectname
-            wandb_runname = config.trainer.wandb.wandb_runname
+            wandb_projectname = config.training.wandb.wandb_projectname
+            wandb_runname = config.training.wandb.wandb_runname
 
             self.wandb_logger = WandbLogger(
                 name=wandb_runname, save_dir=log_dir, project=wandb_projectname

--- a/website/docs/notes/logging.md
+++ b/website/docs/notes/logging.md
@@ -8,6 +8,12 @@ sidebar_label: Terminology and Concepts
 
 MMF has a `WandbLogger` class which lets the user to log their model's progress using [Weights and Biases](https://gitbook-docs.wandb.ai/).
 
+To set up wandb, run the following:
+```
+pip install wandb
+wandb login
+```
+
 The following options are available in config to enable and customize the wandb logging:
 ```yaml
 training:


### PR DESCRIPTION
Although the docs state that the user should set `training.wandb.wandb_projectname` etc., the underlying code uses `config.trainer.wandb.wandb_projectname`. This small fix enables a user to successfully run the wandb logging feature. 

See #1060 for the original comment about the bug.