### PR TITLE
[feat] Add ViLT image and text embeddings

### DIFF
--- a/mmf/modules/encoders.py
+++ b/mmf/modules/encoders.py
@@ -4,12 +4,13 @@ import pickle
 import re
 from collections import OrderedDict
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
 import torch
 import torchvision
+import transformers.models.vit.modeling_vit as vit
 from mmf.common.registry import registry
 from mmf.models.frcnn import GeneralizedRCNN
 from mmf.modules.embeddings import ProjectionEmbedding, TextEmbedding
@@ -18,7 +19,7 @@ from mmf.modules.layers import Identity
 from mmf.utils.build import build_image_encoder, build_text_encoder
 from mmf.utils.download import download_pretrained_model
 from mmf.utils.file_io import PathManager
-from mmf.utils.general import get_absolute_path
+from mmf.utils.general import get_absolute_path, retry_n
 from mmf.utils.logger import log_class_usage
 from omegaconf import MISSING, OmegaConf
 from torch import Tensor, nn
@@ -729,3 +730,142 @@ class ResNet18AudioEncoder(PooledEncoder):
         model.conv1 = nn.Conv2d(1, 64, kernel_size=7, stride=2, padding=3, bias=False)
         modules = list(model.children())[:-2]
         return nn.Sequential(*modules)
+
+
+@registry.register_encoder("vit")
+class ViTEncoder(Encoder):
+    @dataclass
+    class Config(Encoder.Config):
+        name: str = "vit"
+        # See https://huggingface.co/models?filter=vit for available options
+        pretrained_model_name: str = "google/vit-base-patch16-224"
+        random_init: bool = False
+        gradient_checkpointing: bool = False
+
+    def __init__(self, config: Config, *args, **kwargs):
+        from ..modules.vit import ViTConfig
+
+        super().__init__()
+        self.config = config
+        random_init = self.config.get("random_init", False)
+        gradient_checkpointing = self.config.get("gradient_checkpointing", False)
+
+        hf_config = retry_n(
+            6,
+            ViTConfig.from_pretrained,
+            self.config.pretrained_model_name,
+            **OmegaConf.to_container(config),
+        )
+        hf_config.gradient_checkpointing = gradient_checkpointing
+        hf_config.add_pooling_layer = config.get("add_pooling_layer", True)
+        hf_config.do_patch_embeddings = config.get("do_patch_embeddings", True)
+        hf_config.image_size = config.get("image_size", hf_config.image_size)
+
+        if not random_init:
+            self.module = retry_n(
+                6,
+                self._model_class.from_pretrained,
+                self.config.pretrained_model_name,
+                config=hf_config,
+            )
+        else:
+            self.module = retry_n(6, self._model_class, hf_config)
+
+        self.embeddings = self.module.embeddings
+
+        self.original_config = self.config
+        self.config = hf_config
+        self.out_dim = hf_config.hidden_size
+
+    @property
+    def _model_class(self):
+        from ..modules.vit import ViTModel
+
+        return ViTModel
+
+    def forward(self, *args, **kwargs):
+        if "output_hidden_states" not in kwargs:
+            kwargs["output_hidden_states"] = True
+        output = self.module(*args, **kwargs)
+        return output["last_hidden_state"], output["hidden_states"]
+
+
+@registry.register_encoder("vilt_img_embedding")
+class VILTImageEmbedding(Encoder):
+    """
+    Patch embedding used for ViLT.
+    https://arxiv.org/pdf/2102.03334.pdf
+    Implementation based off
+    https://github.com/dandelin/ViLT/blob/master/vilt/modules/vilt_module.py
+    Using huggingface ViT modules.
+    Can be built with random init or the embeddings weights from an exisiting
+    ViT model from huggingface. Model list: availible at
+    https://huggingface.co/models?other=vit&sort=downloads
+    """
+
+    @dataclass
+    class Config(Encoder.Config):
+        image_size: list = field(default_factory=[224, 224])
+        hidden_dropout_prob: float = 0
+        hidden_dim: int = 768
+        hidden_size: int = 768
+        patch_size: int = 16
+        num_channels: int = 3
+        random_init: bool = True
+
+    def __init__(self, config: Config):
+        super().__init__()
+        self.config = config
+        if getattr(config, "random_init", False) and hasattr(
+            config, "pretrained_model_name"
+        ):
+            self.embedding = ViTEncoder(self.config.image_encoder.params).embeddings
+        else:
+            self.embedding = vit.ViTEmbeddings(config)
+
+        self.token_type_embeddings = nn.Embedding(1, config.hidden_size)
+
+    def forward(self, sample_list):
+        image = sample_list["image"]
+        if image.dim() == 5:
+            # manual collation for SimCLR inputs (when VISSL collator is not used)
+            # make num_view the 1st dimension to be consistent with VISSL SimCLR
+            image = image.permute(1, 0, 2, 3, 4).flatten(start_dim=0, end_dim=1)
+
+        img_embeddings = self.embedding(image)
+
+        img_segment_ids = torch.zeros(
+            img_embeddings.size()[:-1],
+            dtype=img_embeddings.dtype,
+            device=img_embeddings.device,
+        ).long()
+        img_type_embed = self.token_type_embeddings(img_segment_ids)
+        img_embeddings = img_embeddings + img_type_embed
+        return img_embeddings
+
+
+@registry.register_encoder("vilt_text_embedding")
+class VILTTextEmbedding(Encoder):
+    @dataclass
+    class Config(Encoder.Config):
+        hidden_dim: int = 768
+        hidden_size: int = 768
+
+    def __init__(self, config: Config):
+
+        super().__init__()
+        self.config = config
+        text_encoder = TransformerEncoder(self.config)
+        self.text_embeddings = text_encoder.embeddings
+        encoder_output_dim = self.config.hidden_dim
+        self.text_projection = nn.Linear(
+            text_encoder.config.hidden_size, encoder_output_dim
+        )
+
+    def forward(self, sample_list):
+        input_ids = sample_list.input_ids
+        segment_ids = sample_list.segment_ids
+
+        text_embedding = self.text_embeddings(input_ids, token_type_ids=segment_ids)
+        text_embedding = self.text_projection(text_embedding)
+        return text_embedding

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.23.0
 fasttext==0.9.1
 nltk==3.4.5
 editdistance==0.5.3
-transformers==3.4.0
+transformers==4.5.1
 sklearn==0.0
 omegaconf>=2.0.6, <=2.1
 lmdb==0.98


### PR DESCRIPTION
Add ViT image and Bert text embedding encoders for ViLT model. 
Embedding encoders are processors for image and text data taking as input sample_lists.
Outputs are concatenated and fed to the ViLT trunk.

Add ViTEncoder with runtime import dependency added in future diff.
Used in future ViLT model diff.

Bump version of transformers to 4.5.1 to enable vit module.

Diff # 2