### PR TITLE
[feat] Add VinVL three-way contrastive head

### DIFF
--- a/mmf/models/transformers/heads/contrastive.py
+++ b/mmf/models/transformers/heads/contrastive.py
@@ -1,0 +1,91 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Dict, Optional
+
+import torch
+from mmf.common.registry import registry
+from mmf.models.transformers.heads.mlp import MLP
+from omegaconf import OmegaConf
+from torch import nn
+
+LABEL_KEY = "three_way_constrastive_labels"
+
+
+@registry.register_transformer_head("contrastive_three_way")
+class ThreeWayContrastive(nn.Module):
+    """Three way contrastive loss used for VinVL pretraining.
+    Described here https://arxiv.org/pdf/2101.00529
+
+    A thin wrapper around MLP for 3 way classification.
+    Effectively ITM with 3 labels.
+    contrastive 3-way loss has 3 labels,
+    0 for a match, 1, 2 for a corrupt caption/image
+    """
+
+    def __init__(
+        self,
+        loss_name: str = "three_way_contrastive_loss",
+        constrastive_label_key: str = "contrastive_labels",
+        hidden_size: int = 768,
+        ignore_index: int = -1,
+        num_layers: int = 0,
+        num_labels: int = 3,
+        hidden_dropout_prob: float = 0.1,
+        layer_norm_eps: float = 1e-6,
+        hidden_act: str = "gelu",
+        pooler_name: str = "bert_pooler",
+        in_dim: Optional[int] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__()
+        self.loss_name = loss_name
+        self.constrastive_label_key = constrastive_label_key
+        # Head modules
+        config = OmegaConf.create(
+            {
+                "hidden_size": hidden_size,
+                "num_layers": num_layers,
+                "num_labels": num_labels,
+                "hidden_dropout_prob": hidden_dropout_prob,
+                "layer_norm_eps": layer_norm_eps,
+                "hidden_act": hidden_act,
+                "pooler_name": pooler_name,
+                "in_dim": in_dim,
+            }
+        )
+        self.contrast_head = MLP(config=config)
+
+        # Loss
+        self.ce_loss = torch.nn.CrossEntropyLoss(ignore_index=ignore_index)
+
+    def forward(
+        self,
+        sequence_output: torch.Tensor,
+        processed_sample_list: Dict[str, Dict[str, torch.Tensor]],
+    ):
+        output_dict = {}
+
+        if self.constrastive_label_key in processed_sample_list:
+            next_sentence_labels = processed_sample_list[self.constrastive_label_key]
+        else:
+            assert (
+                LABEL_KEY in processed_sample_list
+                and processed_sample_list[LABEL_KEY] is not None
+            ), (
+                f"Constrastive three way pretraining requires {LABEL_KEY} to "
+                + "be in sample list with value not None."
+            )
+
+            next_sentence_labels = processed_sample_list[LABEL_KEY][
+                self.constrastive_label_key
+            ]
+
+        scores = self.contrast_head(sequence_output)["scores"]
+        constrastive_loss = self.ce_loss(
+            scores.contiguous().view(-1, 3),
+            next_sentence_labels.contiguous().view(-1),
+        )
+        output_dict["losses"] = {}
+        output_dict["losses"][self.loss_name] = constrastive_loss
+        return output_dict

--- a/tests/models/transformers/test_heads.py
+++ b/tests/models/transformers/test_heads.py
@@ -4,6 +4,7 @@ import unittest
 
 import torch
 from mmf.common.sample import Sample
+from mmf.models.transformers.heads.contrastive import ThreeWayContrastive
 from mmf.models.transformers.heads.itm import ITM
 from mmf.models.transformers.heads.mlm import MLM
 from mmf.models.transformers.heads.mlp import MLP
@@ -287,3 +288,28 @@ class TestWRAHead(unittest.TestCase):
         output = module(self.sequence_input, self.processed_sample_list)
         self.assertTrue("wra_loss" in output["losses"])
         self.assertEqual(output["losses"]["wra_loss"].shape, torch.Size([]))
+
+
+class TestThreeWayContrastiveHead(unittest.TestCase):
+    def setUp(self):
+        bs = 8
+        num_feat = 64
+        feat_dim = 768
+        self.sequence_input = torch.ones(
+            size=(bs, num_feat, feat_dim), dtype=torch.float
+        )
+        contrastive_labels = torch.randint(3, (bs,))
+
+        self.processed_sample_list = Sample()
+        self.processed_sample_list["contrastive_labels"] = contrastive_labels
+
+    def test_forward(self):
+        module = ThreeWayContrastive()
+        output = module(self.sequence_input, self.processed_sample_list)
+        import pdb
+
+        pdb.set_trace()
+        self.assertTrue("three_way_contrastive_loss" in output["losses"])
+        self.assertEqual(
+            output["losses"]["three_way_contrastive_loss"].shape, torch.Size([])
+        )

--- a/tests/models/transformers/test_heads.py
+++ b/tests/models/transformers/test_heads.py
@@ -304,11 +304,11 @@ class TestThreeWayContrastiveHead(unittest.TestCase):
         self.processed_sample_list["contrastive_labels"] = contrastive_labels
 
     def test_forward(self):
-        module = ThreeWayContrastive()
+        module = ThreeWayContrastive(
+            OmegaConf.create({"type": "three_way_contrastive"})
+        )
         output = module(self.sequence_input, self.processed_sample_list)
-        import pdb
 
-        pdb.set_trace()
         self.assertTrue("three_way_contrastive_loss" in output["losses"])
         self.assertEqual(
             output["losses"]["three_way_contrastive_loss"].shape, torch.Size([])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1162
* #1159
* #1158
* #1157
* #1152
* #1151
* #1150
* __->__ #1171
* #1149

Add contrastive head for three-way vinvl loss,
which sometimes randomly swaps captions or labels
with the task of classifying whether image, text, label
triples are correct, or have a swapped text/label.

Differential Revision: [D33001604](https://our.internmc.facebook.com/intern/diff/D33001604)