### PR TITLE
[refactor] Extend WandbLogger to log config variables, entity and kwargs

### DIFF
--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -54,9 +54,11 @@ training:
         # Experiment/ run name to be used while logging the experiment
         # under the project with wandb
         wandb_runname: ${training.experiment_name}
-        # Specify other argument values to be used while logging the experiment
-        init_kwargs:
-            job_type: train
+        # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
+        # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
+        # job_type: 'train'
+        # tags: ['tag1', 'tag2']
+
 
 
     # Size of the batch globally. If distributed or data_parallel

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -50,10 +50,10 @@ training:
         # it will log the run to your user account.
         entity: null
         # Project name to be used while logging the experiment with wandb
-        wandb_projectname: mmf_${oc.env:USER,}
+        project: mmf
         # Experiment/ run name to be used while logging the experiment
         # under the project with wandb
-        wandb_runname: ${training.experiment_name}
+        name: ${training.experiment_name}
         # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
         # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
         # job_type: 'train'

--- a/mmf/configs/defaults.yaml
+++ b/mmf/configs/defaults.yaml
@@ -45,11 +45,19 @@ training:
     wandb:
         # Whether to use Weights and Biases Logger, (Default: false)
         enabled: false
+        # An entity is a username or team name where you're sending runs.
+        # This is necessary if you want to log your metrics to a team account. By default
+        # it will log the run to your user account.
+        entity: null
         # Project name to be used while logging the experiment with wandb
         wandb_projectname: mmf_${oc.env:USER,}
         # Experiment/ run name to be used while logging the experiment
         # under the project with wandb
         wandb_runname: ${training.experiment_name}
+        # Specify other argument values to be used while logging the experiment
+        init_kwargs:
+            job_type: train
+
 
     # Size of the batch globally. If distributed or data_parallel
     # is used, this will be divided equally among GPUs

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -60,10 +60,8 @@ class LogisticsCallback(Callback):
 
             self.wandb_logger = WandbLogger(
                 entity=config.training.wandb.entity,
-                project=config.training.wandb.wandb_projectname,
                 config=config,
-                name=config.training.wandb.wandb_runname,
-                save_dir=log_dir,
+                project=config.training.wandb.project,
             )
 
     def on_train_start(self):

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -58,15 +58,12 @@ class LogisticsCallback(Callback):
             if env_wandb_logdir:
                 log_dir = env_wandb_logdir
 
-            wandb_init_kwargs = config.training.wandb.init_kwargs
-
             self.wandb_logger = WandbLogger(
                 entity=config.training.wandb.entity,
                 project=config.training.wandb.wandb_projectname,
                 config=config,
                 name=config.training.wandb.wandb_runname,
                 save_dir=log_dir,
-                **wandb_init_kwargs,
             )
 
     def on_train_start(self):
@@ -157,6 +154,7 @@ class LogisticsCallback(Callback):
             meter=kwargs["meter"],
             should_print=prefix,
             tb_writer=self.tb_writer,
+            wandb_logger=self.wandb_logger,
         )
         logger.info(f"Finished run in {self.total_timer.get_time_since_start()}")
 

--- a/mmf/trainers/callbacks/logistics.py
+++ b/mmf/trainers/callbacks/logistics.py
@@ -58,11 +58,15 @@ class LogisticsCallback(Callback):
             if env_wandb_logdir:
                 log_dir = env_wandb_logdir
 
-            wandb_projectname = config.training.wandb.wandb_projectname
-            wandb_runname = config.training.wandb.wandb_runname
+            wandb_init_kwargs = config.training.wandb.init_kwargs
 
             self.wandb_logger = WandbLogger(
-                name=wandb_runname, save_dir=log_dir, project=wandb_projectname
+                entity=config.training.wandb.entity,
+                project=config.training.wandb.wandb_projectname,
+                config=config,
+                name=config.training.wandb.wandb_runname,
+                save_dir=log_dir,
+                **wandb_init_kwargs,
             )
 
     def on_train_start(self):

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -7,7 +7,6 @@ import logging
 import os
 import sys
 import time
-from copy import deepcopy
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Union
 
@@ -426,7 +425,7 @@ class WandbLogger:
 
         self._wandb = wandb
         self._wandb_init = dict(entity=entity, config=config, project=project)
-        wandb_kwargs = deepcopy(config.training.wandb)
+        wandb_kwargs = dict(config.training.wandb)
         wandb_kwargs.pop("enabled")
         wandb_kwargs.pop("entity")
         wandb_kwargs.pop("project")

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -425,7 +425,7 @@ class WandbLogger:
             )
 
         self._wandb = wandb
-        self._wandb_init = dict(entity=entity, project=project)
+        self._wandb_init = dict(entity=entity, config=config, project=project)
         wandb_kwargs = deepcopy(config.training.wandb)
         wandb_kwargs.pop("enabled")
         wandb_kwargs.pop("entity")

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -395,9 +395,11 @@ class WandbLogger:
     Log using `Weights and Biases`.
 
     Args:
+        entity: An entity is a username or team name where you're sending runs.
         name: Display name for the run.
         save_dir: Path where data is saved (./save/logs/wandb/ by default).
         project: Display name for the project.
+        config: Configuration for the run.
         **init_kwargs: Arguments passed to :func:`wandb.init`.
 
     Raises:
@@ -406,9 +408,11 @@ class WandbLogger:
 
     def __init__(
         self,
+        entity: Optional[str] = None,
         name: Optional[str] = None,
         save_dir: Optional[str] = None,
         project: Optional[str] = None,
+        config: Optional[Dict] = None,
         **init_kwargs,
     ):
         try:
@@ -421,7 +425,9 @@ class WandbLogger:
 
         self._wandb = wandb
 
-        self._wandb_init = dict(name=name, project=project, dir=save_dir)
+        self._wandb_init = dict(
+            entity=entity, name=name, project=project, dir=save_dir, config=config
+        )
 
         self._wandb_init.update(**init_kwargs)
 

--- a/website/docs/notes/logging.md
+++ b/website/docs/notes/logging.md
@@ -8,13 +8,13 @@ sidebar_label: Weights and Biases Logging
 
 MMF now has a `WandbLogger` class which lets the user to log their model's progress using [Weights and Biases](https://wandb.ai/site). Enable this logger to automatically log the training/validation metrics, system (GPU and CPU) metrics and configuration parameters.
 
-## First time setup 
+## First time setup
 
 To set up wandb, run the following:
 ```
 pip install wandb
 ```
-In order to log anything to the W&B server you need to authenticate the machine with W&B **API key**. You can create a new account by going to https://wandb.ai/signup which will generate an API key. If you are an existing user you can retrieve your key from https://wandb.ai/authorize. You only need to supply your key once, and then it is remembered on the same device. 
+In order to log anything to the W&B server you need to authenticate the machine with W&B **API key**. You can create a new account by going to https://wandb.ai/signup which will generate an API key. If you are an existing user you can retrieve your key from https://wandb.ai/authorize. You only need to supply your key once, and then it is remembered on the same device.
 
 ```
 wandb login
@@ -28,42 +28,42 @@ training:
     # Weights and Biases control, by default Weights and Biases (wandb) is disabled
     wandb:
         # Whether to use Weights and Biases Logger, (Default: false)
-        enabled: false
+        enabled: true
         # An entity is a username or team name where you're sending runs.
         # This is necessary if you want to log your metrics to a team account. By default
         # it will log the run to your user account.
         entity: null
         # Project name to be used while logging the experiment with wandb
-        wandb_projectname: mmf_${oc.env:USER,}
+        project: mmf
         # Experiment/ run name to be used while logging the experiment
         # under the project with wandb
-        wandb_runname: ${training.experiment_name}
+        name: ${training.experiment_name}
         # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
         # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
         # job_type: 'train'
         # tags: ['tag1', 'tag2']
 env:
     wandb_logdir: ${env:MMF_WANDB_LOGDIR,}
-``` 
+```
 
 * To enable wandb logger the user needs to change the following option in the config.
 
 	`training.wandb.enabled=True`
 
-* To give the `entity` which is the name of the team or the username, the user needs to change the following option in the config. In case no `entity` is provided, the data will be logged to the `entity` set as default in the user's settings. 
+* To give the `entity` which is the name of the team or the username, the user needs to change the following option in the config. In case no `entity` is provided, the data will be logged to the `entity` set as default in the user's settings.
 
 	`training.wandb.entity=<teamname/username>`
 
-* To give the current experiment a project and run name, user should add these config options.
+* To give the current experiment a project and run name, user should add these config options. The default project name is `mmf` and the default run name is `${training.experiment_name}`.
 
-	`training.wandb.wandb_projectname=<ProjectName>` <br>
-	`training.wandb.wandb_runname=<RunName>`
+	`training.wandb.project=<ProjectName>` <br>
+	`training.wandb.name=<RunName>`
 
 * To change the path to the directory where wandb metadata would be stored (Default: `env.log_dir`):
 
 	`env.wandb_logdir=<dir_name>`
 
-* To provide extra arguments to `wandb.init()`, the user just needs to define them in the config file. Check out the documentation at https://docs.wandb.ai/ref/python/init to see what arguments are available. An example is shown in the config parameter shown above. 
+* To provide extra arguments to `wandb.init()`, the user just needs to define them in the config file. Check out the documentation at https://docs.wandb.ai/ref/python/init to see what arguments are available. An example is shown in the config parameter shown above. Make sure to use the same key name in the config file as defined in the documentation.
 
 ## Current features
 

--- a/website/docs/notes/logging.md
+++ b/website/docs/notes/logging.md
@@ -1,18 +1,26 @@
 ---
-id: concepts
-title: Terminology and Concepts
-sidebar_label: Terminology and Concepts
+id: logger
+title: Weights and Biases Logging
+sidebar_label: Weights and Biases Logging
 ---
 
 ## Weights and Biases Logger
 
-MMF has a `WandbLogger` class which lets the user to log their model's progress using [Weights and Biases](https://gitbook-docs.wandb.ai/).
+MMF now has a `WandbLogger` class which lets the user to log their model's progress using [Weights and Biases](https://wandb.ai/site). Enable this logger to automatically log the training/validation metrics, system (GPU and CPU) metrics and configuration parameters.
+
+## First time setup 
 
 To set up wandb, run the following:
 ```
 pip install wandb
+```
+In order to log anything to the W&B server you need to authenticate the machine with W&B **API key**. You can create a new account by going to https://wandb.ai/signup which will generate an API key. If you are an existing user you can retrieve your key from https://wandb.ai/authorize. You only need to supply your key once, and then it is remembered on the same device. 
+
+```
 wandb login
 ```
+
+## W&B config parameters
 
 The following options are available in config to enable and customize the wandb logging:
 ```yaml
@@ -21,22 +29,47 @@ training:
     wandb:
         # Whether to use Weights and Biases Logger, (Default: false)
         enabled: false
+        # An entity is a username or team name where you're sending runs.
+        # This is necessary if you want to log your metrics to a team account. By default
+        # it will log the run to your user account.
+        entity: null
         # Project name to be used while logging the experiment with wandb
-        wandb_projectname: mmf_${oc.env:USER}
+        wandb_projectname: mmf_${oc.env:USER,}
         # Experiment/ run name to be used while logging the experiment
         # under the project with wandb
         wandb_runname: ${training.experiment_name}
+        # Specify other argument values that you want to pass to wandb.init(). Check out the documentation
+        # at https://docs.wandb.ai/ref/python/init to see what arguments are available.
+        # job_type: 'train'
+        # tags: ['tag1', 'tag2']
 env:
     wandb_logdir: ${env:MMF_WANDB_LOGDIR,}
-```
-To enable wandb logger the user needs to change the following option in the config.
+``` 
 
-`training.wandb.enabled=True`
+* To enable wandb logger the user needs to change the following option in the config.
 
-To give the current experiment a project and run name, user should add these config options.
+	`training.wandb.enabled=True`
 
-`training.wandb.wandb_projectname=<ProjectName> training.wandb.wandb_runname=<RunName>`
+* To give the `entity` which is the name of the team or the username, the user needs to change the following option in the config. In case no `entity` is provided, the data will be logged to the `entity` set as default in the user's settings. 
 
-To change the path to the directory where wandb metadata would be stored (Default: `env.log_dir`):
+	`training.wandb.entity=<teamname/username>`
 
-`env.wandb_logdir=<dir_name>`
+* To give the current experiment a project and run name, user should add these config options.
+
+	`training.wandb.wandb_projectname=<ProjectName>` <br>
+	`training.wandb.wandb_runname=<RunName>`
+
+* To change the path to the directory where wandb metadata would be stored (Default: `env.log_dir`):
+
+	`env.wandb_logdir=<dir_name>`
+
+* To provide extra arguments to `wandb.init()`, the user just needs to define them in the config file. Check out the documentation at https://docs.wandb.ai/ref/python/init to see what arguments are available. An example is shown in the config parameter shown above. 
+
+## Current features
+
+The following features are currently supported by the `WandbLogger`:
+
+* Training & Validation metrics
+* Learning Rate over time
+* GPU: Type, GPU Utilization, power, temperature, CUDA memory usage
+* Log configuration parameters

--- a/website/docs/notes/logging.md
+++ b/website/docs/notes/logging.md
@@ -48,20 +48,20 @@ env:
 
 * To enable wandb logger the user needs to change the following option in the config.
 
-	`training.wandb.enabled=True`
+    `training.wandb.enabled=True`
 
 * To give the `entity` which is the name of the team or the username, the user needs to change the following option in the config. In case no `entity` is provided, the data will be logged to the `entity` set as default in the user's settings.
 
-	`training.wandb.entity=<teamname/username>`
+    `training.wandb.entity=<teamname/username>`
 
 * To give the current experiment a project and run name, user should add these config options. The default project name is `mmf` and the default run name is `${training.experiment_name}`.
 
-	`training.wandb.project=<ProjectName>` <br>
-	`training.wandb.name=<RunName>`
+    `training.wandb.project=<ProjectName>` <br>
+    `training.wandb.name=<RunName>`
 
 * To change the path to the directory where wandb metadata would be stored (Default: `env.log_dir`):
 
-	`env.wandb_logdir=<dir_name>`
+    `env.wandb_logdir=<dir_name>`
 
 * To provide extra arguments to `wandb.init()`, the user just needs to define them in the config file. Check out the documentation at https://docs.wandb.ai/ref/python/init to see what arguments are available. An example is shown in the config parameter shown above. Make sure to use the same key name in the config file as defined in the documentation.
 


### PR DESCRIPTION
1. I was going through the `WandbLogger` class that was recently added to this library. Since MMF is a config-first framework, it would be great to log the config file to keep track of what's going in the model training/evaluation process. 

   The effect of this small change can be seen through the before and after screenshots. One can compare one experiment from another by comparing the config. 

   Before:
   ![image](https://user-images.githubusercontent.com/31141479/138003564-04da7c53-52a4-41f4-8300-70214debe359.png)

   After: 
   ![image](https://user-images.githubusercontent.com/31141479/138003612-e180bc93-1aba-4040-983f-f6ffd7894d20.png)

2. I have also added another argument to pass `entity` to `wandb.init`. Explicit mention of this will help users who are using a W&B Teams account. 

3. Extra arguments to the `wandb.init()` can be passed via the config file. 

4. Ability to log learning rate over time. 

PS: I am learning about this library and will be using it for personal work. Since I am also affiliated with Weights and Biases, I will be creating some PRs to add functionalities to the logger that might be useful for everyone. :)