### PR TITLE
[feat] Add a refiner head to MMFT

### DIFF
--- a/mmf/__init__.py
+++ b/mmf/__init__.py
@@ -6,7 +6,7 @@ from mmf.utils.patch import patch_transformers
 patch_transformers()
 
 from mmf import utils, common, modules, datasets, models
-from mmf.modules import losses, schedulers, optimizers, metrics
+from mmf.modules import losses, schedulers, optimizers, metrics, poolers
 from mmf.version import __version__
 
 
@@ -17,6 +17,7 @@ __all__ = [
     "datasets",
     "models",
     "losses",
+    "poolers",
     "schedulers",
     "optimizers",
     "metrics",

--- a/mmf/models/mmf_transformer.py
+++ b/mmf/models/mmf_transformer.py
@@ -384,24 +384,25 @@ class MMFTransformer(BaseTransformer):
 
     def forward(self, sample_list: Dict[str, Tensor]) -> Dict[str, Tensor]:
         # Sample preprocess
-        processed_sample_list = self.preprocess_sample(sample_list)
+        orig_and_processed_sample_list = self.preprocess_sample(sample_list)
 
+        orig_and_processed_sample_list["target_key"] = sample_list
         # Arrange masks in a list
         masks = []
         for modality in self.modality_keys:
-            masks.append(processed_sample_list["masks"][modality])
+            masks.append(orig_and_processed_sample_list["masks"][modality])
 
         # Call transformer backend
         sequence_output, encoded_layers = self.backend(
-            processed_sample_list["input_ids"],
-            processed_sample_list["position_ids"],
-            processed_sample_list["segment_ids"],
+            orig_and_processed_sample_list["input_ids"],
+            orig_and_processed_sample_list["position_ids"],
+            orig_and_processed_sample_list["segment_ids"],
             masks,
         )
 
         # Transformer Heads
         return self.postprocess_output(
-            sequence_output, encoded_layers, processed_sample_list
+            sequence_output, encoded_layers, orig_and_processed_sample_list
         )
 
     def postprocess_output(

--- a/mmf/models/transformers/heads/refiner.py
+++ b/mmf/models/transformers/heads/refiner.py
@@ -1,0 +1,187 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Type
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.transformers.base import BaseTransformerHead
+from mmf.modules.losses import RefinerContrastiveLoss, RefinerMSLoss
+from torch import nn
+from transformers.modeling_bert import BertOnlyMLMHead
+
+
+class MLP(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        mlp_dims: List[int],
+        dropout: float = 0.3,
+        nonlinearity: Type[nn.Module] = nn.ReLU,
+        normalization: Optional[Type[nn.Module]] = nn.LayerNorm,
+    ):
+        super(MLP, self).__init__()
+        self.output_dim = mlp_dims[-1]
+        projection_prev_dim = input_dim
+        projection_modulelist = []
+
+        for mlp_dim in mlp_dims:
+            projection_modulelist.append(nn.Linear(projection_prev_dim, mlp_dim))
+            projection_modulelist.append(nonlinearity())
+
+            if normalization is not None:
+                projection_modulelist.append(normalization(mlp_dim))
+            if dropout != 0:
+                projection_modulelist.append(nn.Dropout(dropout))
+            projection_prev_dim = mlp_dim
+
+        self.projection = nn.Sequential(*projection_modulelist)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        input_arguments:
+            @x: torch.FloatTensor
+        """
+        x = self.projection(x)
+        return x
+
+
+@registry.register_transformer_head("refiner")
+class Refiner(BaseTransformerHead):
+    @dataclass
+    class Config(BaseTransformerHead.Config):
+        type: str = "refiner"
+        vocab_size: int = 30522
+        hidden_size: int = 768
+        hidden_dropout_prob: float = 0.1
+        layer_norm_eps: float = 1e-5
+        hidden_act: str = "gelu"
+        ignore_index: int = -1
+        loss_name: str = "refiner_ss_loss"
+        loss_type: str = "mse"
+        refiner_target_pooler: str = "average_k_from_last"
+        refiner_target_layer_depth: int = 1
+        label_key: Optional[str] = None
+        modalities: List[str] = field(default_factory=lambda: ["text", "image"])
+        weights: List[float] = field(default_factory=lambda: [0.1, 0.1])
+        tol: float = 0.000001
+
+    def __init__(self, config: Config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        self.cls = BertOnlyMLMHead(self.config)
+        loss_dict = dict(
+            mse=torch.nn.MSELoss(),
+            cosine=torch.nn.CosineSimilarity(dim=1),
+            contrastive=RefinerContrastiveLoss(),
+            ms=RefinerMSLoss(),
+        )
+        self.refiner_loss = loss_dict.get(self.config.loss_type)
+
+        self.refiner_decoder = {}
+        self.weights = {}
+        for i, modality in enumerate(self.config.modalities):
+            self.refiner_decoder[modality] = MLP(
+                input_dim=self.config.hidden_size,
+                mlp_dims=[self.config.hidden_size],
+                dropout=self.config.hidden_dropout_prob,
+                nonlinearity=torch.nn.ReLU,
+                normalization=torch.nn.LayerNorm,
+            )
+            self.weights[modality] = self.config.weights[i]
+
+        self.modalities = self.config.modalities
+        self.tol = self.config.tol
+        self.refiner_target_pooler = self.config.refiner_target_pooler
+        self.refiner_target_layer_depth = self.config.refiner_target_layer_depth
+        self.loss_name = self.config.loss_name
+
+        pool_class = registry.get_pool_class(self.refiner_target_pooler)
+        if pool_class is None:
+            raise ValueError(
+                f"No pooler {self.refiner_target_pooler} is\
+                             registered to registry"
+            )
+        self.pooler = pool_class(self.refiner_target_layer_depth)
+
+    def forward(
+        self,
+        sequence_output: torch.Tensor,
+        encoded_layers: Optional[List[torch.Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, torch.Tensor]]] = None,
+    ):
+        start_token = {}
+        end_token = {}
+        prev_end_token = 0
+        masks = []
+        for modality in self.modalities:
+            masks.append(processed_sample_list["masks"][modality])
+            sz = processed_sample_list["masks"][modality].size()
+            start_token[modality] = prev_end_token
+            end_token[modality] = start_token[modality] + sz[1] - 1
+            prev_end_token = end_token[modality] + 1
+
+        attention_mask = torch.cat(masks, dim=1)
+        processed_sample_list["refiner_outputs"] = {}
+        processed_sample_list["refiner_outputs"]["fused_embedding"] = self.pooler(
+            sequence_output, attention_mask
+        )
+        processed_sample_list["refiner_targets"] = {}
+        for modality in self.modalities:
+            modality_encodings = []
+            tk_start = start_token[modality]
+            tk_end = end_token[modality]
+            for enc_layers in encoded_layers:
+                modality_encodings.append(enc_layers[:, tk_start : tk_end + 1, :])
+            modality_mask_encodings = attention_mask[:, tk_start : tk_end + 1]
+            processed_sample_list["refiner_targets"][modality] = self.pooler(
+                modality_encodings, modality_mask_encodings
+            )
+
+        output_dict = {}
+        prediction = self.cls(sequence_output)
+        output_dict["logits"] = prediction
+        output_dict["losses"] = {}
+
+        fused_embedding = processed_sample_list["refiner_outputs"]["fused_embedding"]
+        refiner_reconstruct = {}
+        for modality in processed_sample_list["refiner_targets"].keys():
+            local_device = fused_embedding.device
+            self.refiner_decoder[modality].to(local_device)
+            refiner_reconstruct[modality] = self.refiner_decoder[modality](
+                fused_embedding
+            )
+            if isinstance(self.refiner_loss, torch.nn.CosineSimilarity):
+                loss = self.weights[modality] * (
+                    1.0
+                    - torch.mean(
+                        self.refiner_loss(
+                            processed_sample_list["refiner_targets"][modality],
+                            refiner_reconstruct[modality],
+                        )
+                    )
+                )
+            elif isinstance(self.refiner_loss, RefinerContrastiveLoss) or isinstance(
+                self.refiner_loss, RefinerMSLoss
+            ):
+                modality_targets = {}
+                modality_targets["targets"] = processed_sample_list["refiner_targets"][
+                    modality
+                ]
+                refiner_modal_outputs = {}
+                refiner_modal_outputs["scores"] = refiner_reconstruct[modality]
+                loss = self.refinerloss(modality_targets, refiner_modal_outputs)
+
+            else:
+                loss = self.weights[modality] * self.refiner_loss(
+                    processed_sample_list["refiner_targets"][modality],
+                    refiner_reconstruct[modality],
+                )
+
+            if "current_loss" not in locals():
+                current_loss = loss
+            else:
+                current_loss += loss
+
+        output_dict["losses"][self.loss_name] = current_loss
+        output_dict["fused_embedding"] = fused_embedding
+        return output_dict

--- a/mmf/models/transformers/heads/refnet_classifier.py
+++ b/mmf/models/transformers/heads/refnet_classifier.py
@@ -1,0 +1,134 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn as nn
+from mmf.common.registry import registry
+from mmf.models.transformers.base import BaseTransformerHead
+from mmf.modules.losses import LogitBinaryCrossEntropy, MSLoss
+
+from .mlp import MLP
+from .refiner import Refiner
+
+
+logger = logging.getLogger(__name__)
+
+
+class MLPWithLoss(BaseTransformerHead):
+    class Config(BaseTransformerHead.Config):
+        config: MLP.Config
+        loss_name: str = "classification_loss"
+        loss: str = "cross_entropy"
+        max_sample_size: int = 10000
+
+    def __init__(self, config: Config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        self.loss_name = self.config.loss_name
+        if self.config.loss == "cross_entropy":
+            self.loss_fn = nn.CrossEntropyLoss()
+        elif self.config.loss == "logit_bce":
+            self.loss_fn = LogitBinaryCrossEntropy()
+        self.init_output_dict = {}
+        self.init_output_dict["losses"] = {}
+        self.mlp_base = MLP(config)
+
+    def forward(
+        self,
+        sequence_output: torch.Tensor,
+        encoded_layers: Optional[List[torch.Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, torch.Tensor]]] = None,
+    ):
+        output_dict = self.mlp_base(
+            sequence_output, encoded_layers, processed_sample_list
+        )
+        scores = output_dict["scores"]
+        score_max = min(len(scores) - 1, self.config.max_sample_size)
+        if isinstance(self.loss_fn, nn.CrossEntropyLoss):
+            if "losses" not in output_dict.keys():
+                output_dict["losses"] = {}
+            output_dict["losses"][self.loss_name] = self.loss_fn(
+                scores[:score_max],
+                processed_sample_list["target_key"]["targets"][:score_max],
+            )
+        elif isinstance(self.loss_fn, LogitBinaryCrossEntropy):
+            scores_subset = {}
+            scores_subset["scores"] = scores[:score_max]
+            targets_subset = {}
+            targets_subset["targets"] = processed_sample_list["target_key"]["targets"]
+            targets_subset["targets"] = targets_subset["targets"][:score_max]
+            output_dict["losses"][self.loss_name] = self.loss_fn(
+                targets_subset, scores_subset
+            )
+
+        return output_dict
+
+
+@registry.register_transformer_head("refiner_classifier")
+class RefinerClassifier(BaseTransformerHead):
+    @dataclass
+    class Config(BaseTransformerHead.Config):
+        type: str = "refiner_classifier"
+        refiner_config: Optional[Refiner.Config] = None
+        mlp_loss_config: Optional[MLPWithLoss.Config] = None
+        msloss_weight: float = 0.1
+        use_msloss: bool = False
+        embedding_key: str = "fused_embedding"
+        num_labels: int = 2
+
+    def __init__(self, config: Config, *args, **kwargs):
+        super().__init__(config, *args, **kwargs)
+        self.refiner_head = Refiner(self.config.refiner_config)
+        self.mlp_loss_head = MLPWithLoss(self.config.mlp_loss_config)
+        self.max_sample_size = self.config.mlp_loss_config.max_sample_size
+        self.msloss_weight = self.config.msloss_weight
+        if self.config.num_labels > 2:
+            self.is_multilabel = True
+        else:
+            self.is_multilabel = False
+
+        if self.config.use_msloss:
+            self.msloss = MSLoss(is_multilabel=self.is_multilabel)
+        else:
+            self.msloss = None
+        self.emb_f = self.config.embedding_key
+
+    def forward(
+        self,
+        sequence_output: torch.Tensor,
+        encoded_layers: Optional[List[torch.Tensor]] = None,
+        processed_sample_list: Optional[Dict[str, Dict[str, torch.Tensor]]] = None,
+    ):
+
+        output_dict_refiner = self.refiner_head(
+            sequence_output, encoded_layers, processed_sample_list
+        )
+        output_dict = self.mlp_loss_head(
+            sequence_output, encoded_layers, processed_sample_list
+        )
+        for key in output_dict_refiner["losses"].keys():
+            if key not in output_dict["losses"].keys():
+                output_dict["losses"][key] = output_dict_refiner["losses"][key]
+
+        for key in output_dict_refiner.keys():
+            if key not in output_dict.keys():
+                output_dict[key] = output_dict_refiner[key]
+
+        scores = output_dict["scores"]
+
+        score_max = min(len(scores) - 1, self.max_sample_size)
+        if isinstance(self.msloss, MSLoss):
+            emb_f = self.emb_f
+            targets_list = {}
+            targets_list["targets"] = processed_sample_list["target_key"]["targets"][
+                :score_max
+            ]
+            subset_score_list = {}
+            subset_score_list["scores"] = output_dict["scores"][:score_max]
+            subset_score_list[emb_f] = output_dict[emb_f][:score_max]
+            output_dict["losses"]["ms_loss"] = self.msloss_weight * self.msloss(
+                targets_list, subset_score_list
+            )
+
+        return output_dict

--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -861,3 +861,258 @@ class BCEAndKLLoss(nn.Module):
         loss = {"kl": self.weight_softmax * loss1, "bce": loss2}
 
         return loss
+
+
+def calc_ms_loss(pair, base, param, multiplier):
+    return (
+        1.0
+        / param
+        * torch.log(1 + torch.sum(torch.exp(multiplier * param * (pair - base))))
+    )
+
+
+@registry.register_loss("refiner_ms")
+class RefinerMSLoss(nn.Module):
+
+    """
+    A Multi-Similarity loss between the decoder outputs of a given embedding size
+    and its targets
+
+    This loss pulls the decoded signal of a sample closer to its target,
+    while simultaneously pushing it away from other targets
+
+    References:
+
+    1) Wang et al., Multi-Similarity Loss With General Pair Weighting
+    for Deep Metric Learning, CVPR 2019
+    2) Sankaran, S., Yang, D. and Lim, S.N., "Multimodal Fusion Refiner Networks"
+
+    Parameters:
+
+        same as ms_loss (see below)
+
+    """
+
+    def __init__(
+        self,
+        alpha: float = 50,
+        beta: float = 2,
+        base: float = 0.5,
+        margin: float = 0.1,
+        epsilon: float = 1e-16,
+    ):
+        super().__init__()
+        self.alpha = alpha
+        self.beta = beta
+        self.margin = margin
+        self.base = base
+        self.epsilon = epsilon
+
+    def forward(self, sample_list, model_output):
+        targets = sample_list["targets"]
+        inputs = model_output["scores"]
+        n = inputs.size(0)
+        sim_mat = torch.matmul(inputs, targets.t())
+        loss = []
+
+        for i in range(n):
+            # pos pair is the similarity between the refiner output (input to forward)
+            # and target (original encoding)
+            pos_pair = sim_mat[i][i]
+            # neg pair is all the remaining pairs
+            neg_pairs_all = sim_mat[i]
+            # remove the pos_par from neg_pairs
+            neg_pairs_all = neg_pairs_all[abs(neg_pairs_all - pos_pair) > self.epsilon]
+            # All pairs whose similarity is within a margin of the pos_pair similarity
+            neg_pairs = neg_pairs_all[neg_pairs_all + self.margin > pos_pair]
+
+            # nothing to do if there are no negative pairs from line 918
+            if len(neg_pairs) < 1:
+                continue
+
+            pos_loss = calc_ms_loss(pos_pair, self.base, self.beta, -1)
+            neg_loss = calc_ms_loss(neg_pairs, self.base, self.alpha, 1)
+            loss.append(pos_loss + neg_loss)
+
+        loss = sum(loss) / n
+        return loss
+
+
+@registry.register_loss("ms_loss")
+class MSLoss(nn.Module):
+
+    """
+    A Multi-Similarity loss between embeddings of similar and dissimilar
+    labels is implemented here.
+
+    Reference:
+
+    "Multi-similarity loss with general pair weighting for deep metric learning"
+
+    Args:
+
+        alpha, beta, margin: parameters used in loss function calculation
+        hard_mining: if true, select only the hardest examples (defined based on margin)
+        is_multilabel: True if there are more than two labels, false otherwise
+
+    """
+
+    def __init__(
+        self, alpha=50, beta=2, margin=0.5, hard_mining=True, is_multilabel=False
+    ):
+        super().__init__()
+        self.alpha = alpha
+        self.beta = beta
+        self.hard_mining = hard_mining
+        self.margin = margin
+        self.is_multilabel = is_multilabel
+
+    def get_positive_and_negative_pairs(self, sim_vec, targets, curr_target):
+        # given a sample with a similarity vec (embedding similarity to other samples)
+        # return pairs of samples which share the same targets/labels (positive pairs)
+        # and pairs of samples which have different labels (negative pairs)
+        if self.is_multilabel:
+            pos_pair_ = torch.masked_select(
+                sim_vec, torch.matmul(targets, targets[0]) > 0
+            )
+        else:
+            pos_pair_ = torch.masked_select(sim_vec, targets == curr_target)
+
+        #  remove itself
+        pos_pair_ = torch.masked_select(pos_pair_, pos_pair_ < 1 - 1e-5)
+        pos_pair_ = torch.sort(pos_pair_)[0]
+
+        if self.is_multilabel:
+            neg_pair_ = torch.masked_select(
+                sim_vec, torch.matmul(targets, targets[0]) < 1e-5
+            )
+        else:
+            neg_pair_ = torch.masked_select(sim_vec, targets != curr_target)
+        neg_pair_ = torch.sort(neg_pair_)[0]
+
+        if len(pos_pair_) == 0 or len(neg_pair_) == 0:
+            return (pos_pair_, neg_pair_)
+
+        if self.hard_mining is not None:
+            neg_pair = torch.masked_select(neg_pair_, neg_pair_ + 0.1 > pos_pair_[0])
+            pos_pair = torch.masked_select(pos_pair_, pos_pair_ - 0.1 < neg_pair_[-1])
+            neg_pair_ = neg_pair
+            pos_pair_ = pos_pair
+        return (pos_pair_, neg_pair_)
+
+    def forward(self, sample_list, model_output):
+
+        # get the fused features and normalize
+        fusion_features = model_output["fused_embedding"]
+        inputs = F.normalize(fusion_features)
+
+        # get the targets
+        targets = sample_list["targets"]
+
+        batch_size = inputs.size(0)
+        # sim_mat(i,j) contains the similarity between fused_embeddings of ith
+        # and jth samples in a batch
+        sim_mat = torch.matmul(inputs, inputs.t())
+
+        # this is the margin allowed for multi-similarity loss
+        base = self.margin
+
+        loss = []
+
+        for i in range(batch_size):
+
+            (pos_pair_, neg_pair_) = self.get_positive_and_negative_pairs(
+                sim_mat[i], targets, targets[i]
+            )
+            # no compute needed when one of the pairs is not available
+            if len(pos_pair_) == 0 or len(neg_pair_) == 0:
+                continue
+
+            pos_loss = calc_ms_loss(pos_pair_, base, self.beta, -1)
+            neg_loss = calc_ms_loss(neg_pair_, base, self.alpha, 1)
+            loss.append(pos_loss + neg_loss)
+
+        if len(loss) == 0:
+            loss = inputs.new_zeros(1, requires_grad=True)
+        else:
+            loss = sum(loss) / batch_size
+
+        return loss
+
+
+@registry.register_loss("refiner_contrastive_loss")
+class RefinerContrastiveLoss(nn.Module):
+
+    """
+    A contrastive loss between the decoder outputs of a given embedding size
+    and its targets
+
+    This loss can be used in lieu of a reconstruction loss, wherein the goal
+    is to get a decoded signal closer to its target than other targets. As long
+    as the reconstructed signal of a given input is closer to its target than
+    any other target, the loss will remain zero.
+
+    Reference:
+
+    Sankaran, S., Yang, D. and Lim, S.N., "Multimodal Fusion Refiner Networks"
+
+    Parameters:
+
+        sim_thresh: similarity threshold used to consider only samples beyond
+        # this threshold
+
+    """
+
+    def __init__(self, sim_thresh=0.1, epsilon=1e-16):
+        super().__init__()
+        self.similarity_threshold = sim_thresh
+        self.epsilon = epsilon
+
+    def forward(self, sample_list, model_output):
+        targets = sample_list["targets"]
+        inputs = model_output["scores"]
+
+        batch_size = inputs.size(0)
+        # normalize inputs and targets
+        inputs = F.normalize(inputs)
+        targets = F.normalize(targets)
+
+        # matrix containing the similarity between the inputs and targets
+        # (i,j) contains similarity betweeh the i^th decoder and j^th target
+        sim_mat = torch.matmul(inputs, targets.t())
+
+        loss = []
+
+        for i in range(batch_size):
+            sim_ij = sim_mat[i]
+            # pos_similarity contains the similarity between i^th decoder
+            # and i^th target
+            pos_similarity = sim_ij[i]
+
+            # neg_pair_ contains all the batch samples whose similarity with i^th
+            #  decoder is better than a threshold corrected similarity between
+            # i^th decoder and i^th target
+
+            neg_pair_ = torch.masked_select(
+                sim_ij, sim_ij > pos_similarity - self.similarity_threshold
+            )
+
+            # remove the pos_pair from the neg_pair list
+            neg_pair_ = torch.masked_select(
+                neg_pair_, abs(neg_pair_ - pos_similarity) > self.epsilon
+            )
+
+            # The loss is non-zero only when there exists at least one sample whose
+            # target is closer to the decoded signal.
+            if neg_pair_.shape[0] > 0:
+                neg_loss = torch.mean(
+                    self.similarity_threshold + neg_pair_ - pos_similarity
+                )
+                loss.append(neg_loss)
+
+        if len(loss) == 0:
+            loss = inputs.new_zeros(1, requires_grad=True)
+        else:
+            loss = sum(loss) / batch_size
+
+        return loss

--- a/projects/mmbt/configs/hateful_memes/hateful_with_refiner.yaml
+++ b/projects/mmbt/configs/hateful_memes/hateful_with_refiner.yaml
@@ -1,0 +1,33 @@
+includes:
+- configs/models/mmbt/classification.yaml
+- configs/datasets/hateful_memes/bert.yaml
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 1e-5
+    eps: 1e-8
+
+evaluation:
+    metrics:
+    - accuracy
+    - binary_f1
+    - roc_auc
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  max_updates: 22000
+  early_stop:
+    criteria: hateful_memes/roc_auc
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    bert: bert

--- a/projects/mmbt/configs/mmimdb/paper_ablations_reducedlabel.yaml
+++ b/projects/mmbt/configs/mmimdb/paper_ablations_reducedlabel.yaml
@@ -1,0 +1,103 @@
+model_config:
+  mmf_transformer:
+    transformer_base: bert-base-uncased
+    num_labels: 24
+    backend:
+      type: huggingface
+      freeze: false
+      params: {}
+    modalities:
+    - type: text
+      key: text
+      position_dim: 512
+      segment_id: 0
+      embedding_dim: 768
+      layer_norm_eps: 1e-12
+      hidden_dropout_prob: 0.1
+    - type: image
+      key: image
+      embedding_dim: 2048
+      position_dim: 1
+      segment_id: 1
+      layer_norm_eps: 1e-12
+      hidden_dropout_prob: 0.1
+      encoder:
+        type: resnet152
+        params:
+            pretrained: true
+            pool_type: avg
+            num_output_features: 1
+    heads:
+      - type: refiner_classifier
+        refiner_config:
+          type: refiner
+          freeze: false
+          lr_multiplier: 1.0
+          hidden_size: 768
+          vocab_size: 30522
+          loss_type: "cosine"
+          modalities:
+            - "text"
+            - "image"
+          weights:
+            - 0.0
+            - 0.0
+        mlp_config:
+          type: mlp
+          freeze: false
+          num_labels: 24
+          lr_multiplier: 1.0
+          hidden_size: 768
+          vocab_size: 30522
+          loss: logit_bce
+          max_sample_size: 32
+        ms_loss_weight: 0.05
+        use_msloss: true
+    self_weight_decay: 0.997
+dataset_config:
+  mmimdb:
+    return_features_info: false
+    processors:
+      text_processor:
+        type: bert_tokenizer
+        params:
+          tokenizer_config:
+            type: bert-base-uncased
+            params:
+              do_lower_case: true
+          mask_probability: 0
+          max_seq_length: 256
+
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 5e-5
+    eps: 1e-8
+
+evaluation:
+  metrics:
+  - multilabel_macro_f1
+  - multilabel_micro_f1
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 0
+    num_training_steps: 10000
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  # Don't forget to update schedule_attributes if you update this
+  max_updates: 10000
+  find_unused_parameters: true
+  early_stop:
+    criteria: mmimdb/multilabel_micro_f1
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    pooler: pooler
+    backend.transformer: backend.transformer
+    backend.embeddings: backend.embeddings

--- a/projects/mmf_transformer/configs/hateful_memes/hateful_with_refiner.yaml
+++ b/projects/mmf_transformer/configs/hateful_memes/hateful_with_refiner.yaml
@@ -1,0 +1,69 @@
+includes:
+- configs/datasets/hateful_memes/bert.yaml
+
+model_config:
+  mmf_transformer:
+    training_head_type: classification
+    num_labels: 2
+    heads:
+      - type: refiner_classifier
+        refiner_config:
+          type: refiner
+          freeze: false
+          lr_multiplier: 1.0
+          hidden_size: 768
+          vocab_size: 30522
+          loss_type: "ms"
+          modalities:
+            - "text"
+            - "image"
+          weights:
+            - 0.1
+            - 0.1
+          refiner_target_pooling:
+            type: average_k_from_last
+            k: 1
+        mlp_config:
+          type: mlp
+          freeze: false
+          num_labels: 2
+          lr_multiplier: 1.0
+          hidden_size: 768
+          vocab_size: 30522
+          loss: cross_entropy
+          max_sample_size: 2
+        ms_loss_weight: 0.1
+        use_msloss: true
+    self_weight_decay: 0.997
+
+scheduler:
+  type: warmup_linear
+  params:
+    num_warmup_steps: 2000
+    num_training_steps: ${training.max_updates}
+
+optimizer:
+  type: adam_w
+  params:
+    lr: 1e-5
+    eps: 1e-8
+
+evaluation:
+    metrics:
+    - accuracy
+    - binary_f1
+    - roc_auc
+
+training:
+  batch_size: 32
+  lr_scheduler: true
+  max_updates: 22000
+  early_stop:
+    criteria: hateful_memes/roc_auc
+    minimize: false
+
+checkpoint:
+  pretrained_state_mapping:
+    pooler: pooler
+    backend.transformer: backend.transformer
+    backend.embeddings: backend.embeddings

--- a/tests/models/transformers/test_heads.py
+++ b/tests/models/transformers/test_heads.py
@@ -7,6 +7,8 @@ from mmf.common.sample import Sample
 from mmf.models.transformers.heads.itm import ITM
 from mmf.models.transformers.heads.mlm import MLM
 from mmf.models.transformers.heads.mlp import MLP
+from mmf.models.transformers.heads.refiner import Refiner
+from mmf.models.transformers.heads.refnet_classifier import RefinerClassifier
 from omegaconf import OmegaConf
 from tests.test_utils import skip_if_no_cuda
 
@@ -97,3 +99,81 @@ class TestMutilayerMLPHead(unittest.TestCase):
 
         self.assertTrue("scores" in output)
         self.assertEqual(output["scores"].shape, torch.Size([1, 2]))
+
+
+class TestRefinerHead(unittest.TestCase):
+    def setUp(self):
+        self.config = OmegaConf.create(
+            {
+                "type": "refiner",
+                "refiner_target_pooler": "average_k_from_last",
+                "refiner_target_layer_depth": 1,
+            }
+        )
+
+    def test_forward(self):
+        module = Refiner(self.config)
+        sequence_input = torch.ones(size=(1, 128, 768), dtype=torch.float)
+        encoder_output = [sequence_input, sequence_input]
+        processed_sample_list = {}
+        processed_sample_list["masks"] = {}
+        processed_sample_list["masks"]["text"] = torch.ones(
+            size=(1, 64), dtype=torch.long
+        )
+        processed_sample_list["masks"]["image"] = torch.ones(
+            size=(1, 64), dtype=torch.long
+        )
+        output = module(sequence_input, encoder_output, processed_sample_list)
+        self.assertTrue("losses" in output)
+        self.assertTrue("fused_embedding" in output)
+        self.assertTrue("refiner_ss_loss" in output["losses"].keys())
+        self.assertEqual(output["fused_embedding"].shape, torch.Size([1, 768]))
+
+
+class TestRefNetClassifierHead(unittest.TestCase):
+    def setUp(self):
+
+        self.refiner_config = {
+            "type": "refiner",
+            "refiner_target_pooler": "average_k_from_last",
+            "refiner_target_layer_depth": 1,
+        }
+
+        self.mlp_loss_config = OmegaConf.create(
+            {
+                "config": {"type": "mlp"},
+                "loss_name": "classification_loss",
+                "loss": "cross_entropy",
+                "max_sample_size": 10000,
+            }
+        )
+
+        self.config = OmegaConf.create(
+            {
+                "type": "refiner_classifier",
+                "use_msloss": True,
+                "refiner_config": self.refiner_config,
+                "mlp_loss_config": self.mlp_loss_config,
+            }
+        )
+
+    def test_forward(self):
+        module = RefinerClassifier(self.config)
+        sequence_input = torch.ones(size=(5, 128, 768), dtype=torch.float)
+        encoder_output = [sequence_input, sequence_input]
+        processed_sample_list = {}
+        processed_sample_list["masks"] = {}
+        processed_sample_list["masks"]["text"] = torch.ones(
+            size=(5, 64), dtype=torch.long
+        )
+        processed_sample_list["masks"]["image"] = torch.ones(
+            size=(5, 64), dtype=torch.long
+        )
+        processed_sample_list["target_key"] = {}
+        processed_sample_list["target_key"]["targets"] = torch.empty(
+            5, dtype=torch.long
+        ).random_(2)
+        output = module(sequence_input, encoder_output, processed_sample_list)
+        self.assertTrue("losses" in output)
+        self.assertTrue("fused_embedding" in output)
+        self.assertTrue("ms_loss" in output["losses"].keys())

--- a/tests/modules/test_losses.py
+++ b/tests/modules/test_losses.py
@@ -174,3 +174,52 @@ class TestModuleLosses(unittest.TestCase):
         loss_result = combined_loss(sample_list, model_output)
         self.assertAlmostEqual(loss_result["bce"].item(), 504.22253418, 4)
         self.assertAlmostEqual(loss_result["kl"].item(), 0.031847, 4)
+
+    def test_refiner_ms_loss(self):
+        refiner_ms_loss = losses.RefinerMSLoss(
+            alpha=50, beta=2, base=0.5, margin=0.1, epsilon=1e-16
+        )
+
+        torch.manual_seed(1234)
+        random_tensor = torch.rand((1, 768))
+        sample_list = {"targets": random_tensor}
+        model_output = {"scores": random_tensor}
+
+        loss_result = refiner_ms_loss(sample_list, model_output)
+        self.assertEqual(loss_result, 0.0)
+
+    def test_ms_loss(self):
+        ms_loss = losses.MSLoss(
+            alpha=50, beta=2, margin=0.5, hard_mining=True, is_multilabel=False
+        )
+
+        torch.manual_seed(1234)
+
+        label_tensor = torch.Tensor([0, 0, 0, 0, 0])
+        fused_tensor = torch.randn(5, 768)
+        sample_list = {"targets": label_tensor}
+        model_output = {"fused_embedding": fused_tensor}
+        loss_result = ms_loss(sample_list, model_output)
+        self.assertEqual(loss_result, 0.0)
+
+        label_tensor = torch.Tensor([1, 1, 1, 1, 1])
+        loss_result = ms_loss(sample_list, model_output)
+        self.assertEqual(loss_result, 0.0)
+
+        label_tensor = torch.Tensor([1, 1, 1, 1, 1])
+        loss_result = ms_loss(sample_list, model_output)
+        self.assertEqual(loss_result, 0.0)
+
+    def test_refiner_contrastive_loss(self):
+        refiner_contrastive_loss = losses.RefinerContrastiveLoss(
+            sim_thresh=0.1, epsilon=1e-16
+        )
+
+        inputs = torch.rand((10, 768))
+        targets = inputs
+
+        sample_list = {"targets": targets}
+        model_output = {"scores": inputs}
+
+        loss_result = refiner_contrastive_loss(sample_list, model_output)
+        self.assertEqual(loss_result, 0.0)


### PR DESCRIPTION
Summary: We add a refiner module that adds a shallow decoder to reconstruct target embeddings per modality (based on e.g. modality specific pooling). This is based off this paper - https://arxiv.org/abs/2104.03435

Differential Revision: D31936897

