### PR TITLE
[MMF] assert when processor isn't registered

### DIFF
--- a/mmf/datasets/processors/processors.py
+++ b/mmf/datasets/processors/processors.py
@@ -149,6 +149,9 @@ class Processor:
 
         processor_class = registry.get_processor_class(config.type)
 
+        if processor_class is None:
+            raise ValueError(f"No processor class named {config.type} is defined.")
+
         params = {}
         if "params" not in config:
             logger.warning(
@@ -1173,9 +1176,7 @@ class CaptionProcessor(BaseProcessor):
 
 @registry.register_processor("evalai_answer")
 class EvalAIAnswerProcessor(BaseProcessor):
-    """Processes an answer similar to Eval AI
-
-    """
+    """Processes an answer similar to Eval AI"""
 
     CONTRACTIONS = {
         "aint": "ain't",

--- a/tests/datasets/test_processors.py
+++ b/tests/datasets/test_processors.py
@@ -10,6 +10,7 @@ from mmf.datasets.processors.processors import (
     EvalAIAnswerProcessor,
     MultiClassFromFile,
     MultiHotAnswerFromVocabProcessor,
+    Processor,
     TransformerBboxProcessor,
 )
 from mmf.utils.configuration import load_yaml
@@ -191,3 +192,8 @@ class TestDatasetProcessors(unittest.TestCase):
         image = ToPILImage()(torch.ones(1, 224, 224))
         processed_image = image_processor(image)
         self.assertEqual(processed_image.size(), expected_size)
+
+    def test_processor_class_None(self):
+        config = OmegaConf.create({"type": "UndefinedType"})
+        with self.assertRaises(ValueError):
+            Processor(config)


### PR DESCRIPTION
Summary: when a processor isn't registered, raise an error specifying its name

Reviewed By: apsdehal

Differential Revision: D31903309

