### PR TITLE
[feat] Add ViLT model to mmf

### DIFF
--- a/mmf/configs/models/vilt/defaults.yaml
+++ b/mmf/configs/models/vilt/defaults.yaml
@@ -1,0 +1,17 @@
+model_config:
+  vilt:
+    image_encoder:
+        type: vit
+    heads:
+      vqa2:
+        type: multilayer_mlp
+        freeze: false
+        lr_multiplier: 1.0
+        in_dim: 768
+        hidden_size: 1536
+        num_labels: 3129
+        pooler_name: bert_pooler
+    text_embeddings:
+      type: vilt_text_embedding
+    image_embeddings:
+      type: vilt_img_embedding

--- a/mmf/datasets/processors/bert_processors.py
+++ b/mmf/datasets/processors/bert_processors.py
@@ -353,3 +353,14 @@ class MultiSentenceRobertaTokenizer(MultiSentenceBertTokenizer):
         self.fusion_strategy = config.get("fusion", "concat")
         self.tokenizer = RobertaTokenizer(config, *args, **kwargs)
         self._probability = config.get("mask_probability", 0)
+
+
+@registry.register_processor("vilt_text_processor")
+class VILTTextProcessor(BertTokenizer):
+    from omegaconf import OmegaConf
+
+    def __init__(self, config, *args, **kwargs):
+        config.tokenizer_config = self.OmegaConf.create(
+            {"type": "bert-base-uncased", "params": {"do_lower_case": True}}
+        )
+        super().__init__(config, *args, **kwargs)

--- a/mmf/models/__init__.py
+++ b/mmf/models/__init__.py
@@ -17,6 +17,7 @@ from .unimodal import UnimodalBase, UnimodalText, UnimodalModal
 from .visual_bert import VisualBERT
 from .vilbert import ViLBERT
 from .albef.vit import AlbefVitEncoder
+from .vilt import ViLT
 
 
 __all__ = [
@@ -43,4 +44,5 @@ __all__ = [
     "UnimodalModal",
     "UnimodalText",
     "AlbefVitEncoder",
+    "ViLT",
 ]

--- a/mmf/models/transformers/heads/multilayer_mlp.py
+++ b/mmf/models/transformers/heads/multilayer_mlp.py
@@ -1,0 +1,68 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.transformers.heads.mlp import MLP
+from omegaconf import open_dict
+from torch import nn
+from transformers.modeling_bert import BertPredictionHeadTransform
+
+
+logger = logging.getLogger()
+
+
+class PredictionHeadTransformWithInDim(BertPredictionHeadTransform):
+    def __init__(self, config):
+        super().__init__(config)
+        self.dense = nn.Linear(config.in_dim, config.hidden_size)
+
+
+@registry.register_transformer_head("multilayer_mlp")
+class MultiLayerMLP(MLP):
+    @dataclass
+    class Config(MLP.Config):
+        type: str = "multilayer_mlp"
+        in_dim: int = 756
+        hidden_size: int = 1536
+        num_layers: int = 1
+
+    def __init__(self, config: Config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        with open_dict(config):
+            hidden_size = config.hidden_size
+            config.hidden_size = config.in_dim
+            self.pooler = self.get_pooler(config.pooler_name)(config)
+            config.hidden_size = hidden_size
+
+        num_layers = self.config.get("num_layers", 1)
+        in_dim = self.config.in_dim
+        assert num_layers >= 0
+        layers = []
+        for _ in range(num_layers):
+            layers.append(nn.Dropout(self.config.hidden_dropout_prob))
+            layers.append(PredictionHeadTransformWithInDim(self.config))
+            with open_dict(self.config):
+                self.config.in_dim = self.config.hidden_size
+
+        self.classifier = nn.Sequential(
+            *layers, nn.Linear(self.config.in_dim, self.config.num_labels)
+        )
+        self.in_dim = in_dim
+
+    def forward(
+        self,
+        sequence_output: torch.Tensor,
+        encoded_layers: Optional[List[torch.Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, torch.Tensor]]] = None,
+    ):
+        assert (
+            sequence_output.size()[-1] == self.in_dim
+        ), "Mismatch between Multilayer MLP head in_dim and sequence_output last dim."
+        output_dict = {}
+        pooled_output = self.pooler(sequence_output)
+        prediction = self.classifier(pooled_output)
+        output_dict["scores"] = prediction.view(-1, self.num_labels)
+        return output_dict

--- a/mmf/models/vilt.py
+++ b/mmf/models/vilt.py
@@ -1,0 +1,121 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import collections
+import logging
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.base_model import BaseModel
+from mmf.modules.losses import MMFLoss
+from mmf.utils.build import build_encoder
+from mmf.utils.modeling import get_bert_configured_parameters
+from torch import nn
+
+
+logger = logging.getLogger()
+
+
+@registry.register_model("vilt")
+class ViLT(BaseModel):
+    @classmethod
+    def config_path(cls):
+        return "configs/models/vilt/defaults.yaml"
+
+    def build(self):
+        self.text_embeddings = build_encoder(self.config.text_embeddings)
+        self.image_embeddings = build_encoder(self.config.image_embeddings)
+        self.encoder = build_encoder(self.config.image_encoder)
+
+        # TODO: Add more classifiers later.
+        self.heads = nn.ModuleDict()
+        head_configs = self.config.get("heads", {})
+
+        self.tasks = self.config.tasks
+        if isinstance(self.tasks, str):
+            self.tasks = self.tasks.split(",")
+
+        for task in self.tasks:
+            head_config = head_configs[task]
+            head_type = head_config.get("type", "mlp")
+            head_class = registry.get_transformer_head_class(head_type)
+            self.heads[task] = head_class(head_config)
+
+    def init_losses(self):
+        self.losses = nn.ModuleDict()
+        loss_configs = self.config.get("losses", {})
+        for task in self.tasks:
+            if task not in loss_configs:
+                logger.warning(
+                    f"No loss defined for {task}. Head is expected "
+                    + "to return dict with 'losses'"
+                )
+                continue
+            loss_config = loss_configs[task]
+            self.losses[task] = MMFLoss(loss_config)
+
+    def forward(self, sample_list):
+        text_embedding = self.text_embeddings(sample_list)
+        image_embedding = self.image_embeddings(sample_list)
+
+        # Feed through encoder
+        embeddings = torch.cat([image_embedding, text_embedding], dim=1)
+        attention_mask = self.get_attention_mask(
+            sample_list, text_embedding, image_embedding
+        )
+        sequence, _ = self.encoder(embeddings, attention_mask=attention_mask)
+        if sequence.dim() != 3:
+            sequence = sequence.unsqueeze(1)
+
+        outputs = self.heads[sample_list.dataset_name](
+            sequence, processed_sample_list=sample_list
+        )
+
+        if isinstance(outputs, collections.MutableMapping) and "losses" in outputs:
+            return outputs
+
+        logits = outputs
+        if isinstance(outputs, collections.MutableMapping) and "scores" in outputs:
+            logits = outputs["scores"]
+        logits = logits.contiguous().view(-1, logits.size(-1))
+        output = self.losses[sample_list.dataset_name](sample_list, {"scores": logits})
+        return {"losses": output, "scores": logits}
+
+    def get_optimizer_parameters(self, config):
+        if hasattr(self.encoder, "get_optimizer_parameters"):
+            params = self.encoder.get_optimizer_parameters(config)
+        else:
+            params = [{"params": self.encoder.parameters()}]
+        params += get_bert_configured_parameters(self.text_embeddings)
+        params += get_bert_configured_parameters(self.heads)
+        params += [{"params": self.image_embeddings.parameters()}]
+        return params
+
+    def get_attention_mask(self, sample_list, text_embedding, image_embedding):
+        image_mask = getattr(sample_list, "image_mask", None)
+
+        if image_mask is not None and sample_list.input_mask is not None:
+            attention_mask = torch.cat((sample_list.input_mask, image_mask), dim=-1)
+        elif image_mask is not None:
+            text_mask = torch.ones(
+                text_embedding.size()[:-1],
+                dtype=text_embedding.dtype,
+                device=text_embedding.device,
+            )
+            attention_mask = torch.cat((image_mask, text_mask), dim=-1)
+        elif sample_list.input_mask is not None:
+            image_mask = torch.ones(
+                image_embedding.size()[:-1],
+                dtype=image_embedding.dtype,
+                device=image_embedding.device,
+            )
+            attention_mask = torch.cat((image_mask, sample_list.input_mask), dim=-1)
+        else:
+            attention_mask = None
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.masked_fill(
+                ~attention_mask.bool(), float("-inf")
+            )
+            attention_mask = attention_mask[:, None, None, :]
+
+        return attention_mask

--- a/mmf/modules/vit.py
+++ b/mmf/modules/vit.py
@@ -1,0 +1,290 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import torch
+import transformers.models.vit.modeling_vit as vit
+from torch import nn
+from transformers.modeling_bert import BertSelfAttention
+
+
+CKPT_MAPPING = {
+    "megavlt/vit_text_mm_tmlm": "/checkpoint/asg/pretrained_checkpoints/megavlt/vit_text_mm_tmlm.pth",  # noqa
+    "megavlt/vit_text_tmlm": "/checkpoint/asg/pretrained_checkpoints/megavlt/vit_text_tmlm.pth",  # noqa
+}
+
+
+class ViTConfig(vit.ViTConfig):
+    @classmethod
+    def from_pretrained(cls, pretrained_key, *args, **kwargs):
+        if "megavlt/" in pretrained_key:
+            ckpt = torch.load(CKPT_MAPPING[pretrained_key], map_location="cpu")
+            pretrained_key = ckpt["pretrained_model_name"]
+
+        return super().from_pretrained(pretrained_key, *args, **kwargs)
+
+
+class ViTAttention(vit.ViTAttention):
+    def __init__(self, config):
+        super().__init__(config)
+        self.attention = BertSelfAttention(config)
+        self.pruned_heads = set()
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        output_attentions=False,
+    ):
+        self_outputs = self.attention(
+            hidden_states,
+            attention_mask=attention_mask,
+            head_mask=head_mask,
+            output_attentions=output_attentions,
+        )
+
+        attention_output = self.output(self_outputs[0], hidden_states)
+
+        outputs = (attention_output,) + self_outputs[
+            1:
+        ]  # add attentions if we output them
+        return outputs
+
+
+class ViTLayer(nn.Module):
+    """This corresponds to the Block class in the timm implementation."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.chunk_size_feed_forward = config.chunk_size_feed_forward
+        self.seq_len_dim = 1
+        self.attention = ViTAttention(config)
+        self.intermediate = vit.ViTIntermediate(config)
+        self.output = vit.ViTOutput(config)
+        self.layernorm_before = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+        self.layernorm_after = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        output_attentions=False,
+    ):
+        self_attention_outputs = self.attention(
+            self.layernorm_before(
+                hidden_states
+            ),  # in ViT, layernorm is applied before self-attention
+            attention_mask=attention_mask,
+            head_mask=head_mask,
+            output_attentions=output_attentions,
+        )
+        attention_output = self_attention_outputs[0]
+        outputs = self_attention_outputs[
+            1:
+        ]  # add self attentions if we output attention weights
+
+        # first residual connection
+        hidden_states = attention_output + hidden_states
+
+        # in ViT, layernorm is also applied after self-attention
+        layer_output = self.layernorm_after(hidden_states)
+
+        # TODO feedforward chunking not working for now
+        # layer_output = apply_chunking_to_forward(
+        #     self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim,
+        #     layer_output
+        # )
+
+        layer_output = self.intermediate(layer_output)
+
+        # second residual connection is done here
+        layer_output = self.output(layer_output, hidden_states)
+
+        outputs = (layer_output,) + outputs
+
+        return outputs
+
+    def feed_forward_chunk(self, attention_output):
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output)
+        return layer_output
+
+
+class ViTEncoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.layer = nn.ModuleList(
+            [ViTLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        output_attentions=False,
+        output_hidden_states=False,
+        return_dict=True,
+    ):
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attentions = () if output_attentions else None
+
+        for i, layer_module in enumerate(self.layer):
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            layer_head_mask = head_mask[i] if head_mask is not None else None
+
+            if getattr(self.config, "gradient_checkpointing", False) and self.training:
+
+                def create_custom_forward(module):
+                    def custom_forward(*inputs):
+                        return module(*inputs, output_attentions)
+
+                    return custom_forward
+
+                layer_outputs = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(layer_module),
+                    hidden_states,
+                    attention_mask,
+                    layer_head_mask,
+                )
+            else:
+                layer_outputs = layer_module(
+                    hidden_states, attention_mask, layer_head_mask, output_attentions
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_self_attentions = all_self_attentions + (layer_outputs[1],)
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [hidden_states, all_hidden_states, all_self_attentions]
+                if v is not None
+            )
+        return vit.BaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attentions,
+        )
+
+
+class ViTModel(vit.ViTPreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.config = config
+
+        self.embeddings = vit.ViTEmbeddings(config)
+        self.encoder = ViTEncoder(config)
+
+        self.layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        add_pooling_layer = getattr(config, "add_pooling_layer", True)
+        self.pooler = vit.ViTPooler(config) if add_pooling_layer else None
+
+        self.init_weights()
+
+    def get_input_embeddings(self):
+        return self.embeddings.patch_embeddings
+
+    def _prune_heads(self, heads_to_prune):
+        """
+        Prunes heads of the model. heads_to_prune: dict of {layer_num: list of heads
+        to prune in this layer} See base class PreTrainedModel
+        """
+        for layer, heads in heads_to_prune.items():
+            self.encoder.layer[layer].attention.prune_heads(heads)
+
+    def forward(
+        self,
+        input_values=None,
+        attention_mask=None,
+        head_mask=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+        r"""
+        Returns:
+
+        Examples::
+
+            >>> from transformers import ViTFeatureExtractor, ViTModel
+            >>> from PIL import Image
+            >>> import requests
+
+            >>> url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
+            >>> image = Image.open(requests.get(url, stream=True).raw)
+
+            >>> feature_extractor = ViTFeatureExtractor.from_pretrained(
+                    'google/vit-base-patch16-224-in21k'
+                )
+            >>> model = ViTModel.from_pretrained('google/vit-base-patch16-224-in21k')
+
+            >>> inputs = feature_extractor(images=image, return_tensors="pt")
+            >>> outputs = model(**inputs)
+            >>> last_hidden_states = outputs.last_hidden_state
+        """
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if input_values is None:
+            raise ValueError("You have to specify pixel_values")
+
+        # Prepare head mask if needed
+        # 1.0 in head_mask indicate we keep the head
+        # attention_probs has shape bsz x n_heads x N x N
+        # input head_mask has shape [num_heads] or [num_hidden_layers x num_heads]
+        # and head_mask is converted to shape
+        # [num_hidden_layers x batch x num_heads x seq_length x seq_length]
+        head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
+
+        do_patch_embeddings = getattr(self.config, "do_patch_embeddings", True)
+        embedding_output = (
+            self.embeddings(input_values) if do_patch_embeddings else input_values
+        )
+
+        encoder_outputs = self.encoder(
+            embedding_output,
+            attention_mask=attention_mask,
+            head_mask=head_mask,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        sequence_output = encoder_outputs[0]
+        sequence_output = self.layernorm(sequence_output)
+        pooled_output = (
+            self.pooler(sequence_output) if self.pooler is not None else None
+        )
+
+        if not return_dict:
+            return (sequence_output, pooled_output) + encoder_outputs[1:]
+
+        return vit.BaseModelOutputWithPooling(
+            last_hidden_state=sequence_output,
+            pooler_output=pooled_output,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
+        )

--- a/projects/vilt/configs/vqa2/384_imgs.yaml
+++ b/projects/vilt/configs/vqa2/384_imgs.yaml
@@ -1,0 +1,121 @@
+includes:
+- ../projects/unit/configs/vqa2_dataset_cfg.yaml
+
+other_configs:
+  image_w: 384
+  image_h: 384
+dataset_config:
+  vqa2:
+    processors:
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: Resize
+              params:
+                size:
+                - ${other_configs.image_w}
+                - ${other_configs.image_h}
+            - ToTensor
+            - GrayScaleTo3Channels
+            - type: Normalize
+              params:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.229, 0.224, 0.225]
+
+model_config:
+  vilt:
+    tasks: ${datasets}
+    heads:
+      vissl_image:
+        type: mlp
+        num_labels: 1000
+      vqa2:
+        type: multilayer_mlp
+        num_labels: 3129
+      glue_mnli_mismatched:
+        type: mlp
+        num_labels: 3
+      everstore:
+        type: mlp
+        num_labels: 2
+
+    losses:
+      vissl_image: cross_entropy
+      vqa2: logit_bce
+      glue_mnli_mismatched: cross_entropy
+      everstore: cross_entropy
+
+    image_encoder:
+      type: vit
+      params:
+        pretrained_model_name: google/vit-base-patch16-384
+        gradient_checkpointing: false
+        do_pooling: false
+        hidden_dropout_prob: 0
+        add_pooling_layer: False
+        do_patch_embeddings: False
+
+        regularize_bn: False
+        regularize_bias: True
+        hidden_dim: 768
+        pretrained_model: vit_base_patch16_384
+        mlp_dim: 3072
+
+    image_embeddings:
+      type: vilt_img_embedding
+      params:
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        hidden_dropout_prob: 0
+        hidden_dim: 768
+        hidden_size: 768
+        patch_size: 16
+        num_channels: 3
+        random_init: True
+        image_encoder: ${model_config.image_encoder}
+
+    text_embeddings:
+      type: vilt_text_embedding
+      params:
+        bert_model_name: bert-base-uncased
+        hidden_dim: 768
+        hidden_size: 768
+
+
+training:
+  clip_gradients: false
+  lr_scheduler: true
+  max_updates: 44000
+  checkpoint_interval: 4000
+  evaluation_interval: 4000
+  batch_size: 256 # 32 per GPU * 8 GPU
+  find_unused_parameters: false
+
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 4000
+    num_training_steps: ${training.max_updates}
+
+
+evaluation:
+  metrics:
+    - type: accuracy
+      datasets:
+      - vissl_image
+      - glue_mnli_mismatched
+      - everstore
+    - type: vqa_accuracy
+      datasets:
+      - vqa2

--- a/projects/vilt/configs/vqa2/512_imgs.yaml
+++ b/projects/vilt/configs/vqa2/512_imgs.yaml
@@ -1,0 +1,128 @@
+includes:
+- ../projects/unit/configs/vqa2_dataset_cfg.yaml
+
+other_configs:
+  image_w: 512
+  image_h: 512
+dataset_config:
+  vqa2:
+    processors:
+      image_processor:
+        type: torchvision_transforms
+        params:
+          transforms:
+            - type: Resize
+              params:
+                size:
+                - ${other_configs.image_w}
+                - ${other_configs.image_h}
+            - ToTensor
+            - GrayScaleTo3Channels
+            - type: Normalize
+              params:
+                mean: [0.485, 0.456, 0.406]
+                std: [0.229, 0.224, 0.225]
+
+model_config:
+  vilt:
+    tasks: ${datasets}
+    heads:
+      vissl_image:
+        type: mlp
+        num_labels: 1000
+      vqa2:
+        type: multilayer_mlp
+        num_labels: 3129
+      glue_mnli_mismatched:
+        type: mlp
+        num_labels: 3
+      everstore:
+        type: mlp
+        num_labels: 2
+
+    losses:
+      vissl_image: cross_entropy
+      vqa2: logit_bce
+      glue_mnli_mismatched: cross_entropy
+      everstore: cross_entropy
+
+    image_encoder:
+      type: vit
+      params:
+        pretrained_model_name: google/vit-base-patch16-224
+        gradient_checkpointing: false
+        do_pooling: false
+        hidden_dropout_prob: 0
+        add_pooling_layer: False
+        do_patch_embeddings: False
+        random_init: False
+        image_size:
+        - 224
+        - 224
+        patch_size: 16
+        num_channels: 3
+
+        regularize_bn: False
+        regularize_bias: True
+        hidden_dim: 768
+        pretrained_model: vit_base_patch16_224
+        vision_transformer:
+        mlp_dim: 3072
+
+    image_embeddings:
+      type: vilt_img_embedding
+      params:
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        hidden_dropout_prob: 0
+        hidden_dim: 768
+        hidden_size: 768
+        patch_size: 16
+        num_channels: 3
+        random_init: True
+        image_encoder: ${model_config.image_encoder}
+
+    text_embeddings:
+      type: vilt_text_embedding
+      params:
+        bert_model_name: bert-base-uncased
+        hidden_dim: 768
+        hidden_size: 768
+
+
+training:
+  clip_gradients: false
+  lr_scheduler: true
+  max_updates: 44000
+  checkpoint_interval: 4000
+  evaluation_interval: 4000
+  batch_size: 256 # 32 per GPU * 8 GPU
+  find_unused_parameters: false
+
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 4000
+    num_training_steps: ${training.max_updates}
+
+
+evaluation:
+  metrics:
+    - type: accuracy
+      datasets:
+      - vissl_image
+      - glue_mnli_mismatched
+      - everstore
+    - type: vqa_accuracy
+      datasets:
+      - vqa2

--- a/projects/vilt/configs/vqa2/defaults.yaml
+++ b/projects/vilt/configs/vqa2/defaults.yaml
@@ -1,0 +1,120 @@
+includes:
+- ../projects/unit/configs/vqa2_dataset_cfg.yaml
+
+other_configs:
+  image_w: 224
+  image_h: 224
+dataset_config:
+  vqa2:
+    processors:
+      image_processor:
+        type: vilt_image_processor
+        params:
+          size:
+          - ${other_configs.image_w}
+          - ${other_configs.image_h}
+      text_processor:
+        type: vilt_text_processor
+        params:
+          mask_probability: 0
+          max_seq_length: 25
+
+model_config:
+  vilt:
+    tasks: ${datasets}
+    heads:
+      vissl_image:
+        type: mlp
+        num_labels: 1000
+      vqa2:
+        type: multilayer_mlp
+        num_labels: 3129
+      glue_mnli_mismatched:
+        type: mlp
+        num_labels: 3
+      everstore:
+        type: mlp
+        num_labels: 2
+
+    losses:
+      vissl_image: cross_entropy
+      vqa2: logit_bce
+      glue_mnli_mismatched: cross_entropy
+      everstore: cross_entropy
+
+    image_encoder:
+      type: vit
+      params:
+        random_init: True
+        pretrained_model_name: google/vit-base-patch16-224
+        gradient_checkpointing: false
+        do_pooling: false
+        hidden_dropout_prob: 0
+        add_pooling_layer: False
+        do_patch_embeddings: False
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        regularize_bn: False
+        regularize_bias: True
+        hidden_dim: 768
+        pretrained_model: vit_base_patch16_224
+        mlp_dim: 3072
+
+    image_embeddings:
+      type: vilt_img_embedding
+      params:
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        hidden_dropout_prob: 0
+        hidden_dim: 768
+        hidden_size: 768
+        patch_size: 16
+        num_channels: 3
+        random_init: True
+        image_encoder: ${model_config.vilt.image_encoder}
+
+    text_embeddings:
+      type: vilt_text_embedding
+      params:
+        bert_model_name: bert-base-uncased
+        hidden_dim: 768
+        hidden_size: 768
+
+
+training:
+  clip_gradients: false
+  lr_scheduler: true
+  max_updates: 44000
+  checkpoint_interval: 4000
+  evaluation_interval: 4000
+  batch_size: 256 # 32 per GPU * 8 GPU
+  find_unused_parameters: false
+
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 4000
+    num_training_steps: ${training.max_updates}
+
+
+evaluation:
+  metrics:
+    - type: accuracy
+      datasets:
+      - vissl_image
+      - glue_mnli_mismatched
+      - everstore
+    - type: vqa_accuracy
+      datasets:
+      - vqa2

--- a/projects/vilt/configs/vqa2/pretrained.yaml
+++ b/projects/vilt/configs/vqa2/pretrained.yaml
@@ -1,0 +1,120 @@
+includes:
+- ../projects/unit/configs/vqa2_dataset_cfg.yaml
+
+other_configs:
+  image_w: 224
+  image_h: 224
+dataset_config:
+  vqa2:
+    processors:
+      image_processor:
+        type: vilt_image_processor
+        params:
+          size:
+          - ${other_configs.image_w}
+          - ${other_configs.image_h}
+      text_processor:
+        type: vilt_text_processor
+        params:
+          mask_probability: 0
+          max_seq_length: 25
+
+model_config:
+  vilt:
+    tasks: ${datasets}
+    heads:
+      vissl_image:
+        type: mlp
+        num_labels: 1000
+      vqa2:
+        type: multilayer_mlp
+        num_labels: 3129
+      glue_mnli_mismatched:
+        type: mlp
+        num_labels: 3
+      everstore:
+        type: mlp
+        num_labels: 2
+
+    losses:
+      vissl_image: cross_entropy
+      vqa2: logit_bce
+      glue_mnli_mismatched: cross_entropy
+      everstore: cross_entropy
+
+    image_encoder:
+      type: vit
+      params:
+        random_init: False
+        pretrained_model_name: google/vit-base-patch16-224
+        gradient_checkpointing: false
+        do_pooling: false
+        hidden_dropout_prob: 0
+        add_pooling_layer: False
+        do_patch_embeddings: False
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        regularize_bn: False
+        regularize_bias: True
+        hidden_dim: 768
+        pretrained_model: vit_base_patch16_224
+        mlp_dim: 3072
+
+    image_embeddings:
+      type: vilt_img_embedding
+      params:
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        hidden_dropout_prob: 0
+        hidden_dim: 768
+        hidden_size: 768
+        patch_size: 16
+        num_channels: 3
+        random_init: False
+        image_encoder: ${model_config.vilt.image_encoder}
+
+    text_embeddings:
+      type: vilt_text_embedding
+      params:
+        bert_model_name: bert-base-uncased
+        hidden_dim: 768
+        hidden_size: 768
+
+
+training:
+  clip_gradients: false
+  lr_scheduler: true
+  max_updates: 44000
+  checkpoint_interval: 4000
+  evaluation_interval: 4000
+  batch_size: 256 # 32 per GPU * 8 GPU
+  find_unused_parameters: false
+
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 4000
+    num_training_steps: ${training.max_updates}
+
+
+evaluation:
+  metrics:
+    - type: accuracy
+      datasets:
+      - vissl_image
+      - glue_mnli_mismatched
+      - everstore
+    - type: vqa_accuracy
+      datasets:
+      - vqa2

--- a/projects/vilt/configs/vqa2/pretrained_32.yaml
+++ b/projects/vilt/configs/vqa2/pretrained_32.yaml
@@ -1,0 +1,120 @@
+includes:
+- ../projects/unit/configs/vqa2_dataset_cfg.yaml
+
+other_configs:
+  image_w: 224
+  image_h: 224
+dataset_config:
+  vqa2:
+    processors:
+      image_processor:
+        type: vilt_image_processor
+        params:
+          size:
+          - ${other_configs.image_w}
+          - ${other_configs.image_h}
+      text_processor:
+        type: vilt_text_processor
+        params:
+          mask_probability: 0
+          max_seq_length: 25
+
+model_config:
+  vilt:
+    tasks: ${datasets}
+    heads:
+      vissl_image:
+        type: mlp
+        num_labels: 1000
+      vqa2:
+        type: multilayer_mlp
+        num_labels: 3129
+      glue_mnli_mismatched:
+        type: mlp
+        num_labels: 3
+      everstore:
+        type: mlp
+        num_labels: 2
+
+    losses:
+      vissl_image: cross_entropy
+      vqa2: logit_bce
+      glue_mnli_mismatched: cross_entropy
+      everstore: cross_entropy
+
+    image_encoder:
+      type: vit
+      params:
+        random_init: False
+        pretrained_model_name: google/vit-base-patch32-224-in21k
+        gradient_checkpointing: false
+        do_pooling: false
+        hidden_dropout_prob: 0
+        add_pooling_layer: False
+        do_patch_embeddings: False
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        regularize_bn: False
+        regularize_bias: True
+        hidden_dim: 768
+        pretrained_model: vit_base_patch32_224_in21k
+        mlp_dim: 3072
+
+    image_embeddings:
+      type: vilt_img_embedding
+      params:
+        image_size:
+        - ${other_configs.image_w}
+        - ${other_configs.image_h}
+        hidden_dropout_prob: 0
+        hidden_dim: 768
+        hidden_size: 768
+        patch_size: 32
+        num_channels: 3
+        random_init: False
+        image_encoder: ${model_config.vilt.image_encoder}
+
+    text_embeddings:
+      type: vilt_text_embedding
+      params:
+        bert_model_name: bert-base-uncased
+        hidden_dim: 768
+        hidden_size: 768
+
+
+training:
+  clip_gradients: false
+  lr_scheduler: true
+  max_updates: 44000
+  checkpoint_interval: 4000
+  evaluation_interval: 4000
+  batch_size: 256 # 32 per GPU * 8 GPU
+  find_unused_parameters: false
+
+
+optimizer:
+  type: adam_w_skip_params_with_zero_grad
+  params:
+    lr: 5e-5
+    eps: 1e-8
+    weight_decay: 1e-4
+
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 4000
+    num_training_steps: ${training.max_updates}
+
+
+evaluation:
+  metrics:
+    - type: accuracy
+      datasets:
+      - vissl_image
+      - glue_mnli_mismatched
+      - everstore
+    - type: vqa_accuracy
+      datasets:
+      - vqa2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.23.0
 fasttext==0.9.1
 nltk==3.4.5
 editdistance==0.5.3
-transformers==3.4.0
+transformers==4.5.1
 sklearn==0.0
 omegaconf>=2.0.6, <=2.1
 lmdb==0.98

--- a/tests/models/test_vilt.py
+++ b/tests/models/test_vilt.py
@@ -1,0 +1,65 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import gc
+import unittest
+
+import tests.test_utils as test_utils
+import torch
+from mmf.common.sample import SampleList
+from mmf.modules.hf_layers import replace_with_jit
+from mmf.utils.build import build_model
+from mmf.utils.configuration import Configuration
+from mmf.utils.env import setup_imports, teardown_imports
+from mmf.utils.general import get_current_device
+
+
+BERT_VOCAB_SIZE = 30255
+
+
+class TestViltPretraining(unittest.TestCase):
+    def setUp(self):
+        test_utils.setup_proxy()
+        setup_imports()
+        replace_with_jit()
+        model_name = "vilt"
+        args = test_utils.dummy_args(
+            model=model_name,
+            dataset="vqa2",
+            config="projects/vilt/configs/vqa2/defaults.yaml",
+        )
+        configuration = Configuration(args)
+        config = configuration.get_config()
+        model_config = config.model_config[model_name]
+        model_config.model = model_name
+        self.pretrain_model = build_model(model_config)
+
+    def tearDown(self):
+        teardown_imports()
+        del self.pretrain_model
+        gc.collect()
+
+    def test_pretrained_model(self):
+        sample_list = SampleList()
+
+        sample_list.add_field(
+            "input_ids",
+            torch.randint(low=0, high=BERT_VOCAB_SIZE, size=(1, 128)).long(),
+        )
+        sample_list.add_field("input_mask", torch.ones((1, 128)).long())
+        sample_list.add_field("segment_ids", torch.zeros(1, 128).long())
+        sample_list.add_field("image", torch.rand((1, 3, 224, 224)).float())
+        sample_list.add_field("targets", torch.rand((1, 3129)).float())
+
+        # self.pretrain_model.eval()
+        self.pretrain_model.training = True
+        self.pretrain_model = self.pretrain_model.to(get_current_device())
+        sample_list = sample_list.to(get_current_device())
+
+        sample_list.dataset_name = "vqa2"
+        sample_list.dataset_type = "test"
+        with torch.no_grad():
+            model_output = self.pretrain_model(sample_list)
+
+        print(model_output)
+        self.assertTrue("losses" in model_output)
+        self.assertTrue("test/vqa2/logit_bce" in model_output["losses"])


### PR DESCRIPTION
Summary:
Work in progress
Add ViLT model to mmf from megaVLT,
using ViT from huggingface.

With pretrained ViT, mmf run on vqa2 gives on 224x224 images gives,

```
2021-09-15T06:42:41 | mmf.trainers.core.evaluation_loop: Finished training. Loaded 103
2021-09-15T06:42:41 | mmf.trainers.core.evaluation_loop:  -- skipped 0 batches.
2021-09-15T06:42:42 | mmf.trainers.callbacks.logistics: progress: 28000/44000, val/vqa2/logit_bce: 4.0725, val/total_loss: 4.0725, val/vqa2/vqa_accuracy: 0.5970
```
