### PR TITLE
[fix] Remove SizeProportionalIterationStrategy for val and test splits (#191)

### DIFF
--- a/mmf/utils/build.py
+++ b/mmf/utils/build.py
@@ -602,17 +602,9 @@ def build_iteration_strategy(
         # This assumes all dataloaders will have same dataset type
         iteration_strategy_class = registry.get_iteration_strategy_class(config.type)
         config = config.get("params", {})
-        dataset_type = dataloaders[list(dataloaders.keys())[0]].dataset.dataset_type
-        if dataset_type != "train":
-            logger.info(
-                f"{iteration_strategy_class.__name__} updated to size "
-                + f"proportional for {dataset_type}"
-            )
-            return SizeProportionalIterationStrategy.from_params(
-                dataloaders, *args, **kwargs
-            )
-        else:
-            return iteration_strategy_class(config, dataloaders, *args, **kwargs)
+        # val and test splits won't be affected as test reporter iterates
+        # over the datasets one by one without using any iteration strategy
+        return iteration_strategy_class(config, dataloaders, *args, **kwargs)
 
 
 def build_meters(run_type: str) -> List[Meter]:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/mmf-internal/pull/191

We'd like to have the same iteration strategy for all dataset splits (train, val, test). Test reporter is used to iterate over datasets one by one rather than using any iteration strategy.

Differential Revision: D31740149

