### PR TITLE
Pooler functions of transformer encoder layers to support Refiner

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -48,6 +48,7 @@ class Registry:
         "model_name_mapping": {},
         "metric_name_mapping": {},
         "loss_name_mapping": {},
+        "pool_name_mapping": {},
         "fusion_name_mapping": {},
         "optimizer_name_mapping": {},
         "scheduler_name_mapping": {},
@@ -202,6 +203,35 @@ class Registry:
                 func, nn.Module
             ), "All loss must inherit torch.nn.Module class"
             cls.mapping["loss_name_mapping"][name] = func
+            return func
+
+        return wrap
+
+    @classmethod
+    def register_pooler(cls, name):
+        r"""Register a modality pooling method to registry with key 'name'
+
+        Args:
+            name: Key with which the pooling method will be registered.
+
+        Usage::
+
+            from mmf.common.registry import registry
+            from torch import nn
+
+            @registry.register_pool("average_pool")
+            class average_pool(nn.Module):
+                ...
+
+        """
+
+        def wrap(func):
+            from torch import nn
+
+            assert issubclass(
+                func, nn.Module
+            ), "All pooling methods must inherit torch.nn.Module class"
+            cls.mapping["pool_name_mapping"][name] = func
             return func
 
         return wrap
@@ -507,6 +537,10 @@ class Registry:
     @classmethod
     def get_loss_class(cls, name):
         return cls.mapping["loss_name_mapping"].get(name, None)
+
+    @classmethod
+    def get_pool_class(cls, name):
+        return cls.mapping["pool_name_mapping"].get(name, None)
 
     @classmethod
     def get_optimizer_class(cls, name):

--- a/mmf/modules/poolers.py
+++ b/mmf/modules/poolers.py
@@ -1,0 +1,91 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""
+This module contains implementations for various pooling methods from
+transformer encoder layers
+.. code::
+
+   from mmf.common.registry import registry
+   from torch import nn
+
+
+   @registry.register_pooler("custom")
+   class CustomPool(nn.Module):
+       ...
+"""
+from typing import List
+import torch
+import torch.nn as nn
+from mmf.common.registry import registry
+
+
+@registry.register_pooler("average_concat_last_k")
+class AverageConcatLastN(nn.Module):
+    def __init__(
+        self,
+        k=4,
+        tol=0.000001
+    ):
+        super().__init__()
+        self.num_layers = k
+        self.tol = tol
+
+    def forward(self, encoded_layers: List[torch.Tensor], pad_mask: torch.Tensor):
+        assert (
+            self.num_layers <= len(encoded_layers)
+        ), "k should be less than the number of encoder layers"
+        encoder_avg = torch.cat(encoded_layers[-self.num_layers:], 2)
+
+        pad_mask = pad_mask.unsqueeze(2)
+        encoder_avg = encoder_avg * pad_mask.float()
+        pooled_output = torch.sum(encoder_avg, 1) / (
+            torch.sum(pad_mask, 1).float() + self.tol
+        )
+        return pooled_output
+
+
+@registry.register_pooler("average_k_from_last")
+class AverageKFromLast(nn.Module):
+    def __init__(
+        self,
+        k=2,
+        tol=0.000001
+    ):
+        super().__init__()
+        self.k = k
+        self.tol = tol
+
+    def forward(self, encoded_layers: List[torch.Tensor], pad_mask: torch.Tensor):
+        assert (
+            self.k <= len(encoded_layers)
+        ), "k should be less than the number of encoder layers"
+        encoder_avg = encoded_layers[-self.k]
+        pad_mask = pad_mask.unsqueeze(2)
+        encoder_avg = encoder_avg * pad_mask.float()
+        pooled_output = torch.sum(encoder_avg, 1) / (
+            torch.sum(pad_mask, 1).float() + self.tol
+        )
+        return pooled_output
+
+
+@registry.register_pooler("average_sum_last_k")
+class AverageSumLastK(nn.Module):
+    def __init__(
+        self,
+        k=4,
+        tol=0.000001
+    ):
+        super().__init__()
+        self.k = k
+        self.tol = tol
+
+    def forward(self, encoded_layers: List[torch.Tensor], pad_mask: torch.Tensor):
+        assert (
+            self.k <= len(encoded_layers)
+        ), "k should be less than the number of encoder layers"
+        encoder_avg = torch.stack(encoded_layers[-self.k:]).sum(0)
+        pad_mask = pad_mask.unsqueeze(2)
+        encoder_avg = encoder_avg * pad_mask.float()
+        pooled_output = torch.sum(encoder_avg, 1) / (
+            torch.sum(pad_mask, 1).float() + self.tol
+        )
+        return pooled_output

--- a/tests/modules/test_poolers.py
+++ b/tests/modules/test_poolers.py
@@ -1,0 +1,48 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import unittest
+
+import mmf.modules.poolers as poolers
+import torch
+
+
+class TestModulePoolers(unittest.TestCase):
+    def setUp(self):
+        self.k = 2
+        self.batch_size = 64
+        self.num_tokens = 10
+        self.embedding_size = 768
+        self.token_len = 10
+        self.encoded_layers = [
+            torch.randn(self.batch_size, self.token_len, self.embedding_size),
+            torch.randn(self.batch_size, self.token_len, self.embedding_size),
+            torch.randn(self.batch_size, self.token_len, self.embedding_size)
+        ]
+        self.pad_mask = torch.randn(self.batch_size, self.token_len)
+
+    def test_AverageConcat(self):
+        pool_fn = poolers.AverageConcatLastN(self.k)
+        out = pool_fn(self.encoded_layers, self.pad_mask)
+        if torch.cuda.is_available():
+            pool_fn.cuda()
+            out = pool_fn(self.encoded_layers.cuda(), self.pad_mask.cuda())
+
+        assert torch.Size([self.batch_size, self.embedding_size * self.k]) == out.shape
+
+    def test_AverageKFromLast(self):
+        pool_fn = poolers.AverageKFromLast(self.k)
+        out = pool_fn(self.encoded_layers, self.pad_mask)
+        if torch.cuda.is_available():
+            pool_fn.cuda()
+            out = pool_fn([self.encoded_layers.cuda(), self.pad_mask.cuda()])
+
+        assert torch.Size([self.batch_size, self.embedding_size]) == out.shape
+
+    def test_AverageSumLastK(self):
+        pool_fn = poolers.AverageSumLastK(self.k)
+        out = pool_fn(self.encoded_layers, self.pad_mask)
+        if torch.cuda.is_available():
+            pool_fn.cuda()
+            out = pool_fn([self.encoded_layers.cuda(), self.pad_mask.cuda()])
+
+        assert torch.Size([self.batch_size, self.embedding_size]) == out.shape


### PR DESCRIPTION
Summary: Modules for different pooler functions from transformer encoder layers to support Refiner (D30704069) and possibly other applications.

Reviewed By: apsdehal

Differential Revision: D31507765

