### PR TITLE
[MMF] MultiDataLoader len property change if dataset is type Iterable

### DIFF
--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -30,7 +30,9 @@ class LightningLoopCallback(Callback):
         # for logging
         self.total_timer = Timer()
         self.snapshot_timer = Timer()
-        self.snapshot_iterations = len(self.lightning_trainer.val_loader)
+        self.snapshot_iterations = 0
+        if self.lightning_trainer.val_loader.has_len():
+            self.snapshot_iterations = len(self.lightning_trainer.val_loader)
         self.train_timer = Timer()
 
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):


### PR DESCRIPTION
Summary:
MultiDataLoader len property currently sets length of zero for datasets that are iterable. However that can be misleading since zero len is being used as proxy for an iterable dataset.
1. Add a has_len() property to MultiDataLoader to check if it has len
2. Return float("inf") as len if it has a iterable dataset

Differential Revision: D34024359

