### PR TITLE
[chore] Update numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=1.6.0, <=1.9.0
 torchvision>=0.7.0, <=0.10.0
-numpy>=1.16.6
+numpy>=1.16.6, <=1.21.4
 tqdm>=4.43.0,<4.50.0
 torchtext==0.5.0
 GitPython==3.1.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Set numpy version range to [1.16.6, 1.21.4]
This fixes website documentation deployment.