### PR TITLE
[fix] Undo replace_with_jit in unit tests

### DIFF
--- a/mmf/modules/hf_layers.py
+++ b/mmf/modules/hf_layers.py
@@ -26,10 +26,62 @@ from transformers.modeling_roberta import (
 from transformers.modeling_utils import PreTrainedModel
 
 
+original_functions = {}
+
+
 def replace_with_jit():
     """
     Monkey patch some transformer functions to replace with scriptable ones.
     """
+    # to revert monkey patch without reload()
+    original_functions["BertEmbeddings.forward"] = original_functions.get(
+        "BertEmbeddings.forward", BertEmbeddings.forward
+    )
+    original_functions["BertEncoder.forward"] = original_functions.get(
+        "BertEncoder.forward", BertEncoder.forward
+    )
+    original_functions["BertLayer.forward"] = original_functions.get(
+        "BertLayer.forward", BertLayer.forward
+    )
+    original_functions["BertAttention.forward"] = original_functions.get(
+        "BertAttention.forward", BertAttention.forward
+    )
+    original_functions["BertSelfAttention.forward"] = original_functions.get(
+        "BertSelfAttention.forward", BertSelfAttention.forward
+    )
+    original_functions[
+        "BertSelfAttention.transpose_for_scores"
+    ] = original_functions.get(
+        "BertSelfAttention.transpose_for_scores", BertSelfAttention.transpose_for_scores
+    )
+    original_functions["BertModel.forward"] = original_functions.get(
+        "BertModel.forward", BertModel.forward
+    )
+    original_functions["RobertaEmbeddings.forward"] = original_functions.get(
+        "RobertaEmbeddings.forward", RobertaEmbeddings.forward
+    )
+    original_functions["RobertaEncoder.forward"] = original_functions.get(
+        "RobertaEncoder.forward", RobertaEncoder.forward
+    )
+    original_functions["RobertaLayer.forward"] = original_functions.get(
+        "RobertaLayer.forward", RobertaLayer.forward
+    )
+    original_functions["RobertaAttention.forward"] = original_functions.get(
+        "RobertaAttention.forward", RobertaAttention.forward
+    )
+    original_functions["RobertaSelfAttention.forward"] = original_functions.get(
+        "RobertaSelfAttention.forward", RobertaSelfAttention.forward
+    )
+    original_functions[
+        "RobertaSelfAttention.transpose_for_scores"
+    ] = original_functions.get(
+        "RobertaSelfAttention.transpose_for_scores",
+        RobertaSelfAttention.transpose_for_scores,
+    )
+    original_functions["RobertaModel.forward"] = original_functions.get(
+        "RobertaModel.forward", RobertaModel.forward
+    )
+
     BertEmbeddings.forward = BertEmbeddingsJit.forward
     BertEncoder.forward = BertEncoderJit.forward
     BertLayer.forward = BertLayerJit.forward
@@ -52,6 +104,52 @@ def replace_with_jit():
         BertSelfAttentionJit.transpose_for_scores
     )
     RobertaModel.forward = BertModelJit.forward
+    print("replace")
+
+
+def undo_replace_with_jit():
+    """
+    Reload modules to undo monkey patch.
+    """
+    BertEmbeddings.forward = original_functions.get(
+        "BertEmbeddings.forward", BertEmbeddings.forward
+    )
+    BertEncoder.forward = original_functions.get(
+        "BertEncoder.forward", BertEncoder.forward
+    )
+    BertLayer.forward = original_functions.get("BertLayer.forward", BertLayer.forward)
+    BertAttention.forward = original_functions.get(
+        "BertAttention.forward", BertAttention.forward
+    )
+    BertSelfAttention.forward = original_functions.get(
+        "BertSelfAttention.forward", BertSelfAttention.forward
+    )
+    BertSelfAttention.transpose_for_scores = original_functions.get(
+        "BertSelfAttention.transpose_for_scores", BertSelfAttention.transpose_for_scores
+    )
+    BertModel.forward = original_functions.get("BertModel.forward", BertModel.forward)
+    RobertaEmbeddings.forward = original_functions.get(
+        "RobertaEmbeddings.forward", RobertaEmbeddings.forward
+    )
+    RobertaEncoder.forward = original_functions.get(
+        "RobertaEncoder.forward", RobertaEncoder.forward
+    )
+    RobertaLayer.forward = original_functions.get(
+        "RobertaLayer.forward", RobertaLayer.forward
+    )
+    RobertaAttention.forward = original_functions.get(
+        "RobertaAttention.forward", RobertaAttention.forward
+    )
+    RobertaSelfAttention.forward = original_functions.get(
+        "RobertaSelfAttention.forward", RobertaSelfAttention.forward
+    )
+    RobertaSelfAttention.transpose_for_scores = original_functions.get(
+        "RobertaSelfAttention.transpose_for_scores",
+        RobertaSelfAttention.transpose_for_scores,
+    )
+    RobertaModel.forward = original_functions.get(
+        "RobertaModel.forward", RobertaModel.forward
+    )
 
 
 class BertEmbeddingsJit(BertEmbeddings):

--- a/tests/models/interfaces/test_interfaces.py
+++ b/tests/models/interfaces/test_interfaces.py
@@ -10,6 +10,7 @@ import numpy as np
 import tests.test_utils as test_utils
 import torch
 from mmf.models.mmbt import MMBT
+from mmf.modules.hf_layers import undo_replace_with_jit
 from mmf.utils.configuration import get_mmf_env, load_yaml
 from mmf.utils.file_io import PathManager
 from mmf.utils.general import get_current_device
@@ -79,3 +80,6 @@ class TestModelInterfaces(unittest.TestCase):
         )
 
         return model_folder
+
+    def tearDown(self):
+        undo_replace_with_jit()

--- a/tests/models/test_mmbt.py
+++ b/tests/models/test_mmbt.py
@@ -14,6 +14,7 @@ from mmf.modules.encoders import (
     TextEncoderFactory,
     TextEncoderTypes,
 )
+from mmf.modules.hf_layers import undo_replace_with_jit
 from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports, teardown_imports
@@ -36,6 +37,7 @@ class TestMMBTTorchscript(unittest.TestCase):
 
     def tearDown(self):
         teardown_imports()
+        undo_replace_with_jit()
         del self.model_config
         gc.collect()
 
@@ -103,6 +105,7 @@ class TestMMBTTorchscript(unittest.TestCase):
 
 class TestMMBTConfig(unittest.TestCase):
     def tearDown(self):
+        undo_replace_with_jit()
         gc.collect()
 
     def test_mmbt_from_params(self):

--- a/tests/models/test_vilbert.py
+++ b/tests/models/test_vilbert.py
@@ -5,6 +5,7 @@ import unittest
 
 import tests.test_utils as test_utils
 import torch
+from mmf.modules.hf_layers import undo_replace_with_jit
 from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports, teardown_imports
@@ -37,6 +38,7 @@ class TestViLBertTorchscript(unittest.TestCase):
 
     def tearDown(self):
         teardown_imports()
+        undo_replace_with_jit()
         del self.model_config
         gc.collect()
 

--- a/tests/models/test_visual_bert.py
+++ b/tests/models/test_visual_bert.py
@@ -6,7 +6,7 @@ import unittest
 import tests.test_utils as test_utils
 import torch
 from mmf.common.sample import SampleList
-from mmf.modules.hf_layers import replace_with_jit
+from mmf.modules.hf_layers import replace_with_jit, undo_replace_with_jit
 from mmf.utils.build import build_model
 from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports, teardown_imports
@@ -33,6 +33,7 @@ class TestVisualBertTorchscript(unittest.TestCase):
 
     def tearDown(self):
         teardown_imports()
+        undo_replace_with_jit()
         del self.finetune_model
         gc.collect()
 
@@ -63,6 +64,7 @@ class TestVisualBertPretraining(unittest.TestCase):
 
     def tearDown(self):
         teardown_imports()
+        undo_replace_with_jit()
         del self.pretrain_model
         gc.collect()
 

--- a/tests/modules/test_optimizers.py
+++ b/tests/modules/test_optimizers.py
@@ -5,6 +5,7 @@ import unittest
 
 import torch
 from mmf.models.mmbt import MMBT
+from mmf.modules.hf_layers import undo_replace_with_jit
 from mmf.utils.build import build_optimizer
 from omegaconf import OmegaConf
 from tests.test_utils import SimpleModel, skip_if_no_network
@@ -18,6 +19,7 @@ class TestOptimizers(unittest.TestCase):
 
     def tearDown(self):
         del self.config
+        undo_replace_with_jit()
         gc.collect()
 
     def test_build_optimizer_simple_model(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Fix bug where monkey patch on transformers
leaked into other unit tests resulting in
ViLT unit tests passing in isolation but
failing due to unexpected signatures when run
with other tests.