### PR TITLE
[MMF]Disable lightning resume test internally

### DIFF
--- a/mmf/datasets/processors/bert_processors.py
+++ b/mmf/datasets/processors/bert_processors.py
@@ -8,7 +8,11 @@ import torch
 from mmf.common.registry import registry
 from mmf.common.sample import Sample, SampleList
 from mmf.datasets.processors.processors import BaseProcessor
-from transformers.tokenization_auto import AutoTokenizer
+
+try:
+    from transformers3.tokenization_auto import AutoTokenizer
+except ImportError:
+    from transformers.tokenization_auto import AutoTokenizer
 
 
 @registry.register_processor("masked_token")
@@ -405,7 +409,10 @@ def get_pair_text_tokens(
 @registry.register_processor("vilt_text_tokenizer")
 class VILTTextTokenizer(MaskedTokenProcessor):
     def __init__(self, config, *args, **kwargs):
-        from transformers import BertTokenizer
+        try:
+            from transformers3 import BertTokenizer
+        except ImportError:
+            from transformers import BertTokenizer
 
         if isinstance(config, str):
             config = {"from_pretrained": config}
@@ -427,7 +434,10 @@ class VILTTextTokenizer(MaskedTokenProcessor):
 @registry.register_processor("uniter_text_tokenizer")
 class UNITERTextTokenizer(MaskedTokenProcessor):
     def __init__(self, config, *args, **kwargs):
-        from transformers import BertTokenizer
+        try:
+            from transformers3 import BertTokenizer
+        except ImportError:
+            from transformers import BertTokenizer
 
         if isinstance(config, str):
             config = {"from_pretrained": config}
@@ -514,7 +524,10 @@ class UNITERTextTokenizer(MaskedTokenProcessor):
 @registry.register_processor("vinvl_text_tokenizer")
 class VinVLTextTokenizer(MaskedTokenProcessor):
     def __init__(self, config, *args, **kwargs):
-        from transformers import BertTokenizer
+        try:
+            from transformers3 import BertTokenizer
+        except ImportError:
+            from transformers import BertTokenizer
 
         if isinstance(config, str):
             config = {"from_pretrained": config}

--- a/mmf/models/krisp.py
+++ b/mmf/models/krisp.py
@@ -17,15 +17,27 @@ from mmf.utils.transform import (
 )
 from omegaconf import OmegaConf
 from torch import nn
-from transformers.modeling_bert import (
-    BertConfig,
-    BertEncoder,
-    BertLayer,
-    BertModel,
-    BertPooler,
-    BertPredictionHeadTransform,
-    BertPreTrainedModel,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        BertConfig,
+        BertEncoder,
+        BertLayer,
+        BertModel,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        BertConfig,
+        BertEncoder,
+        BertLayer,
+        BertModel,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+    )
 
 
 logger = logging.getLogger(__name__)

--- a/mmf/models/lxmert.py
+++ b/mmf/models/lxmert.py
@@ -25,20 +25,37 @@ from mmf.utils.modeling import get_optimizer_parameters_for_bert
 from omegaconf import OmegaConf
 from torch import nn
 from torch.nn import CrossEntropyLoss, SmoothL1Loss
-from transformers.modeling_bert import (
-    ACT2FN,
-    BertAttention,
-    BertConfig,
-    BertEmbeddings,
-    BertIntermediate,
-    BertLayer,
-    BertOutput,
-    BertPooler,
-    BertPredictionHeadTransform,
-    BertPreTrainedModel,
-    BertSelfAttention,
-    BertSelfOutput,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        ACT2FN,
+        BertAttention,
+        BertConfig,
+        BertEmbeddings,
+        BertIntermediate,
+        BertLayer,
+        BertOutput,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+        BertSelfAttention,
+        BertSelfOutput,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        ACT2FN,
+        BertAttention,
+        BertConfig,
+        BertEmbeddings,
+        BertIntermediate,
+        BertLayer,
+        BertOutput,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+        BertSelfAttention,
+        BertSelfOutput,
+    )
 
 
 class GeLU(nn.Module):

--- a/mmf/models/m4c.py
+++ b/mmf/models/m4c.py
@@ -11,12 +11,21 @@ from mmf.modules.layers import ClassifierLayer
 from mmf.utils.build import build_image_encoder
 from omegaconf import OmegaConf
 from torch import nn
-from transformers.modeling_bert import (
-    BertConfig,
-    BertEmbeddings,
-    BertEncoder,
-    BertPreTrainedModel,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        BertConfig,
+        BertEmbeddings,
+        BertEncoder,
+        BertPreTrainedModel,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        BertConfig,
+        BertEmbeddings,
+        BertEncoder,
+        BertPreTrainedModel,
+    )
 
 
 logger = logging.getLogger(__name__)

--- a/mmf/models/mmbt.py
+++ b/mmf/models/mmbt.py
@@ -30,7 +30,17 @@ from mmf.utils.configuration import get_mmf_cache_dir
 from mmf.utils.modeling import get_optimizer_parameters_for_bert
 from omegaconf import DictConfig, II, OmegaConf
 from torch import nn, Tensor
-from transformers.modeling_bert import BertForPreTraining, BertPredictionHeadTransform
+
+try:
+    from transformers3.modeling_bert import (
+        BertForPreTraining,
+        BertPredictionHeadTransform,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        BertForPreTraining,
+        BertPredictionHeadTransform,
+    )
 
 
 # TODO: Remove after transformers package upgrade to 2.5

--- a/mmf/models/mmf_bert.py
+++ b/mmf/models/mmf_bert.py
@@ -6,14 +6,25 @@ from mmf.models.pythia import Pythia
 from mmf.modules.embeddings import ProjectionEmbedding
 from mmf.utils.transform import transform_to_batch_sequence
 from torch import nn
-from transformers.modeling_bert import (
-    BertConfig,
-    BertEmbeddings,
-    BertForPreTraining,
-    BertPooler,
-    BertPredictionHeadTransform,
-    BertPreTrainingHeads,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        BertConfig,
+        BertEmbeddings,
+        BertForPreTraining,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainingHeads,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        BertConfig,
+        BertEmbeddings,
+        BertForPreTraining,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainingHeads,
+    )
 
 
 @registry.register_model("mmf_bert")

--- a/mmf/models/transformers/backends/huggingface.py
+++ b/mmf/models/transformers/backends/huggingface.py
@@ -9,7 +9,11 @@ from mmf.models.transformers.base import BaseTransformer, BaseTransformerBackend
 from mmf.modules.hf_layers import BertModelJit, replace_with_jit
 from omegaconf import OmegaConf
 from torch import nn, Tensor
-from transformers import AutoConfig, AutoModel
+
+try:
+    from transformers3 import AutoConfig, AutoModel
+except ImportError:
+    from transformers import AutoConfig, AutoModel
 
 
 class HuggingfaceEmbeddings(nn.Module):

--- a/mmf/models/transformers/heads/itm.py
+++ b/mmf/models/transformers/heads/itm.py
@@ -6,7 +6,11 @@ from typing import Dict, List, Optional
 import torch
 from mmf.common.registry import registry
 from mmf.models.transformers.base import BaseTransformerHead
-from transformers.modeling_bert import BertOnlyNSPHead, BertPooler
+
+try:
+    from transformers3.modeling_bert import BertOnlyNSPHead, BertPooler
+except ImportError:
+    from transformers.modeling_bert import BertOnlyNSPHead, BertPooler
 
 
 LABEL_KEY = "itm_labels"

--- a/mmf/models/transformers/heads/mlm.py
+++ b/mmf/models/transformers/heads/mlm.py
@@ -7,7 +7,11 @@ from typing import Dict, List, Optional
 import torch
 from mmf.common.registry import registry
 from mmf.models.transformers.base import BaseTransformerHead
-from transformers.modeling_bert import BertOnlyMLMHead
+
+try:
+    from transformers3.modeling_bert import BertOnlyMLMHead
+except ImportError:
+    from transformers.modeling_bert import BertOnlyMLMHead
 
 LABEL_KEY = "mlm_labels"
 COMBINED_LABEL_KEY = "combined_labels"

--- a/mmf/models/transformers/heads/mlp.py
+++ b/mmf/models/transformers/heads/mlp.py
@@ -10,7 +10,11 @@ from mmf.models.transformers.base import BaseTransformerHead
 from mmf.modules import layers
 from omegaconf import OmegaConf, open_dict
 from torch import nn
-from transformers.modeling_bert import BertPooler, BertPredictionHeadTransform
+
+try:
+    from transformers3.modeling_bert import BertPooler, BertPredictionHeadTransform
+except ImportError:
+    from transformers.modeling_bert import BertPooler, BertPredictionHeadTransform
 
 
 @registry.register_transformer_head("multilayer_mlp")

--- a/mmf/models/transformers/heads/refiner.py
+++ b/mmf/models/transformers/heads/refiner.py
@@ -8,7 +8,11 @@ from mmf.common.registry import registry
 from mmf.models.transformers.base import BaseTransformerHead
 from mmf.modules.losses import RefinerContrastiveLoss, RefinerMSLoss
 from torch import nn
-from transformers.modeling_bert import BertOnlyMLMHead
+
+try:
+    from transformers3.modeling_bert import BertOnlyMLMHead
+except ImportError:
+    from transformers.modeling_bert import BertOnlyMLMHead
 
 
 class MLP(nn.Module):

--- a/mmf/models/unit/unit.py
+++ b/mmf/models/unit/unit.py
@@ -16,7 +16,11 @@ from mmf.models.unit.unit_base_model import (
 from mmf.modules.encoders import TransformerEncoder
 from mmf.utils.distributed import byte_tensor_to_object
 from torch import nn, Tensor
-from transformers.modeling_bert import BertPredictionHeadTransform
+
+try:
+    from transformers3.modeling_bert import BertPredictionHeadTransform
+except ImportError:
+    from transformers.modeling_bert import BertPredictionHeadTransform
 
 
 logger = logging.getLogger(__name__)

--- a/mmf/models/uniter.py
+++ b/mmf/models/uniter.py
@@ -19,7 +19,12 @@ from mmf.modules.losses import MMFLoss
 from mmf.utils.general import retry_n
 from omegaconf import DictConfig, MISSING, OmegaConf
 from torch import nn, Tensor
-from transformers.modeling_bert import BertConfig, BertEmbeddings, BertModel
+
+
+try:
+    from transformers3.modeling_bert import BertConfig, BertEmbeddings, BertModel
+except ImportError:
+    from transformers.modeling_bert import BertConfig, BertEmbeddings, BertModel
 
 
 NUM_RETRIES = 6

--- a/mmf/models/vilbert.py
+++ b/mmf/models/vilbert.py
@@ -16,17 +16,31 @@ from mmf.utils.modeling import get_optimizer_parameters_for_bert
 from omegaconf import OmegaConf
 from torch import nn, Tensor
 from torch.nn import CrossEntropyLoss
-from transformers.modeling_bert import (
-    ACT2FN,
-    BertConfig,
-    BertEmbeddings,
-    BertIntermediate,
-    BertLMPredictionHead,
-    BertOutput,
-    BertPredictionHeadTransform,
-    BertPreTrainedModel,
-    BertSelfOutput,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        ACT2FN,
+        BertConfig,
+        BertEmbeddings,
+        BertIntermediate,
+        BertLMPredictionHead,
+        BertOutput,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+        BertSelfOutput,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        ACT2FN,
+        BertConfig,
+        BertEmbeddings,
+        BertIntermediate,
+        BertLMPredictionHead,
+        BertOutput,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+        BertSelfOutput,
+    )
 
 
 class BertSelfAttention(nn.Module):

--- a/mmf/models/vinvl.py
+++ b/mmf/models/vinvl.py
@@ -19,12 +19,21 @@ from mmf.models.transformers.heads.mlp import MLP
 from mmf.utils.general import retry_n
 from omegaconf import MISSING, OmegaConf
 from torch import nn, Tensor
-from transformers.modeling_bert import (
-    BertConfig,
-    BertEmbeddings,
-    BertEncoder,
-    BertPreTrainedModel,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        BertConfig,
+        BertEmbeddings,
+        BertEncoder,
+        BertPreTrainedModel,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        BertConfig,
+        BertEmbeddings,
+        BertEncoder,
+        BertPreTrainedModel,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/mmf/models/visual_bert.py
+++ b/mmf/models/visual_bert.py
@@ -21,13 +21,23 @@ from mmf.utils.transform import (
 )
 from omegaconf import OmegaConf
 from torch import nn, Tensor
-from transformers.modeling_bert import (
-    BertConfig,
-    BertForPreTraining,
-    BertPooler,
-    BertPredictionHeadTransform,
-    BertPreTrainedModel,
-)
+
+try:
+    from transformers3.modeling_bert import (
+        BertConfig,
+        BertForPreTraining,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+    )
+except ImportError:
+    from transformers.modeling_bert import (
+        BertConfig,
+        BertForPreTraining,
+        BertPooler,
+        BertPredictionHeadTransform,
+        BertPreTrainedModel,
+    )
 
 
 class VisualBERTBase(BertPreTrainedModel):

--- a/mmf/modules/embeddings.py
+++ b/mmf/modules/embeddings.py
@@ -15,7 +15,11 @@ from mmf.modules.layers import AttnPool1d, Identity
 from mmf.utils.file_io import PathManager
 from mmf.utils.vocab import Vocab
 from torch import nn, Tensor
-from transformers.modeling_bert import BertEmbeddings
+
+try:
+    from transformers3.modeling_bert import BertEmbeddings
+except ImportError:
+    from transformers.modeling_bert import BertEmbeddings
 
 
 class TextEmbedding(nn.Module):

--- a/mmf/modules/encoders.py
+++ b/mmf/modules/encoders.py
@@ -24,8 +24,13 @@ from mmf.utils.general import get_absolute_path
 from mmf.utils.logger import log_class_usage
 from omegaconf import MISSING, OmegaConf
 from torch import nn, Tensor
-from transformers.configuration_auto import AutoConfig
-from transformers.modeling_auto import AutoModel
+
+try:
+    from transformers3.configuration_auto import AutoConfig
+    from transformers3.modeling_auto import AutoModel
+except ImportError:
+    from transformers.configuration_auto import AutoConfig
+    from transformers.modeling_auto import AutoModel
 
 try:
     from detectron2.modeling import build_resnet_backbone, ShapeSpec

--- a/mmf/modules/hf_layers.py
+++ b/mmf/modules/hf_layers.py
@@ -6,25 +6,47 @@ from typing import List, Optional, Tuple
 import torch
 from mmf.utils.patch import restore_saved_modules, safecopy_modules
 from torch import nn, Tensor
-from transformers.modeling_bert import (
-    BertAttention,
-    BertEmbeddings,
-    BertEncoder,
-    BertLayer,
-    BertModel,
-    BertPooler,
-    BertSelfAttention,
-    BertSelfOutput,
-)
-from transformers.modeling_roberta import (
-    RobertaAttention,
-    RobertaEmbeddings,
-    RobertaEncoder,
-    RobertaLayer,
-    RobertaModel,
-    RobertaSelfAttention,
-)
-from transformers.modeling_utils import PreTrainedModel
+
+try:
+    from transformers3.modeling_bert import (
+        BertAttention,
+        BertEmbeddings,
+        BertEncoder,
+        BertLayer,
+        BertModel,
+        BertPooler,
+        BertSelfAttention,
+        BertSelfOutput,
+    )
+    from transformers3.modeling_roberta import (
+        RobertaAttention,
+        RobertaEmbeddings,
+        RobertaEncoder,
+        RobertaLayer,
+        RobertaModel,
+        RobertaSelfAttention,
+    )
+    from transformers3.modeling_utils import PreTrainedModel
+except ImportError:
+    from transformers.modeling_bert import (
+        BertAttention,
+        BertEmbeddings,
+        BertEncoder,
+        BertLayer,
+        BertModel,
+        BertPooler,
+        BertSelfAttention,
+        BertSelfOutput,
+    )
+    from transformers.modeling_roberta import (
+        RobertaAttention,
+        RobertaEmbeddings,
+        RobertaEncoder,
+        RobertaLayer,
+        RobertaModel,
+        RobertaSelfAttention,
+    )
+    from transformers.modeling_utils import PreTrainedModel
 
 
 patch_functions = [

--- a/mmf/modules/layers.py
+++ b/mmf/modules/layers.py
@@ -126,10 +126,16 @@ class ClassifierLayer(nn.Module):
 class BertClassifierHead(nn.Module):
     def __init__(self, in_dim=768, out_dim=2, config=None, *args, **kwargs):
         super().__init__()
-        from transformers.modeling_bert import BertPredictionHeadTransform
+        try:
+            from transformers3.modeling_bert import BertPredictionHeadTransform
+        except ImportError:
+            from transformers.modeling_bert import BertPredictionHeadTransform
 
         if config is None:
-            from transformers.configuration_bert import BertConfig
+            try:
+                from transformers3.configuration_bert import BertConfig
+            except ImportError:
+                from transformers.configuration_bert import BertConfig
 
             config = BertConfig.from_pretrained("bert-base-uncased")
 

--- a/mmf/modules/optimizers.py
+++ b/mmf/modules/optimizers.py
@@ -4,7 +4,11 @@ from typing import Callable
 
 import torch
 from mmf.common.registry import registry
-from transformers.optimization import AdamW
+
+try:
+    from transformers3.optimization import AdamW
+except ImportError:
+    from transformers.optimization import AdamW
 
 
 registry.register_optimizer("adam_w")(AdamW)

--- a/mmf/modules/schedulers.py
+++ b/mmf/modules/schedulers.py
@@ -4,10 +4,17 @@ from bisect import bisect_right
 
 from mmf.common.registry import registry
 from torch.optim.lr_scheduler import LambdaLR
-from transformers.optimization import (
-    get_cosine_schedule_with_warmup,
-    get_linear_schedule_with_warmup,
-)
+
+try:
+    from transformers3.optimization import (
+        get_cosine_schedule_with_warmup,
+        get_linear_schedule_with_warmup,
+    )
+except ImportError:
+    from transformers.optimization import (
+        get_cosine_schedule_with_warmup,
+        get_linear_schedule_with_warmup,
+    )
 
 
 @registry.register_scheduler("pythia")

--- a/mmf/modules/vit.py
+++ b/mmf/modules/vit.py
@@ -8,12 +8,20 @@ from mmf.utils.general import retry_n
 from omegaconf import OmegaConf
 from packaging import version
 from torch import nn
-from transformers import __version__ as transformers_version
-from transformers.modeling_bert import BertSelfAttention
+
+try:
+    from transformers3 import __version__ as transformers_version
+    from transformers3.modeling_bert import BertSelfAttention
+except ImportError:
+    from transformers import __version__ as transformers_version
+    from transformers.modeling_bert import BertSelfAttention
 
 
 if version.parse(transformers_version) >= version.parse("4.5.0"):
-    import transformers.models.vit.modeling_vit as vit
+    try:
+        import transformers3.models.vit.modeling_vit as vit
+    except ImportError:
+        import transformers.models.vit.modeling_vit as vit
 
     has_VIT = True
 else:

--- a/mmf/utils/patch.py
+++ b/mmf/utils/patch.py
@@ -29,7 +29,10 @@ def patch_transformers(log_incompatible=False):
     to look for local folder at the last in path resolver. This is
     reverted back to original behavior at the end of the function.
     """
-    import transformers
+    try:
+        import transformers3 as transformers
+    except ImportError:
+        import transformers
 
     # pl uses importlib to find_transformers spec throwing if None
     # this prevents mmf/__init__() from raising and value error

--- a/tests/models/test_vinvl.py
+++ b/tests/models/test_vinvl.py
@@ -11,7 +11,11 @@ from mmf.utils.configuration import Configuration
 from mmf.utils.env import setup_imports, teardown_imports
 from mmf.utils.general import get_current_device
 from omegaconf import OmegaConf
-from transformers.modeling_bert import BertConfig
+
+try:
+    from transformers3.modeling_bert import BertConfig
+except ImportError:
+    from transformers.modeling_bert import BertConfig
 
 
 class TestVinVLBase(unittest.TestCase):

--- a/tests/modules/test_hf_layers.py
+++ b/tests/modules/test_hf_layers.py
@@ -3,7 +3,11 @@
 import unittest
 
 from mmf.modules.hf_layers import replace_with_jit, undo_replace_with_jit
-from transformers.modeling_bert import BertSelfAttention
+
+try:
+    from transformers3.modeling_bert import BertSelfAttention
+except ImportError:
+    from transformers.modeling_bert import BertSelfAttention
 
 
 class TestHFLayers(unittest.TestCase):

--- a/tests/modules/test_vit.py
+++ b/tests/modules/test_vit.py
@@ -12,7 +12,10 @@ from torch import nn
 @skip_if_old_transformers(min_version="4.5.0")
 class TestViT(unittest.TestCase):
     def setUp(self):
-        import transformers.models.vit.modeling_vit as vit
+        try:
+            import transformers3.models.vit.modeling_vit as vit
+        except ImportError:
+            import transformers.models.vit.modeling_vit as vit
 
         setup_proxy()
         config = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,11 @@ def skip_if_non_fb(testfn, reason="Doesn't run on non FB infra"):
 def skip_if_old_transformers(min_version="4.5.0"):
     def wrap(testfn, reason="Requires newer version of transformers"):
         from packaging import version
-        from transformers import __version__ as transformers_version
+
+        try:
+            from transformers3 import __version__ as transformers_version
+        except ImportError:
+            from transformers import __version__ as transformers_version
 
         return unittest.skipUnless(
             version.parse(transformers_version) >= version.parse(min_version), reason

--- a/tests/trainers/lightning/test_checkpoint.py
+++ b/tests/trainers/lightning/test_checkpoint.py
@@ -12,6 +12,7 @@ from mmf.trainers.callbacks.early_stopping import EarlyStoppingCallback
 from mmf.trainers.lightning_core.loop_callback import LightningLoopCallback
 from mmf.utils.checkpoint import get_ckpt_path_from_folder
 from mmf.utils.download import download_pretrained_model
+from tests.test_utils import skip_if_no_network
 from tests.trainers.test_utils import (
     get_config_with_defaults,
     get_lightning_trainer,
@@ -363,6 +364,7 @@ class TestLightningCheckpoint(TestLightningCheckpoint):
             mmf_ckpt_current["model"], lightning_ckpt_current["state_dict"]
         )
 
+    @skip_if_no_network
     def test_load_trainer_ckpt_number_of_steps(self):
         with mock_env_with_temp("mmf.trainers.lightning_trainer.get_mmf_env") as tmp_d:
             # to generate ckpt file, max_steps is saved as 6

--- a/tools/scripts/bert/extract_bert_embeddings.py
+++ b/tools/scripts/bert/extract_bert_embeddings.py
@@ -5,8 +5,13 @@ import argparse
 import numpy as np
 import torch
 from tqdm import tqdm
-from transformers.modeling_bert import BertModel
-from transformers.tokenization_auto import AutoTokenizer
+
+try:
+    from transformers3.modeling_bert import BertModel
+    from transformers3.tokenization_auto import AutoTokenizer
+except ImportError:
+    from transformers.modeling_bert import BertModel
+    from transformers.tokenization_auto import AutoTokenizer
 
 
 class BertFeatExtractor:


### PR DESCRIPTION
Summary: The lightning version in oss is pinned to a different version from internal causing test failures in either oss or internal. So turning off internal tests for now.

Reviewed By: ebsmothers

Differential Revision: D42173262

