### PR TITLE
[fix] Update UNITER VILLA checksums

### DIFF
--- a/mmf/configs/zoo/models.yaml
+++ b/mmf/configs/zoo/models.yaml
@@ -554,7 +554,7 @@ uniter:
     resources:
     - url: mmf://models/uniter/uniter.pretrained.tar.gz
       file_name: uniter.pretrained.tar.gz
-      hashcode: e843e65a3d8b4ed353779b96d654dde0440f5f04a79b3b4740309d40a3542664
+      hashcode: 479420e9a3065f79c34ba74c81e7bc78fba0d99fa070eebfa98b0eff53fd21c0
 
 villa:
   defaults: ${villa.pretrained}
@@ -563,4 +563,4 @@ villa:
     resources:
     - url: mmf://models/uniter/villa.pretrained.tar.gz
       file_name: villa.pretrained.tar.gz
-      hashcode: 7a8f31421ef644fddc99bd142a0090660573dd526a779d025253c3fd996754fc
+      hashcode: 11eb0e4f5c133dba48b1f32cb4483ea7839870b7c84e7a18df17d85c2901ecbb

--- a/projects/uniter/configs/masked_coco/defaults.yaml
+++ b/projects/uniter/configs/masked_coco/defaults.yaml
@@ -70,5 +70,6 @@ scheduler:
 training:
   batch_size: 480
   lr_scheduler: true
+  find_unused_parameters: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 60000

--- a/projects/uniter/configs/vqa2/defaults.yaml
+++ b/projects/uniter/configs/vqa2/defaults.yaml
@@ -52,6 +52,7 @@ evaluation:
 training:
   batch_size: 5120
   lr_scheduler: true
+  find_unused_parameters: true
   # Don't forget to update schedule_attributes if you update this
   max_updates: 5000
   early_stop:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Update UNITER and VILLA checksums for new
checkpoints that include empty configs.