### PR TITLE
[MMF] Check if eval interval is defined in logger.py

### DIFF
--- a/mmf/trainers/lightning_core/loop_callback.py
+++ b/mmf/trainers/lightning_core/loop_callback.py
@@ -30,7 +30,9 @@ class LightningLoopCallback(Callback):
         # for logging
         self.total_timer = Timer()
         self.snapshot_timer = Timer()
-        self.snapshot_iterations = len(self.lightning_trainer.val_loader)
+        self.snapshot_iterations = 0
+        if self.lightning_trainer.val_loader.has_len():
+            self.snapshot_iterations = len(self.lightning_trainer.val_loader)
         self.train_timer = Timer()
 
     def on_train_start(self, trainer: Trainer, pl_module: LightningModule):

--- a/mmf/utils/logger.py
+++ b/mmf/utils/logger.py
@@ -268,7 +268,8 @@ def calculate_time_left(
     time_left = num_logs_left * time_taken_for_log
 
     snapshot_iteration = num_snapshot_iterations / log_interval
-    snapshot_iteration *= iterations_left / eval_interval
+    if eval_interval:
+        snapshot_iteration *= iterations_left / eval_interval
     time_left += snapshot_iteration * time_taken_for_log
 
     return timer.get_time_hhmmss(gap=time_left)


### PR DESCRIPTION
Summary: This function is also called by lightning trainer. If val_check_interval is set to 0.0, meaning skip validation, then we have to check whether eval_interval is defined before using it.

Differential Revision: D34024356

