### PR TITLE
[MMC] implement multiple dataset with round robin in pretraining

### DIFF
--- a/mmf/modules/losses.py
+++ b/mmf/modules/losses.py
@@ -188,6 +188,14 @@ class MMFLoss(nn.Module):
 
     def forward(self, sample_list: Dict[str, Tensor], model_output: Dict[str, Tensor]):
         loss_dict = {}
+        if hasattr(self.loss_criterion, "datasets"):
+            datasets = self.loss_criterion.datasets
+            if (
+                isinstance(datasets, list)
+                and sample_list["dataset_name"] not in datasets
+            ):
+                return loss_dict
+
         loss_result = self.loss_criterion(sample_list, model_output)
 
         if not isinstance(loss_result, collections.abc.Mapping):


### PR DESCRIPTION
Summary: Merge two pretraining datasets and support round robin strategy. Each loss is computed given a certain dataset. This slightly changes the `MMFLoss` where it skips the computation if the current dataset name is not in the specified datasets.

Reviewed By: lichengunc

Differential Revision: D33834556

