### PR TITLE
fix unexpected ValueError

### DIFF
--- a/mmf/common/registry.py
+++ b/mmf/common/registry.py
@@ -632,8 +632,8 @@ class Registry:
 
         if (
             "writer" in cls.mapping["state"]
-            and value == default
             and no_warning is False
+            and type(value) == type(default) and value == default
         ):
             cls.mapping["state"]["writer"].warning(
                 "Key {} is not present in registry, returning default value "


### PR DESCRIPTION
When value is a numpy array, comparing a numpy array with None object will give another numpy array. Then a ValueError will be raised, says: ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all(). For example, you can test this funtion with value = numpy.array([1,2,3]), and default=None.

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines), please open an issue first about
the feature/bug, and indicate how you want to contribute.

Use [contributing guidelines](https://github.com/facebookresearch/mmf/tree/main/.github/CONTRIBUTING.md) before opening up the PR to follow MMF style guidelines.
