### PR TITLE
[chore] Bump transformers version to 4.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.23.0
 fasttext==0.9.1
 nltk==3.4.5
 editdistance==0.5.3
-transformers==3.4.0
+transformers==4.5.1
 sklearn==0.0
 omegaconf>=2.0.6, <=2.1
 lmdb==0.98


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Bumping transformers version for ViT module.